### PR TITLE
Select Audio Track

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -7,7 +7,7 @@ android {
     buildToolsVersion "25.0.0"
 
     defaultConfig {
-        minSdkVersion 15
+        minSdkVersion 16
         targetSdkVersion 24
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }

--- a/core/src/main/java/com/novoda/noplayer/Player.java
+++ b/core/src/main/java/com/novoda/noplayer/Player.java
@@ -2,7 +2,6 @@ package com.novoda.noplayer;
 
 import android.net.Uri;
 
-import com.google.android.exoplayer.MediaFormat;
 import com.novoda.noplayer.exoplayer.Bitrate;
 import com.novoda.noplayer.player.PlayerInformation;
 
@@ -32,7 +31,7 @@ public interface Player extends PlayerState, PlayerListeners {
 
     void setAudioTrack(int mediaTrackPosition);
 
-    List<MediaFormat> getAudioTracks();
+    List<PlayerAudioTrack> getAudioTracks();
 
     interface PreReleaseListener {
 

--- a/core/src/main/java/com/novoda/noplayer/Player.java
+++ b/core/src/main/java/com/novoda/noplayer/Player.java
@@ -29,7 +29,7 @@ public interface Player extends PlayerState, PlayerListeners {
 
     void attach(PlayerView playerView);
 
-    void setAudioTrack(int mediaTrackPosition);
+    void setAudioTrack(int audioTrackIndex);
 
     List<PlayerAudioTrack> getAudioTracks();
 

--- a/core/src/main/java/com/novoda/noplayer/Player.java
+++ b/core/src/main/java/com/novoda/noplayer/Player.java
@@ -29,7 +29,7 @@ public interface Player extends PlayerState, PlayerListeners {
 
     void attach(PlayerView playerView);
 
-    void setAudioTrack(int audioTrackIndex);
+    void selectAudioTrack(int audioTrackIndex);
 
     List<PlayerAudioTrack> getAudioTracks();
 

--- a/core/src/main/java/com/novoda/noplayer/Player.java
+++ b/core/src/main/java/com/novoda/noplayer/Player.java
@@ -2,8 +2,11 @@ package com.novoda.noplayer;
 
 import android.net.Uri;
 
+import com.google.android.exoplayer.MediaFormat;
 import com.novoda.noplayer.exoplayer.Bitrate;
 import com.novoda.noplayer.player.PlayerInformation;
+
+import java.util.List;
 
 public interface Player extends PlayerState, PlayerListeners {
 
@@ -26,6 +29,10 @@ public interface Player extends PlayerState, PlayerListeners {
     PlayerInformation getPlayerInformation();
 
     void attach(PlayerView playerView);
+
+    void setAudioTrack(int mediaTrackPosition);
+
+    List<MediaFormat> getAudioTracks();
 
     interface PreReleaseListener {
 

--- a/core/src/main/java/com/novoda/noplayer/PlayerAudioTrack.java
+++ b/core/src/main/java/com/novoda/noplayer/PlayerAudioTrack.java
@@ -1,0 +1,35 @@
+package com.novoda.noplayer;
+
+public class PlayerAudioTrack {
+
+    private final String trackId;
+
+    public PlayerAudioTrack(String trackId) {
+        this.trackId = trackId;
+    }
+
+    public String trackId() {
+        return trackId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        PlayerAudioTrack that = (PlayerAudioTrack) o;
+
+        return trackId != null ? trackId.equals(that.trackId) : that.trackId == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        return trackId != null ? trackId.hashCode() : 0;
+    }
+
+}

--- a/core/src/main/java/com/novoda/noplayer/PlayerAudioTrack.java
+++ b/core/src/main/java/com/novoda/noplayer/PlayerAudioTrack.java
@@ -3,13 +3,37 @@ package com.novoda.noplayer;
 public class PlayerAudioTrack {
 
     private final String trackId;
+    private final String language;
+    private final String mimeType;
+    private final int numberOfChannels;
+    private final int frequency;
 
-    public PlayerAudioTrack(String trackId) {
+    public PlayerAudioTrack(String trackId, String language, String mimeType, int numberOfChannels, int frequency) {
         this.trackId = trackId;
+        this.language = language;
+        this.mimeType = mimeType;
+        this.numberOfChannels = numberOfChannels;
+        this.frequency = frequency;
     }
 
     public String trackId() {
         return trackId;
+    }
+
+    public String language() {
+        return language;
+    }
+
+    public String mimeType() {
+        return mimeType;
+    }
+
+    public int numberOfChannels() {
+        return numberOfChannels;
+    }
+
+    public int frequency() {
+        return frequency;
     }
 
     @Override
@@ -23,13 +47,29 @@ public class PlayerAudioTrack {
 
         PlayerAudioTrack that = (PlayerAudioTrack) o;
 
-        return trackId != null ? trackId.equals(that.trackId) : that.trackId == null;
+        if (numberOfChannels != that.numberOfChannels) {
+            return false;
+        }
+        if (frequency != that.frequency) {
+            return false;
+        }
+        if (trackId != null ? !trackId.equals(that.trackId) : that.trackId != null) {
+            return false;
+        }
+        if (language != null ? !language.equals(that.language) : that.language != null) {
+            return false;
+        }
+        return mimeType != null ? mimeType.equals(that.mimeType) : that.mimeType == null;
 
     }
 
     @Override
     public int hashCode() {
-        return trackId != null ? trackId.hashCode() : 0;
+        int result = trackId != null ? trackId.hashCode() : 0;
+        result = 31 * result + (language != null ? language.hashCode() : 0);
+        result = 31 * result + (mimeType != null ? mimeType.hashCode() : 0);
+        result = 31 * result + numberOfChannels;
+        result = 31 * result + frequency;
+        return result;
     }
-
 }

--- a/core/src/main/java/com/novoda/noplayer/exoplayer/ExoPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/exoplayer/ExoPlayerFacade.java
@@ -438,26 +438,32 @@ public class ExoPlayerFacade implements ChunkSampleSource.EventListener,
         // Do nothing.
     }
 
-    public void setAudioTrack(int mediaTrackPosition) {
+    public void selectAudioTrack(int audioTrackIndex) {
         int trackCount = player.getTrackCount(Renderers.AUDIO_RENDERER_ID);
-        if (mediaTrackPosition > trackCount || mediaTrackPosition < 0) {
+        if (audioTrackIndex < 0 || audioTrackIndex > trackCount - 1) {
             Log.e(String.format(
                     "Attempt to %s has been ignored because an invalid position was specified: %s, total: %s",
-                    "setAudioTrack()",
-                    mediaTrackPosition,
+                    "selectAudioTrack()",
+                    audioTrackIndex,
                     trackCount
                   )
             );
             return;
         }
-        player.setSelectedTrack(Renderers.AUDIO_RENDERER_ID, mediaTrackPosition);
+        player.setSelectedTrack(Renderers.AUDIO_RENDERER_ID, audioTrackIndex);
     }
 
     public List<PlayerAudioTrack> getAudioTracks() {
         List<PlayerAudioTrack> tracks = new ArrayList<>();
         for (int i = 0; i < player.getTrackCount(Renderers.AUDIO_RENDERER_ID); i++) {
             MediaFormat track = player.getTrackFormat(Renderers.AUDIO_RENDERER_ID, i);
-            PlayerAudioTrack playerAudioTrack = new PlayerAudioTrack(track.trackId, track.language, track.mimeType, track.channelCount, track.bitrate);
+            PlayerAudioTrack playerAudioTrack = new PlayerAudioTrack(
+                    track.trackId,
+                    track.language,
+                    track.mimeType,
+                    track.channelCount,
+                    track.bitrate
+            );
             tracks.add(playerAudioTrack);
         }
         return tracks;

--- a/core/src/main/java/com/novoda/noplayer/exoplayer/ExoPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/exoplayer/ExoPlayerFacade.java
@@ -25,6 +25,7 @@ import com.google.android.exoplayer.text.SubtitleLayout;
 import com.google.android.exoplayer.text.TextRenderer;
 import com.google.android.exoplayer.upstream.BandwidthMeter;
 import com.novoda.noplayer.ContentType;
+import com.novoda.noplayer.PlayerAudioTrack;
 import com.novoda.noplayer.SurfaceHolderRequester;
 import com.novoda.notils.exception.DeveloperError;
 import com.novoda.notils.logger.simple.Log;
@@ -438,14 +439,20 @@ public class ExoPlayerFacade implements ChunkSampleSource.EventListener,
     }
 
     public void setAudioTrack(int mediaTrackPosition) {
+        int trackCount = player.getTrackCount(Renderers.AUDIO_RENDERER_ID);
+        if (mediaTrackPosition > trackCount || mediaTrackPosition < 0) {
+            Log.e(String.format("Attempt to %s has been ignored because an invalid position was specified: %s", "setAudioTrack()", mediaTrackPosition));
+            return;
+        }
         player.setSelectedTrack(Renderers.AUDIO_RENDERER_ID, mediaTrackPosition);
     }
 
-    public List<MediaFormat> getAudioTracks() {
-        List<MediaFormat> tracks = new ArrayList<>();
+    public List<PlayerAudioTrack> getAudioTracks() {
+        List<PlayerAudioTrack> tracks = new ArrayList<>();
         for (int i = 0; i < player.getTrackCount(Renderers.AUDIO_RENDERER_ID); i++) {
             MediaFormat track = player.getTrackFormat(Renderers.AUDIO_RENDERER_ID, i);
-            tracks.add(track);
+            PlayerAudioTrack playerAudioTrack = new PlayerAudioTrack(track.trackId);
+            tracks.add(playerAudioTrack);
         }
         return tracks;
     }

--- a/core/src/main/java/com/novoda/noplayer/exoplayer/ExoPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/exoplayer/ExoPlayerFacade.java
@@ -441,7 +441,13 @@ public class ExoPlayerFacade implements ChunkSampleSource.EventListener,
     public void setAudioTrack(int mediaTrackPosition) {
         int trackCount = player.getTrackCount(Renderers.AUDIO_RENDERER_ID);
         if (mediaTrackPosition > trackCount || mediaTrackPosition < 0) {
-            Log.e(String.format("Attempt to %s has been ignored because an invalid position was specified: %s", "setAudioTrack()", mediaTrackPosition));
+            Log.e(String.format(
+                    "Attempt to %s has been ignored because an invalid position was specified: %s, total: %s",
+                    "setAudioTrack()",
+                    mediaTrackPosition,
+                    trackCount
+                  )
+            );
             return;
         }
         player.setSelectedTrack(Renderers.AUDIO_RENDERER_ID, mediaTrackPosition);
@@ -451,7 +457,7 @@ public class ExoPlayerFacade implements ChunkSampleSource.EventListener,
         List<PlayerAudioTrack> tracks = new ArrayList<>();
         for (int i = 0; i < player.getTrackCount(Renderers.AUDIO_RENDERER_ID); i++) {
             MediaFormat track = player.getTrackFormat(Renderers.AUDIO_RENDERER_ID, i);
-            PlayerAudioTrack playerAudioTrack = new PlayerAudioTrack(track.trackId);
+            PlayerAudioTrack playerAudioTrack = new PlayerAudioTrack(track.trackId, track.language, track.mimeType, track.channelCount, track.bitrate);
             tracks.add(playerAudioTrack);
         }
         return tracks;

--- a/core/src/main/java/com/novoda/noplayer/exoplayer/ExoPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/exoplayer/ExoPlayerFacade.java
@@ -11,6 +11,7 @@ import com.google.android.exoplayer.ExoPlayer;
 import com.google.android.exoplayer.MediaCodecAudioTrackRenderer;
 import com.google.android.exoplayer.MediaCodecTrackRenderer.DecoderInitializationException;
 import com.google.android.exoplayer.MediaCodecVideoTrackRenderer;
+import com.google.android.exoplayer.MediaFormat;
 import com.google.android.exoplayer.TimeRange;
 import com.google.android.exoplayer.TrackRenderer;
 import com.google.android.exoplayer.audio.AudioTrack;
@@ -29,6 +30,7 @@ import com.novoda.notils.exception.DeveloperError;
 import com.novoda.notils.logger.simple.Log;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -433,6 +435,19 @@ public class ExoPlayerFacade implements ChunkSampleSource.EventListener,
     @Override
     public void onUpstreamDiscarded(int sourceId, long mediaStartTimeMs, long mediaEndTimeMs) {
         // Do nothing.
+    }
+
+    public void setAudioTrack(int mediaTrackPosition) {
+        player.setSelectedTrack(Renderers.AUDIO_RENDERER_ID, mediaTrackPosition);
+    }
+
+    public List<MediaFormat> getAudioTracks() {
+        List<MediaFormat> tracks = new ArrayList<>();
+        for (int i = 0; i < player.getTrackCount(Renderers.AUDIO_RENDERER_ID); i++) {
+            MediaFormat track = player.getTrackFormat(Renderers.AUDIO_RENDERER_ID, i);
+            tracks.add(track);
+        }
+        return tracks;
     }
 
     public void setSubtitleLayout(SubtitleLayout subtitleLayout) {

--- a/core/src/main/java/com/novoda/noplayer/exoplayer/ExoPlayerImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/exoplayer/ExoPlayerImpl.java
@@ -2,10 +2,10 @@ package com.novoda.noplayer.exoplayer;
 
 import android.net.Uri;
 
-import com.google.android.exoplayer.MediaFormat;
 import com.novoda.noplayer.ContentType;
 import com.novoda.noplayer.Heart;
 import com.novoda.noplayer.Player;
+import com.novoda.noplayer.PlayerAudioTrack;
 import com.novoda.noplayer.PlayerListenersHolder;
 import com.novoda.noplayer.PlayerView;
 import com.novoda.noplayer.Timeout;
@@ -188,7 +188,7 @@ public class ExoPlayerImpl extends PlayerListenersHolder implements Player {
     }
 
     @Override
-    public List<MediaFormat> getAudioTracks() {
+    public List<PlayerAudioTrack> getAudioTracks() {
         return exoPlayer.getAudioTracks();
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/exoplayer/ExoPlayerImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/exoplayer/ExoPlayerImpl.java
@@ -183,8 +183,8 @@ public class ExoPlayerImpl extends PlayerListenersHolder implements Player {
     }
 
     @Override
-    public void setAudioTrack(int audioTrackIndex) {
-        exoPlayer.setAudioTrack(audioTrackIndex);
+    public void selectAudioTrack(int audioTrackIndex) {
+        exoPlayer.selectAudioTrack(audioTrackIndex);
     }
 
     @Override

--- a/core/src/main/java/com/novoda/noplayer/exoplayer/ExoPlayerImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/exoplayer/ExoPlayerImpl.java
@@ -2,6 +2,7 @@ package com.novoda.noplayer.exoplayer;
 
 import android.net.Uri;
 
+import com.google.android.exoplayer.MediaFormat;
 import com.novoda.noplayer.ContentType;
 import com.novoda.noplayer.Heart;
 import com.novoda.noplayer.Player;
@@ -12,6 +13,8 @@ import com.novoda.noplayer.VideoContainer;
 import com.novoda.noplayer.VideoDuration;
 import com.novoda.noplayer.VideoPosition;
 import com.novoda.noplayer.player.PlayerInformation;
+
+import java.util.List;
 
 public class ExoPlayerImpl extends PlayerListenersHolder implements Player {
 
@@ -177,5 +180,15 @@ public class ExoPlayerImpl extends PlayerListenersHolder implements Player {
     // Used by the infinite modular video activity, purely for logging purposes
     public ExoPlayerFacade getInternalExoPlayer() {
         return exoPlayer;
+    }
+
+    @Override
+    public void setAudioTrack(int mediaTrackPosition) {
+        exoPlayer.setAudioTrack(mediaTrackPosition);
+    }
+
+    @Override
+    public List<MediaFormat> getAudioTracks() {
+        return exoPlayer.getAudioTracks();
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/exoplayer/ExoPlayerImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/exoplayer/ExoPlayerImpl.java
@@ -183,8 +183,8 @@ public class ExoPlayerImpl extends PlayerListenersHolder implements Player {
     }
 
     @Override
-    public void setAudioTrack(int mediaTrackPosition) {
-        exoPlayer.setAudioTrack(mediaTrackPosition);
+    public void setAudioTrack(int audioTrackIndex) {
+        exoPlayer.setAudioTrack(audioTrackIndex);
     }
 
     @Override

--- a/core/src/main/java/com/novoda/noplayer/exoplayer/Renderers.java
+++ b/core/src/main/java/com/novoda/noplayer/exoplayer/Renderers.java
@@ -36,6 +36,10 @@ public class Renderers {
         return renderers[VIDEO_RENDERER_INDEX];
     }
 
+    public TrackRenderer getAudioRenderer() {
+        return renderers[AUDIO_RENDERER_INDEX];
+    }
+
     public TrackRenderer[] asArray() {
         return Arrays.copyOf(renderers, renderers.length);
     }

--- a/core/src/main/java/com/novoda/noplayer/mediaplayer/AndroidMediaPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/mediaplayer/AndroidMediaPlayerFacade.java
@@ -6,10 +6,13 @@ import android.media.MediaPlayer;
 import android.net.Uri;
 import android.view.SurfaceHolder;
 
+import com.google.android.exoplayer.MediaFormat;
 import com.novoda.noplayer.SurfaceHolderRequester;
 import com.novoda.notils.logger.simple.Log;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 public class AndroidMediaPlayerFacade {
@@ -73,7 +76,6 @@ public class AndroidMediaPlayerFacade {
 
     private MediaPlayer createMediaPlayer(SurfaceHolder surfaceHolder, Uri videoUri) throws IOException {
         MediaPlayer mediaPlayer = new MediaPlayer();
-
         mediaPlayer.setOnPreparedListener(internalPeparedListener);
         mediaPlayer.setOnVideoSizeChangedListener(internalSizeChangedListener);
         mediaPlayer.setOnCompletionListener(internalCompletionListener);
@@ -235,5 +237,13 @@ public class AndroidMediaPlayerFacade {
                 && currentState != STATE_ERROR
                 && currentState != STATE_IDLE
                 && currentState != STATE_PREPARING;
+    }
+
+    public List<MediaFormat> getAudioTracks() {
+        return Collections.emptyList();
+    }
+
+    public void setAudioTrack() {
+        // TODO:
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/mediaplayer/AndroidMediaPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/mediaplayer/AndroidMediaPlayerFacade.java
@@ -11,7 +11,7 @@ import com.novoda.noplayer.SurfaceHolderRequester;
 import com.novoda.notils.logger.simple.Log;
 
 import java.io.IOException;
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -240,10 +240,33 @@ public class AndroidMediaPlayerFacade {
     }
 
     public List<PlayerAudioTrack> getAudioTracks() {
-        return Collections.emptyList();
+        ArrayList<PlayerAudioTrack> audioTracks = new ArrayList<>();
+        for (MediaPlayer.TrackInfo trackInfo : mediaPlayer.getTrackInfo()) {
+            if (trackInfo.getTrackType() == MediaPlayer.TrackInfo.MEDIA_TRACK_TYPE_AUDIO) {
+                audioTracks.add(new PlayerAudioTrack(String.valueOf(trackInfo.hashCode()), trackInfo.getLanguage(), "", -1, -1));
+            }
+        }
+        return audioTracks;
     }
 
-    public void setAudioTrack() {
-        // TODO:
+    public void setAudioTrack(int audioTrackIndex) {
+        int index = 0;
+        MediaPlayer.TrackInfo[] trackInfos = mediaPlayer.getTrackInfo();
+
+        for (int i = 0; i < trackInfos.length; i++) {
+            MediaPlayer.TrackInfo trackInfo = trackInfos[i];
+            if (trackInfo.getTrackType() == MediaPlayer.TrackInfo.MEDIA_TRACK_TYPE_AUDIO && index == audioTrackIndex) {
+                mediaPlayer.selectTrack(i);
+            } else if (trackInfo.getTrackType() == MediaPlayer.TrackInfo.MEDIA_TRACK_TYPE_AUDIO) {
+                index++;
+            }
+        }
+        Log.e(String.format(
+                "Attempt to %s has been ignored because an invalid position was specified: %s, total: %s",
+                "setAudioTrack()",
+                audioTrackIndex,
+                index
+              )
+        );
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/mediaplayer/AndroidMediaPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/mediaplayer/AndroidMediaPlayerFacade.java
@@ -263,7 +263,7 @@ public class AndroidMediaPlayerFacade {
         }
         Log.e(String.format(
                 "Attempt to %s has been ignored because an invalid position was specified: %s, total: %s",
-                "setAudioTrack()",
+                "selectAudioTrack()",
                 audioTrackIndex,
                 index
               )

--- a/core/src/main/java/com/novoda/noplayer/mediaplayer/AndroidMediaPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/mediaplayer/AndroidMediaPlayerFacade.java
@@ -6,7 +6,7 @@ import android.media.MediaPlayer;
 import android.net.Uri;
 import android.view.SurfaceHolder;
 
-import com.google.android.exoplayer.MediaFormat;
+import com.novoda.noplayer.PlayerAudioTrack;
 import com.novoda.noplayer.SurfaceHolderRequester;
 import com.novoda.notils.logger.simple.Log;
 
@@ -239,7 +239,7 @@ public class AndroidMediaPlayerFacade {
                 && currentState != STATE_PREPARING;
     }
 
-    public List<MediaFormat> getAudioTracks() {
+    public List<PlayerAudioTrack> getAudioTracks() {
         return Collections.emptyList();
     }
 

--- a/core/src/main/java/com/novoda/noplayer/mediaplayer/AndroidMediaPlayerImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/mediaplayer/AndroidMediaPlayerImpl.java
@@ -5,10 +5,10 @@ import android.net.Uri;
 import android.os.Handler;
 import android.os.Looper;
 
-import com.google.android.exoplayer.MediaFormat;
 import com.novoda.noplayer.ContentType;
 import com.novoda.noplayer.Heart;
 import com.novoda.noplayer.Player;
+import com.novoda.noplayer.PlayerAudioTrack;
 import com.novoda.noplayer.PlayerListenersHolder;
 import com.novoda.noplayer.PlayerView;
 import com.novoda.noplayer.SystemClock;
@@ -311,7 +311,7 @@ public class AndroidMediaPlayerImpl extends PlayerListenersHolder implements Pla
     }
 
     @Override
-    public List<MediaFormat> getAudioTracks() {
+    public List<PlayerAudioTrack> getAudioTracks() {
         return mediaPlayer.getAudioTracks();
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/mediaplayer/AndroidMediaPlayerImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/mediaplayer/AndroidMediaPlayerImpl.java
@@ -5,6 +5,7 @@ import android.net.Uri;
 import android.os.Handler;
 import android.os.Looper;
 
+import com.google.android.exoplayer.MediaFormat;
 import com.novoda.noplayer.ContentType;
 import com.novoda.noplayer.Heart;
 import com.novoda.noplayer.Player;
@@ -17,6 +18,8 @@ import com.novoda.noplayer.VideoDuration;
 import com.novoda.noplayer.VideoPosition;
 import com.novoda.noplayer.player.PlayerInformation;
 import com.novoda.notils.logger.simple.Log;
+
+import java.util.List;
 
 public class AndroidMediaPlayerImpl extends PlayerListenersHolder implements Player {
 
@@ -300,5 +303,15 @@ public class AndroidMediaPlayerImpl extends PlayerListenersHolder implements Pla
         mediaPlayer.release();
         getStateChangedListeners().onVideoReleased();
         videoContainer.hide();
+    }
+
+    @Override
+    public void setAudioTrack(int mediaTrackPosition) {
+        mediaPlayer.setAudioTrack();
+    }
+
+    @Override
+    public List<MediaFormat> getAudioTracks() {
+        return mediaPlayer.getAudioTracks();
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/mediaplayer/AndroidMediaPlayerImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/mediaplayer/AndroidMediaPlayerImpl.java
@@ -306,7 +306,7 @@ public class AndroidMediaPlayerImpl extends PlayerListenersHolder implements Pla
     }
 
     @Override
-    public void setAudioTrack(int audioTrackIndex) {
+    public void selectAudioTrack(int audioTrackIndex) {
         mediaPlayer.setAudioTrack(audioTrackIndex);
 
     }

--- a/core/src/main/java/com/novoda/noplayer/mediaplayer/AndroidMediaPlayerImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/mediaplayer/AndroidMediaPlayerImpl.java
@@ -306,8 +306,9 @@ public class AndroidMediaPlayerImpl extends PlayerListenersHolder implements Pla
     }
 
     @Override
-    public void setAudioTrack(int mediaTrackPosition) {
-        mediaPlayer.setAudioTrack();
+    public void setAudioTrack(int audioTrackIndex) {
+        mediaPlayer.setAudioTrack(audioTrackIndex);
+
     }
 
     @Override


### PR DESCRIPTION
#### Problem
Clients of `no-player` are unable to select the `audio track` they desire at any point during video playback. 

#### Solution
Expose methods in the `Player` to allow clients to get a list of `PlayerAudioTrack`. `PlayAudioTrack` consists of basic info around a `MediaFormat` such as `language`, `channels`, `mimeType` etc. To set an `AudioTrack` the client needs to specify an index from the `PlayerAudioTrack` that matches the audio track they desire. 

`mediaPlayer.selectTrack()` is only available above `api` level 15 so we upped this as well in this PR. It seems impossible to set an `audio track` before this.

#### Paired with
@jackSzm 