### PR TITLE
Update compile and buildTools to 25

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -3,12 +3,11 @@ apply plugin: 'bintray-release'
 apply plugin: 'jacoco'
 
 android {
-    compileSdkVersion 24
-    buildToolsVersion "25.0.0"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.2"
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 24
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
 

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 22
-    buildToolsVersion "22.0.1"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.2"
 
     defaultConfig {
         applicationId "com.novoda.demo"
         minSdkVersion 16
-        targetSdkVersion 24
+        targetSdkVersion 25
         versionCode 1
         versionName "1.0"
     }


### PR DESCRIPTION
I had problem building demo ("Failed to execute aapt") until I updated the buildToolsVersion.

Updated it for both modules (no problems unless increasing targetSdkVersion).

Removed targetSdkVersion for the library since it's unnecessary and can be picked up by the parent project in some cases.