### PR TITLE
Null checks when dealing with audio tracks. 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ task wrapper(type: Wrapper) {
 }
 
 allprojects {
-    version = "1.0.2"
+    version = "1.0.3"
 }
 
 buildscript {

--- a/core/src/main/java/com/novoda/noplayer/exoplayer/ExoPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/exoplayer/ExoPlayerFacade.java
@@ -32,7 +32,6 @@ import com.novoda.notils.logger.simple.Log;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -441,8 +440,7 @@ public class ExoPlayerFacade implements ChunkSampleSource.EventListener,
 
     public void selectAudioTrack(int audioTrackIndex) {
         if (player == null) {
-            Log.w("You can only call selectAudioTrack() when video is prepared.");
-            return;
+            throw new NullPointerException("You can only call selectAudioTrack() when video is prepared.");
         }
 
         int trackCount = player.getTrackCount(Renderers.AUDIO_RENDERER_ID);
@@ -463,8 +461,7 @@ public class ExoPlayerFacade implements ChunkSampleSource.EventListener,
 
     public List<PlayerAudioTrack> getAudioTracks() {
         if (player == null) {
-            Log.w("You can only call getAudioTracks() when video is prepared.");
-            return Collections.emptyList();
+            throw new NullPointerException("You can only call getAudioTracks() when video is prepared.");
         }
 
         List<PlayerAudioTrack> tracks = new ArrayList<>();

--- a/core/src/main/java/com/novoda/noplayer/exoplayer/ExoPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/exoplayer/ExoPlayerFacade.java
@@ -32,6 +32,7 @@ import com.novoda.notils.logger.simple.Log;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -439,7 +440,13 @@ public class ExoPlayerFacade implements ChunkSampleSource.EventListener,
     }
 
     public void selectAudioTrack(int audioTrackIndex) {
+        if (player == null) {
+            Log.w("You can only call selectAudioTrack() when video is prepared.");
+            return;
+        }
+
         int trackCount = player.getTrackCount(Renderers.AUDIO_RENDERER_ID);
+
         if (audioTrackIndex < 0 || audioTrackIndex > trackCount - 1) {
             Log.e(String.format(
                     "Attempt to %s has been ignored because an invalid position was specified: %s, total: %s",
@@ -450,10 +457,16 @@ public class ExoPlayerFacade implements ChunkSampleSource.EventListener,
             );
             return;
         }
+
         player.setSelectedTrack(Renderers.AUDIO_RENDERER_ID, audioTrackIndex);
     }
 
     public List<PlayerAudioTrack> getAudioTracks() {
+        if (player == null) {
+            Log.w("You can only call getAudioTracks() when video is prepared.");
+            return Collections.emptyList();
+        }
+
         List<PlayerAudioTrack> tracks = new ArrayList<>();
         for (int i = 0; i < player.getTrackCount(Renderers.AUDIO_RENDERER_ID); i++) {
             MediaFormat track = player.getTrackFormat(Renderers.AUDIO_RENDERER_ID, i);

--- a/core/src/main/java/com/novoda/noplayer/mediaplayer/AndroidMediaPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/mediaplayer/AndroidMediaPlayerFacade.java
@@ -26,7 +26,8 @@ public class AndroidMediaPlayerFacade {
     private static final int STATE_PAUSED = 4;
     private static final int STATE_PLAYBACK_COMPLETED = 5;
     private static final Map<String, String> NO_HEADERS = null;
-    public static final int INVALID_AUDIO_TRACK_INDEX = -1;
+
+    private static final int INVALID_AUDIO_TRACK_INDEX = -1;
 
     private final Context context;
 

--- a/core/src/main/java/com/novoda/noplayer/mediaplayer/AndroidMediaPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/mediaplayer/AndroidMediaPlayerFacade.java
@@ -12,7 +12,6 @@ import com.novoda.notils.logger.simple.Log;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -244,8 +243,7 @@ public class AndroidMediaPlayerFacade {
 
     public List<PlayerAudioTrack> getAudioTracks() {
         if (mediaPlayer == null) {
-            Log.w("You can only call getAudioTracks() when video is prepared.");
-            return Collections.emptyList();
+            throw new NullPointerException("You can only call getAudioTracks() when video is prepared.");
         }
 
         return getOnlyAudioTracks();
@@ -263,8 +261,7 @@ public class AndroidMediaPlayerFacade {
 
     public void selectAudioTrack(int audioTrackIndex) {
         if (mediaPlayer == null) {
-            Log.w("You can only call selectAudioTrack() when video is prepared.");
-            return;
+            throw new NullPointerException("You can only call selectAudioTrack() when video is prepared.");
         }
 
         int absoluteAudioTrackIndex = getAbsoluteAudioTrackIndex(audioTrackIndex);

--- a/core/src/main/java/com/novoda/noplayer/mediaplayer/AndroidMediaPlayerImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/mediaplayer/AndroidMediaPlayerImpl.java
@@ -307,7 +307,7 @@ public class AndroidMediaPlayerImpl extends PlayerListenersHolder implements Pla
 
     @Override
     public void selectAudioTrack(int audioTrackIndex) {
-        mediaPlayer.setAudioTrack(audioTrackIndex);
+        mediaPlayer.selectAudioTrack(audioTrackIndex);
 
     }
 


### PR DESCRIPTION
## Problem 

When calling `getAudioTracks()` and `selectAudioTrack()` before video is prepared we can get either `NullPointerException` or invalid result being 0. 
You should only call those methods after video is prepared. 

## Solution

We've added null checks in mentioned methods and log appropriate message. 

## Paired with
@Mecharyry 