### PR TITLE
Refactoring media player listeners

### DIFF
--- a/core/src/main/java/com/novoda/noplayer/exoplayer/forwarder/EventInfoForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/exoplayer/forwarder/EventInfoForwarder.java
@@ -20,59 +20,65 @@ class EventInfoForwarder implements ExoPlayer.EventListener {
 
     @Override
     public void onTimelineChanged(Timeline timeline, Object manifest) {
-        HashMap<String, String> keyValuePairs = new HashMap<>();
-        keyValuePairs.put("timeline", String.valueOf(timeline));
-        keyValuePairs.put("manifest", String.valueOf(manifest));
+        HashMap<String, String> callingMethodParameters = new HashMap<>();
 
-        infoListeners.onNewInfo("onTimelineChanged", keyValuePairs);
+        callingMethodParameters.put("timeline", String.valueOf(timeline));
+        callingMethodParameters.put("manifest", String.valueOf(manifest));
+
+        infoListeners.onNewInfo("onTimelineChanged", callingMethodParameters);
     }
 
     @Override
     public void onTracksChanged(TrackGroupArray trackGroups, TrackSelectionArray trackSelections) {
-        HashMap<String, String> keyValuePairs = new HashMap<>();
-        keyValuePairs.put("trackGroups", String.valueOf(trackGroups));
-        keyValuePairs.put("trackSelections", String.valueOf(trackSelections));
+        HashMap<String, String> callingMethodParameters = new HashMap<>();
 
-        infoListeners.onNewInfo("onTracksChanged", keyValuePairs);
+        callingMethodParameters.put("trackGroups", String.valueOf(trackGroups));
+        callingMethodParameters.put("trackSelections", String.valueOf(trackSelections));
+
+        infoListeners.onNewInfo("onTracksChanged", callingMethodParameters);
     }
 
     @Override
     public void onLoadingChanged(boolean isLoading) {
-        HashMap<String, String> keyValuePairs = new HashMap<>();
-        keyValuePairs.put("isLoading", String.valueOf(isLoading));
+        HashMap<String, String> callingMethodParameters = new HashMap<>();
 
-        infoListeners.onNewInfo("onLoadingChanged", keyValuePairs);
+        callingMethodParameters.put("isLoading", String.valueOf(isLoading));
+
+        infoListeners.onNewInfo("onLoadingChanged", callingMethodParameters);
     }
 
     @Override
     public void onPlayerStateChanged(boolean playWhenReady, int playbackState) {
-        HashMap<String, String> keyValuePairs = new HashMap<>();
-        keyValuePairs.put("playWhenReady", String.valueOf(playWhenReady));
-        keyValuePairs.put("playbackState", String.valueOf(playbackState));
+        HashMap<String, String> callingMethodParameters = new HashMap<>();
 
-        infoListeners.onNewInfo("onPlayerStateChanged", keyValuePairs);
+        callingMethodParameters.put("playWhenReady", String.valueOf(playWhenReady));
+        callingMethodParameters.put("playbackState", String.valueOf(playbackState));
+
+        infoListeners.onNewInfo("onPlayerStateChanged", callingMethodParameters);
     }
 
     @Override
     public void onPlayerError(ExoPlaybackException error) {
-        HashMap<String, String> keyValuePairs = new HashMap<>();
-        keyValuePairs.put("error", String.valueOf(error));
+        HashMap<String, String> callingMethodParameters = new HashMap<>();
 
-        infoListeners.onNewInfo("onPlayerError", keyValuePairs);
+        callingMethodParameters.put("error", String.valueOf(error));
+
+        infoListeners.onNewInfo("onPlayerError", callingMethodParameters);
     }
 
     @Override
     public void onPositionDiscontinuity() {
-        HashMap<String, String> keyValuePairs = new HashMap<>();
+        HashMap<String, String> callingMethodParameters = new HashMap<>();
 
-        infoListeners.onNewInfo("onPositionDiscontinuity", keyValuePairs);
+        infoListeners.onNewInfo("onPositionDiscontinuity", callingMethodParameters);
     }
 
     @Override
     public void onPlaybackParametersChanged(PlaybackParameters playbackParameters) {
-        HashMap<String, String> keyValuePairs = new HashMap<>();
-        keyValuePairs.put("playbackParameters", String.valueOf(playbackParameters));
+        HashMap<String, String> callingMethodParameters = new HashMap<>();
 
-        infoListeners.onNewInfo("onPlaybackParametersChanged", keyValuePairs);
+        callingMethodParameters.put("playbackParameters", String.valueOf(playbackParameters));
+
+        infoListeners.onNewInfo("onPlaybackParametersChanged", callingMethodParameters);
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/exoplayer/forwarder/ExtractorInfoForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/exoplayer/forwarder/ExtractorInfoForwarder.java
@@ -16,9 +16,10 @@ class ExtractorInfoForwarder implements ExtractorMediaSource.EventListener {
 
     @Override
     public void onLoadError(IOException error) {
-        HashMap<String, String> keyValuePairs = new HashMap<>();
-        keyValuePairs.put("error", String.valueOf(error));
+        HashMap<String, String> callingMethodParameters = new HashMap<>();
 
-        infoListeners.onNewInfo("onLoadError", keyValuePairs);
+        callingMethodParameters.put("error", String.valueOf(error));
+
+        infoListeners.onNewInfo("onLoadError", callingMethodParameters);
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/exoplayer/forwarder/InfoListener.java
+++ b/core/src/main/java/com/novoda/noplayer/exoplayer/forwarder/InfoListener.java
@@ -7,6 +7,15 @@ import java.util.Map;
  */
 public interface InfoListener {
 
-    void onNewInfo(String callingMethod, Map<String, String> keyValuePairs);
+    /**
+     * All event listeners attached to implementations of Player will
+     * forward information through this to provide debugging
+     * information to client applications.
+     *
+     * @param callingMethod       The method name from where this call originated.
+     * @param callingMethodParams Parameter name and value pairs from where this call originated.
+     *                            Pass only string representations not whole objects.
+     */
+    void onNewInfo(String callingMethod, Map<String, String> callingMethodParams);
 
 }

--- a/core/src/main/java/com/novoda/noplayer/exoplayer/forwarder/MediaSourceInfoForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/exoplayer/forwarder/MediaSourceInfoForwarder.java
@@ -19,102 +19,108 @@ class MediaSourceInfoForwarder implements AdaptiveMediaSourceEventListener {
     @Override
     public void onLoadStarted(DataSpec dataSpec, int dataType, int trackType, Format trackFormat, int trackSelectionReason,
                               Object trackSelectionData, long mediaStartTimeMs, long mediaEndTimeMs, long elapsedRealtimeMs) {
-        HashMap<String, String> keyValuePairs = new HashMap<>();
-        keyValuePairs.put("dataSpec", String.valueOf(dataSpec));
-        keyValuePairs.put("dataType", String.valueOf(dataType));
-        keyValuePairs.put("trackType", String.valueOf(trackType));
-        keyValuePairs.put("trackFormat", String.valueOf(trackFormat));
-        keyValuePairs.put("trackSelectionReason", String.valueOf(trackSelectionReason));
-        keyValuePairs.put("trackSelectionData", String.valueOf(trackSelectionData));
-        keyValuePairs.put("mediaStartTimeMs", String.valueOf(mediaStartTimeMs));
-        keyValuePairs.put("mediaEndTimeMs", String.valueOf(mediaEndTimeMs));
-        keyValuePairs.put("elapsedRealtimeMs", String.valueOf(elapsedRealtimeMs));
+        HashMap<String, String> callingMethodParameters = new HashMap<>();
 
-        infoListeners.onNewInfo("onLoadStarted", keyValuePairs);
+        callingMethodParameters.put("dataSpec", String.valueOf(dataSpec));
+        callingMethodParameters.put("dataType", String.valueOf(dataType));
+        callingMethodParameters.put("trackType", String.valueOf(trackType));
+        callingMethodParameters.put("trackFormat", String.valueOf(trackFormat));
+        callingMethodParameters.put("trackSelectionReason", String.valueOf(trackSelectionReason));
+        callingMethodParameters.put("trackSelectionData", String.valueOf(trackSelectionData));
+        callingMethodParameters.put("mediaStartTimeMs", String.valueOf(mediaStartTimeMs));
+        callingMethodParameters.put("mediaEndTimeMs", String.valueOf(mediaEndTimeMs));
+        callingMethodParameters.put("elapsedRealtimeMs", String.valueOf(elapsedRealtimeMs));
+
+        infoListeners.onNewInfo("onLoadStarted", callingMethodParameters);
     }
 
     @Override
     public void onLoadCompleted(DataSpec dataSpec, int dataType, int trackType, Format trackFormat, int trackSelectionReason,
                                 Object trackSelectionData, long mediaStartTimeMs, long mediaEndTimeMs, long elapsedRealtimeMs,
                                 long loadDurationMs, long bytesLoaded) {
-        HashMap<String, String> keyValuePairs = new HashMap<>();
-        keyValuePairs.put("dataSpec", String.valueOf(dataSpec));
-        keyValuePairs.put("dataType", String.valueOf(dataType));
-        keyValuePairs.put("trackType", String.valueOf(trackType));
-        keyValuePairs.put("trackFormat", String.valueOf(trackFormat));
-        keyValuePairs.put("trackSelectionReason", String.valueOf(trackSelectionReason));
-        keyValuePairs.put("trackSelectionData", String.valueOf(trackSelectionData));
-        keyValuePairs.put("mediaStartTimeMs", String.valueOf(mediaStartTimeMs));
-        keyValuePairs.put("mediaEndTimeMs", String.valueOf(mediaEndTimeMs));
-        keyValuePairs.put("elapsedRealtimeMs", String.valueOf(elapsedRealtimeMs));
-        keyValuePairs.put("loadDurationMs", String.valueOf(loadDurationMs));
-        keyValuePairs.put("bytesLoaded", String.valueOf(bytesLoaded));
+        HashMap<String, String> callingMethodParameters = new HashMap<>();
 
-        infoListeners.onNewInfo("onLoadCompleted", keyValuePairs);
+        callingMethodParameters.put("dataSpec", String.valueOf(dataSpec));
+        callingMethodParameters.put("dataType", String.valueOf(dataType));
+        callingMethodParameters.put("trackType", String.valueOf(trackType));
+        callingMethodParameters.put("trackFormat", String.valueOf(trackFormat));
+        callingMethodParameters.put("trackSelectionReason", String.valueOf(trackSelectionReason));
+        callingMethodParameters.put("trackSelectionData", String.valueOf(trackSelectionData));
+        callingMethodParameters.put("mediaStartTimeMs", String.valueOf(mediaStartTimeMs));
+        callingMethodParameters.put("mediaEndTimeMs", String.valueOf(mediaEndTimeMs));
+        callingMethodParameters.put("elapsedRealtimeMs", String.valueOf(elapsedRealtimeMs));
+        callingMethodParameters.put("loadDurationMs", String.valueOf(loadDurationMs));
+        callingMethodParameters.put("bytesLoaded", String.valueOf(bytesLoaded));
+
+        infoListeners.onNewInfo("onLoadCompleted", callingMethodParameters);
     }
 
     @Override
     public void onLoadCanceled(DataSpec dataSpec, int dataType, int trackType, Format trackFormat, int trackSelectionReason,
                                Object trackSelectionData, long mediaStartTimeMs, long mediaEndTimeMs, long elapsedRealtimeMs,
                                long loadDurationMs, long bytesLoaded) {
-        HashMap<String, String> keyValuePairs = new HashMap<>();
-        keyValuePairs.put("dataSpec", String.valueOf(dataSpec));
-        keyValuePairs.put("dataType", String.valueOf(dataType));
-        keyValuePairs.put("trackType", String.valueOf(trackType));
-        keyValuePairs.put("trackFormat", String.valueOf(trackFormat));
-        keyValuePairs.put("trackSelectionReason", String.valueOf(trackSelectionReason));
-        keyValuePairs.put("trackSelectionData", String.valueOf(trackSelectionData));
-        keyValuePairs.put("mediaStartTimeMs", String.valueOf(mediaStartTimeMs));
-        keyValuePairs.put("mediaEndTimeMs", String.valueOf(mediaEndTimeMs));
-        keyValuePairs.put("elapsedRealtimeMs", String.valueOf(elapsedRealtimeMs));
-        keyValuePairs.put("loadDurationMs", String.valueOf(loadDurationMs));
-        keyValuePairs.put("bytesLoaded", String.valueOf(bytesLoaded));
+        HashMap<String, String> callingMethodParameters = new HashMap<>();
 
-        infoListeners.onNewInfo("onLoadCanceled", keyValuePairs);
+        callingMethodParameters.put("dataSpec", String.valueOf(dataSpec));
+        callingMethodParameters.put("dataType", String.valueOf(dataType));
+        callingMethodParameters.put("trackType", String.valueOf(trackType));
+        callingMethodParameters.put("trackFormat", String.valueOf(trackFormat));
+        callingMethodParameters.put("trackSelectionReason", String.valueOf(trackSelectionReason));
+        callingMethodParameters.put("trackSelectionData", String.valueOf(trackSelectionData));
+        callingMethodParameters.put("mediaStartTimeMs", String.valueOf(mediaStartTimeMs));
+        callingMethodParameters.put("mediaEndTimeMs", String.valueOf(mediaEndTimeMs));
+        callingMethodParameters.put("elapsedRealtimeMs", String.valueOf(elapsedRealtimeMs));
+        callingMethodParameters.put("loadDurationMs", String.valueOf(loadDurationMs));
+        callingMethodParameters.put("bytesLoaded", String.valueOf(bytesLoaded));
+
+        infoListeners.onNewInfo("onLoadCanceled", callingMethodParameters);
     }
 
     @Override
     public void onLoadError(DataSpec dataSpec, int dataType, int trackType, Format trackFormat, int trackSelectionReason,
                             Object trackSelectionData, long mediaStartTimeMs, long mediaEndTimeMs, long elapsedRealtimeMs, long loadDurationMs,
                             long bytesLoaded, IOException error, boolean wasCanceled) {
-        HashMap<String, String> keyValuePairs = new HashMap<>();
-        keyValuePairs.put("dataSpec", String.valueOf(dataSpec));
-        keyValuePairs.put("dataType", String.valueOf(dataType));
-        keyValuePairs.put("trackType", String.valueOf(trackType));
-        keyValuePairs.put("trackFormat", String.valueOf(trackFormat));
-        keyValuePairs.put("trackSelectionReason", String.valueOf(trackSelectionReason));
-        keyValuePairs.put("trackSelectionData", String.valueOf(trackSelectionData));
-        keyValuePairs.put("mediaStartTimeMs", String.valueOf(mediaStartTimeMs));
-        keyValuePairs.put("mediaEndTimeMs", String.valueOf(mediaEndTimeMs));
-        keyValuePairs.put("elapsedRealtimeMs", String.valueOf(elapsedRealtimeMs));
-        keyValuePairs.put("loadDurationMs", String.valueOf(loadDurationMs));
-        keyValuePairs.put("bytesLoaded", String.valueOf(bytesLoaded));
-        keyValuePairs.put("IOException", String.valueOf(error));
-        keyValuePairs.put("wasCanceled", String.valueOf(wasCanceled));
+        HashMap<String, String> callingMethodParameters = new HashMap<>();
 
-        infoListeners.onNewInfo("onLoadError", keyValuePairs);
+        callingMethodParameters.put("dataSpec", String.valueOf(dataSpec));
+        callingMethodParameters.put("dataType", String.valueOf(dataType));
+        callingMethodParameters.put("trackType", String.valueOf(trackType));
+        callingMethodParameters.put("trackFormat", String.valueOf(trackFormat));
+        callingMethodParameters.put("trackSelectionReason", String.valueOf(trackSelectionReason));
+        callingMethodParameters.put("trackSelectionData", String.valueOf(trackSelectionData));
+        callingMethodParameters.put("mediaStartTimeMs", String.valueOf(mediaStartTimeMs));
+        callingMethodParameters.put("mediaEndTimeMs", String.valueOf(mediaEndTimeMs));
+        callingMethodParameters.put("elapsedRealtimeMs", String.valueOf(elapsedRealtimeMs));
+        callingMethodParameters.put("loadDurationMs", String.valueOf(loadDurationMs));
+        callingMethodParameters.put("bytesLoaded", String.valueOf(bytesLoaded));
+        callingMethodParameters.put("IOException", String.valueOf(error));
+        callingMethodParameters.put("wasCanceled", String.valueOf(wasCanceled));
+
+        infoListeners.onNewInfo("onLoadError", callingMethodParameters);
     }
 
     @Override
     public void onUpstreamDiscarded(int trackType, long mediaStartTimeMs, long mediaEndTimeMs) {
-        HashMap<String, String> keyValuePairs = new HashMap<>();
-        keyValuePairs.put("trackType", String.valueOf(trackType));
-        keyValuePairs.put("mediaStartTimeMs", String.valueOf(mediaStartTimeMs));
-        keyValuePairs.put("mediaEndTimeMs", String.valueOf(mediaEndTimeMs));
+        HashMap<String, String> callingMethodParameters = new HashMap<>();
 
-        infoListeners.onNewInfo("onUpstreamDiscarded", keyValuePairs);
+        callingMethodParameters.put("trackType", String.valueOf(trackType));
+        callingMethodParameters.put("mediaStartTimeMs", String.valueOf(mediaStartTimeMs));
+        callingMethodParameters.put("mediaEndTimeMs", String.valueOf(mediaEndTimeMs));
+
+        infoListeners.onNewInfo("onUpstreamDiscarded", callingMethodParameters);
     }
 
     @Override
     public void onDownstreamFormatChanged(int trackType, Format trackFormat, int trackSelectionReason, Object trackSelectionData,
                                           long mediaTimeMs) {
-        HashMap<String, String> keyValuePairs = new HashMap<>();
-        keyValuePairs.put("trackType", String.valueOf(trackType));
-        keyValuePairs.put("trackFormat", String.valueOf(trackFormat));
-        keyValuePairs.put("trackSelectionReason", String.valueOf(trackSelectionReason));
-        keyValuePairs.put("trackSelectionData", String.valueOf(trackSelectionData));
-        keyValuePairs.put("mediaTimeMs", String.valueOf(mediaTimeMs));
+        HashMap<String, String> callingMethodParameters = new HashMap<>();
 
-        infoListeners.onNewInfo("onDownstreamFormatChanged", keyValuePairs);
+        callingMethodParameters.put("trackType", String.valueOf(trackType));
+        callingMethodParameters.put("trackFormat", String.valueOf(trackFormat));
+        callingMethodParameters.put("trackSelectionReason", String.valueOf(trackSelectionReason));
+        callingMethodParameters.put("trackSelectionData", String.valueOf(trackSelectionData));
+        callingMethodParameters.put("mediaTimeMs", String.valueOf(mediaTimeMs));
+
+        infoListeners.onNewInfo("onDownstreamFormatChanged", callingMethodParameters);
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/exoplayer/forwarder/VideoRendererInfoForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/exoplayer/forwarder/VideoRendererInfoForwarder.java
@@ -19,63 +19,70 @@ class VideoRendererInfoForwarder implements VideoRendererEventListener {
 
     @Override
     public void onDroppedFrames(int count, long elapsedMs) {
-        HashMap<String, String> keyValuePairs = new HashMap<>();
-        keyValuePairs.put("count", String.valueOf(count));
-        keyValuePairs.put("elapsedMs", String.valueOf(elapsedMs));
+        HashMap<String, String> callingMethodParameters = new HashMap<>();
 
-        infoListeners.onNewInfo("onDroppedFrames", keyValuePairs);
+        callingMethodParameters.put("count", String.valueOf(count));
+        callingMethodParameters.put("elapsedMs", String.valueOf(elapsedMs));
+
+        infoListeners.onNewInfo("onDroppedFrames", callingMethodParameters);
     }
 
     @Override
     public void onVideoEnabled(DecoderCounters counters) {
-        HashMap<String, String> keyValuePairs = new HashMap<>();
-        keyValuePairs.put("counters", String.valueOf(counters));
+        HashMap<String, String> callingMethodParameters = new HashMap<>();
 
-        infoListeners.onNewInfo("onVideoEnabled", keyValuePairs);
+        callingMethodParameters.put("counters", String.valueOf(counters));
+
+        infoListeners.onNewInfo("onVideoEnabled", callingMethodParameters);
     }
 
     @Override
     public void onVideoDecoderInitialized(String decoderName, long initializedTimestampMs, long initializationDurationMs) {
-        HashMap<String, String> keyValuePairs = new HashMap<>();
-        keyValuePairs.put("decoderName", String.valueOf(decoderName));
-        keyValuePairs.put("initializedTimestampMs", String.valueOf(initializedTimestampMs));
-        keyValuePairs.put("initializationDurationMs", String.valueOf(initializationDurationMs));
+        HashMap<String, String> callingMethodParameters = new HashMap<>();
 
-        infoListeners.onNewInfo("onVideoDecoderInitialized", keyValuePairs);
+        callingMethodParameters.put("decoderName", String.valueOf(decoderName));
+        callingMethodParameters.put("initializedTimestampMs", String.valueOf(initializedTimestampMs));
+        callingMethodParameters.put("initializationDurationMs", String.valueOf(initializationDurationMs));
+
+        infoListeners.onNewInfo("onVideoDecoderInitialized", callingMethodParameters);
     }
 
     @Override
     public void onVideoInputFormatChanged(Format format) {
-        HashMap<String, String> keyValuePairs = new HashMap<>();
-        keyValuePairs.put("format", String.valueOf(format));
+        HashMap<String, String> callingMethodParameters = new HashMap<>();
 
-        infoListeners.onNewInfo("onVideoInputFormatChanged", keyValuePairs);
+        callingMethodParameters.put("format", String.valueOf(format));
+
+        infoListeners.onNewInfo("onVideoInputFormatChanged", callingMethodParameters);
     }
 
     @Override
     public void onVideoSizeChanged(int width, int height, int unappliedRotationDegrees, float pixelWidthHeightRatio) {
-        HashMap<String, String> keyValuePairs = new HashMap<>();
-        keyValuePairs.put("width", String.valueOf(width));
-        keyValuePairs.put("height", String.valueOf(height));
-        keyValuePairs.put("unappliedRotationDegrees", String.valueOf(unappliedRotationDegrees));
-        keyValuePairs.put("pixelWidthHeightRatio", String.valueOf(pixelWidthHeightRatio));
+        HashMap<String, String> callingMethodParameters = new HashMap<>();
 
-        infoListeners.onNewInfo("onVideoSizeChanged", keyValuePairs);
+        callingMethodParameters.put("width", String.valueOf(width));
+        callingMethodParameters.put("height", String.valueOf(height));
+        callingMethodParameters.put("unappliedRotationDegrees", String.valueOf(unappliedRotationDegrees));
+        callingMethodParameters.put("pixelWidthHeightRatio", String.valueOf(pixelWidthHeightRatio));
+
+        infoListeners.onNewInfo("onVideoSizeChanged", callingMethodParameters);
     }
 
     @Override
     public void onRenderedFirstFrame(Surface surface) {
-        HashMap<String, String> keyValuePairs = new HashMap<>();
-        keyValuePairs.put("surface", String.valueOf(surface));
+        HashMap<String, String> callingMethodParameters = new HashMap<>();
 
-        infoListeners.onNewInfo("onRenderedFirstFrame", keyValuePairs);
+        callingMethodParameters.put("surface", String.valueOf(surface));
+
+        infoListeners.onNewInfo("onRenderedFirstFrame", callingMethodParameters);
     }
 
     @Override
     public void onVideoDisabled(DecoderCounters counters) {
-        HashMap<String, String> keyValuePairs = new HashMap<>();
-        keyValuePairs.put("counters", String.valueOf(counters));
+        HashMap<String, String> callingMethodParameters = new HashMap<>();
 
-        infoListeners.onNewInfo("onVideoDisabled", keyValuePairs);
+        callingMethodParameters.put("counters", String.valueOf(counters));
+
+        infoListeners.onNewInfo("onVideoDisabled", callingMethodParameters);
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/listeners/InfoListeners.java
+++ b/core/src/main/java/com/novoda/noplayer/listeners/InfoListeners.java
@@ -19,9 +19,9 @@ public class InfoListeners implements InfoListener {
     }
 
     @Override
-    public void onNewInfo(String callingMethod, Map<String, String> keyValuePairs) {
+    public void onNewInfo(String callingMethod, Map<String, String> callingMethodParams) {
         for (InfoListener listener : listeners) {
-            listener.onNewInfo(callingMethod, keyValuePairs);
+            listener.onNewInfo(callingMethod, callingMethodParams);
         }
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/mediaplayer/AndroidMediaPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/mediaplayer/AndroidMediaPlayerFacade.java
@@ -15,7 +15,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-public class AndroidMediaPlayerFacade {
+class AndroidMediaPlayerFacade {
 
     private static final int STATE_ERROR = -1;
     private static final int STATE_IDLE = 0;
@@ -42,7 +42,7 @@ public class AndroidMediaPlayerFacade {
     private SurfaceHolderRequester surfaceHolderRequester;
     private List<PlayerAudioTrack> audioTracks;
 
-    public AndroidMediaPlayerFacade(Context context) {
+    AndroidMediaPlayerFacade(Context context) {
         this.context = context;
         currentState = STATE_IDLE;
     }
@@ -150,23 +150,23 @@ public class AndroidMediaPlayerFacade {
         }
     };
 
-    public void setOnPreparedListener(MediaPlayer.OnPreparedListener listener) {
+    void setOnPreparedListener(MediaPlayer.OnPreparedListener listener) {
         onPreparedListener = listener;
     }
 
-    public void setOnCompletionListener(MediaPlayer.OnCompletionListener listener) {
+    void setOnCompletionListener(MediaPlayer.OnCompletionListener listener) {
         onCompletionListener = listener;
     }
 
-    public void setOnErrorListener(MediaPlayer.OnErrorListener listener) {
+    void setOnErrorListener(MediaPlayer.OnErrorListener listener) {
         onErrorListener = listener;
     }
 
-    public void setOnSizeChangedListener(MediaPlayer.OnVideoSizeChangedListener listener) {
+    void setOnSizeChangedListener(MediaPlayer.OnVideoSizeChangedListener listener) {
         onSizeChangedListener = listener;
     }
 
-    public void release() {
+    void release() {
         if (hasPlayer()) {
             mediaPlayer.reset();
             mediaPlayer.release();
@@ -179,7 +179,7 @@ public class AndroidMediaPlayerFacade {
         return mediaPlayer != null;
     }
 
-    public void start() {
+    void start() {
         if (isInPlaybackState()) {
             if (surfaceHolderRequester == null) {
                 logPlayerNotAttachedWarning("start()");
@@ -207,7 +207,7 @@ public class AndroidMediaPlayerFacade {
         }
     }
 
-    public int getDuration() {
+    int getDuration() {
         if (isInPlaybackState()) {
             return mediaPlayer.getDuration();
         }
@@ -215,24 +215,24 @@ public class AndroidMediaPlayerFacade {
         return -1;
     }
 
-    public int getCurrentPosition() {
+    int getCurrentPosition() {
         if (isInPlaybackState()) {
             return mediaPlayer.getCurrentPosition();
         }
         return 0;
     }
 
-    public void seekTo(int msec) {
+    void seekTo(int msec) {
         if (isInPlaybackState()) {
             mediaPlayer.seekTo(msec);
         }
     }
 
-    public boolean isPlaying() {
+    boolean isPlaying() {
         return isInPlaybackState() && mediaPlayer.isPlaying();
     }
 
-    public int getBufferPercentage() {
+    int getBufferPercentage() {
         if (hasPlayer()) {
             return currentBufferPercentage;
         }
@@ -252,7 +252,7 @@ public class AndroidMediaPlayerFacade {
         }
     }
 
-    public List<PlayerAudioTrack> getAudioTracks() {
+    List<PlayerAudioTrack> getAudioTracks() {
         if (mediaPlayer == null) {
             throw new NullPointerException("You can only call getAudioTracks() when video is prepared.");
         }
@@ -270,7 +270,7 @@ public class AndroidMediaPlayerFacade {
         return audioTracks;
     }
 
-    public void selectAudioTrack(int audioTrackIndex) {
+    void selectAudioTrack(int audioTrackIndex) {
         if (mediaPlayer == null) {
             throw new NullPointerException("You can only call selectAudioTrack() when video is prepared.");
         }
@@ -306,7 +306,7 @@ public class AndroidMediaPlayerFacade {
         return INVALID_AUDIO_TRACK_INDEX;
     }
 
-    public void setOnSeekCompleteListener(MediaPlayer.OnSeekCompleteListener seekToResettingSeekListener) {
+    void setOnSeekCompleteListener(MediaPlayer.OnSeekCompleteListener seekToResettingSeekListener) {
         mediaPlayer.setOnSeekCompleteListener(seekToResettingSeekListener);
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/mediaplayer/AndroidMediaPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/mediaplayer/AndroidMediaPlayerFacade.java
@@ -305,4 +305,8 @@ public class AndroidMediaPlayerFacade {
 
         return INVALID_AUDIO_TRACK_INDEX;
     }
+
+    public void setOnSeekCompleteListener(MediaPlayer.OnSeekCompleteListener seekToResettingSeekListener) {
+        mediaPlayer.setOnSeekCompleteListener(seekToResettingSeekListener);
+    }
 }

--- a/core/src/main/java/com/novoda/noplayer/mediaplayer/AndroidMediaPlayerImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/mediaplayer/AndroidMediaPlayerImpl.java
@@ -1,5 +1,6 @@
 package com.novoda.noplayer.mediaplayer;
 
+import android.content.Context;
 import android.media.MediaPlayer;
 import android.net.Uri;
 import android.os.Handler;
@@ -23,7 +24,7 @@ import com.novoda.notils.logger.simple.Log;
 
 import java.util.List;
 
-public class AndroidMediaPlayerImpl extends PlayerListenersHolder implements Player {
+public final class AndroidMediaPlayerImpl extends PlayerListenersHolder implements Player {
 
     private static final VideoPosition NO_SEEK_TO_POSITION = VideoPosition.INVALID;
     private static final MediaPlayerInformation MEDIA_PLAYER_INFORMATION = new MediaPlayerInformation();
@@ -46,7 +47,12 @@ public class AndroidMediaPlayerImpl extends PlayerListenersHolder implements Pla
     private StateChangedListener stateChangedListener;
     private CheckBufferHeartbeatCallback heartbeatCallback;
 
-    public AndroidMediaPlayerImpl(final AndroidMediaPlayerFacade mediaPlayer, MediaPlayerForwarder forwarder) {
+    public static AndroidMediaPlayerImpl newInstance(Context context) {
+        AndroidMediaPlayerFacade androidMediaPlayer = new AndroidMediaPlayerFacade(context);
+        return new AndroidMediaPlayerImpl(androidMediaPlayer, new MediaPlayerForwarder());
+    }
+
+    private AndroidMediaPlayerImpl(final AndroidMediaPlayerFacade mediaPlayer, MediaPlayerForwarder forwarder) {
         this.mediaPlayer = mediaPlayer;
         handler = new Handler(Looper.getMainLooper());
         Heart.Heartbeat<Player> onHeartbeat = new Heart.Heartbeat<>(getHeartbeatCallbacks(), this);

--- a/core/src/main/java/com/novoda/noplayer/mediaplayer/AndroidMediaPlayerImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/mediaplayer/AndroidMediaPlayerImpl.java
@@ -76,7 +76,7 @@ public final class AndroidMediaPlayerImpl extends PlayerListenersHolder implemen
             @Override
             public void onPrepared(PlayerState playerState) {
                 loadTimeout.cancel();
-                mediaPlayer.setOnSeekCompleteListener(seekToResettingSeekListener); //TODO move in forwarder ?
+                mediaPlayer.setOnSeekCompleteListener(seekToResettingSeekListener);
             }
         });
         addErrorListener(new ErrorListener() {

--- a/core/src/main/java/com/novoda/noplayer/mediaplayer/CheckBufferHeartbeatCallback.java
+++ b/core/src/main/java/com/novoda/noplayer/mediaplayer/CheckBufferHeartbeatCallback.java
@@ -6,7 +6,7 @@ import com.novoda.noplayer.VideoPosition;
 
 @SuppressWarnings("PMD.RedundantFieldInitializer")
         // we're being very explicit with our default field values, not a bad thing!
-class CheckBufferHeartbeatCallback implements Heart.Heartbeat.Callback<Player> {
+public class CheckBufferHeartbeatCallback implements Heart.Heartbeat.Callback<Player> {
 
     private static final int FORCED_BUFFERING_BEATS_THRESHOLD = 4;
     private final BufferListener bufferListener;
@@ -14,7 +14,7 @@ class CheckBufferHeartbeatCallback implements Heart.Heartbeat.Callback<Player> {
     private VideoPosition previousPosition = VideoPosition.INVALID;
     private int beatsPlayed;
 
-    CheckBufferHeartbeatCallback(BufferListener bufferListener) {
+    public CheckBufferHeartbeatCallback(BufferListener bufferListener) {
         this.bufferListener = bufferListener;
     }
 

--- a/core/src/main/java/com/novoda/noplayer/mediaplayer/CheckBufferHeartbeatCallback.java
+++ b/core/src/main/java/com/novoda/noplayer/mediaplayer/CheckBufferHeartbeatCallback.java
@@ -4,8 +4,6 @@ import com.novoda.noplayer.Heart;
 import com.novoda.noplayer.Player;
 import com.novoda.noplayer.VideoPosition;
 
-@SuppressWarnings("PMD.RedundantFieldInitializer")
-        // we're being very explicit with our default field values, not a bad thing!
 public class CheckBufferHeartbeatCallback implements Heart.Heartbeat.Callback<Player> {
 
     private static final int FORCED_BUFFERING_BEATS_THRESHOLD = 4;
@@ -14,7 +12,7 @@ public class CheckBufferHeartbeatCallback implements Heart.Heartbeat.Callback<Pl
     private VideoPosition previousPosition = VideoPosition.INVALID;
     private int beatsPlayed;
 
-    public CheckBufferHeartbeatCallback(BufferListener bufferListener) {
+    CheckBufferHeartbeatCallback(BufferListener bufferListener) {
         this.bufferListener = bufferListener;
     }
 

--- a/core/src/main/java/com/novoda/noplayer/mediaplayer/forwarder/BufferHeartbeatListener.java
+++ b/core/src/main/java/com/novoda/noplayer/mediaplayer/forwarder/BufferHeartbeatListener.java
@@ -1,0 +1,22 @@
+package com.novoda.noplayer.mediaplayer.forwarder;
+
+import com.novoda.noplayer.listeners.BufferStateListeners;
+import com.novoda.noplayer.mediaplayer.CheckBufferHeartbeatCallback;
+
+class BufferHeartbeatListener implements CheckBufferHeartbeatCallback.BufferListener {
+    private final BufferStateListeners bufferStateListeners;
+
+    public BufferHeartbeatListener(BufferStateListeners bufferStateListeners) {
+        this.bufferStateListeners = bufferStateListeners;
+    }
+
+    @Override
+    public void onBufferStart() {
+        bufferStateListeners.onBufferStarted();
+    }
+
+    @Override
+    public void onBufferComplete() {
+        bufferStateListeners.onBufferCompleted();
+    }
+}

--- a/core/src/main/java/com/novoda/noplayer/mediaplayer/forwarder/BufferInfoForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/mediaplayer/forwarder/BufferInfoForwarder.java
@@ -15,16 +15,16 @@ class BufferInfoForwarder implements CheckBufferHeartbeatCallback.BufferListener
 
     @Override
     public void onBufferStart() {
-        HashMap<String, String> keyValuePairs = new HashMap<>();
+        HashMap<String, String> callingMethodParameters = new HashMap<>();
 
-        infoListeners.onNewInfo("onBufferStart", keyValuePairs);
+        infoListeners.onNewInfo("onBufferStart", callingMethodParameters);
 
     }
 
     @Override
     public void onBufferComplete() {
-        HashMap<String, String> keyValuePairs = new HashMap<>();
+        HashMap<String, String> callingMethodParameters = new HashMap<>();
 
-        infoListeners.onNewInfo("onBufferStart", keyValuePairs);
+        infoListeners.onNewInfo("onBufferStart", callingMethodParameters);
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/mediaplayer/forwarder/BufferInfoForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/mediaplayer/forwarder/BufferInfoForwarder.java
@@ -1,0 +1,30 @@
+package com.novoda.noplayer.mediaplayer.forwarder;
+
+import com.novoda.noplayer.listeners.InfoListeners;
+import com.novoda.noplayer.mediaplayer.CheckBufferHeartbeatCallback;
+
+import java.util.HashMap;
+
+class BufferInfoForwarder implements CheckBufferHeartbeatCallback.BufferListener {
+
+    private final InfoListeners infoListeners;
+
+    public BufferInfoForwarder(InfoListeners infoListeners) {
+        this.infoListeners = infoListeners;
+    }
+
+    @Override
+    public void onBufferStart() {
+        HashMap<String, String> keyValuePairs = new HashMap<>();
+
+        infoListeners.onNewInfo("onBufferStart", keyValuePairs);
+
+    }
+
+    @Override
+    public void onBufferComplete() {
+        HashMap<String, String> keyValuePairs = new HashMap<>();
+
+        infoListeners.onNewInfo("onBufferStart", keyValuePairs);
+    }
+}

--- a/core/src/main/java/com/novoda/noplayer/mediaplayer/forwarder/BufferOnPreparedListener.java
+++ b/core/src/main/java/com/novoda/noplayer/mediaplayer/forwarder/BufferOnPreparedListener.java
@@ -1,0 +1,18 @@
+package com.novoda.noplayer.mediaplayer.forwarder;
+
+import android.media.MediaPlayer;
+
+import com.novoda.noplayer.listeners.BufferStateListeners;
+
+class BufferOnPreparedListener implements MediaPlayer.OnPreparedListener {
+    private final BufferStateListeners bufferStateListeners;
+
+    public BufferOnPreparedListener(BufferStateListeners bufferStateListeners) {
+        this.bufferStateListeners = bufferStateListeners;
+    }
+
+    @Override
+    public void onPrepared(MediaPlayer mp) {
+        bufferStateListeners.onBufferCompleted();
+    }
+}

--- a/core/src/main/java/com/novoda/noplayer/mediaplayer/forwarder/CompletionForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/mediaplayer/forwarder/CompletionForwarder.java
@@ -1,0 +1,18 @@
+package com.novoda.noplayer.mediaplayer.forwarder;
+
+import android.media.MediaPlayer;
+
+import com.novoda.noplayer.listeners.CompletionListeners;
+
+class CompletionForwarder implements MediaPlayer.OnCompletionListener {
+    private final CompletionListeners completionListeners;
+
+    public CompletionForwarder(CompletionListeners completionListeners) {
+        this.completionListeners = completionListeners;
+    }
+
+    @Override
+    public void onCompletion(MediaPlayer mp) {
+        completionListeners.onCompletion();
+    }
+}

--- a/core/src/main/java/com/novoda/noplayer/mediaplayer/forwarder/CompletionInfoForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/mediaplayer/forwarder/CompletionInfoForwarder.java
@@ -16,9 +16,10 @@ class CompletionInfoForwarder implements MediaPlayer.OnCompletionListener {
 
     @Override
     public void onCompletion(MediaPlayer mp) {
-        HashMap<String, String> keyValuePairs = new HashMap<>();
-        keyValuePairs.put("mp", String.valueOf(mp));
+        HashMap<String, String> callingMethodParameters = new HashMap<>();
 
-        infoListeners.onNewInfo("onCompletion", keyValuePairs);
+        callingMethodParameters.put("mp", String.valueOf(mp));
+
+        infoListeners.onNewInfo("onCompletion", callingMethodParameters);
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/mediaplayer/forwarder/CompletionInfoForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/mediaplayer/forwarder/CompletionInfoForwarder.java
@@ -1,0 +1,24 @@
+package com.novoda.noplayer.mediaplayer.forwarder;
+
+import android.media.MediaPlayer;
+
+import com.novoda.noplayer.listeners.InfoListeners;
+
+import java.util.HashMap;
+
+class CompletionInfoForwarder implements MediaPlayer.OnCompletionListener {
+
+    private final InfoListeners infoListeners;
+
+    public CompletionInfoForwarder(InfoListeners infoListeners) {
+        this.infoListeners = infoListeners;
+    }
+
+    @Override
+    public void onCompletion(MediaPlayer mp) {
+        HashMap<String, String> keyValuePairs = new HashMap<>();
+        keyValuePairs.put("mp", String.valueOf(mp));
+
+        infoListeners.onNewInfo("onCompletion", keyValuePairs);
+    }
+}

--- a/core/src/main/java/com/novoda/noplayer/mediaplayer/forwarder/ErrorForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/mediaplayer/forwarder/ErrorForwarder.java
@@ -1,0 +1,29 @@
+package com.novoda.noplayer.mediaplayer.forwarder;
+
+import android.media.MediaPlayer;
+
+import com.novoda.noplayer.Player;
+import com.novoda.noplayer.listeners.BufferStateListeners;
+import com.novoda.noplayer.listeners.ErrorListeners;
+import com.novoda.noplayer.mediaplayer.ErrorFactory;
+
+class ErrorForwarder implements MediaPlayer.OnErrorListener {
+
+    private final BufferStateListeners bufferStateListeners;
+    private final ErrorListeners errorListeners;
+    private final Player player;
+
+    public ErrorForwarder(BufferStateListeners bufferStateListeners, ErrorListeners errorListeners, Player player) {
+        this.bufferStateListeners = bufferStateListeners;
+        this.errorListeners = errorListeners;
+        this.player = player;
+    }
+
+    @Override
+    public boolean onError(MediaPlayer mp, int what, int extra) {
+        bufferStateListeners.onBufferCompleted();
+        Player.PlayerError error = ErrorFactory.createErrorFrom(what, extra);
+        errorListeners.onError(player, error);
+        return true;
+    }
+}

--- a/core/src/main/java/com/novoda/noplayer/mediaplayer/forwarder/ErrorInfoForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/mediaplayer/forwarder/ErrorInfoForwarder.java
@@ -16,12 +16,13 @@ class ErrorInfoForwarder implements MediaPlayer.OnErrorListener {
 
     @Override
     public boolean onError(MediaPlayer mp, int what, int extra) {
-        HashMap<String, String> keyValuePairs = new HashMap<>();
-        keyValuePairs.put("mp", String.valueOf(mp));
-        keyValuePairs.put("what", String.valueOf(what));
-        keyValuePairs.put("extra", String.valueOf(extra));
+        HashMap<String, String> callingMethodParameters = new HashMap<>();
 
-        infoListeners.onNewInfo("onError", keyValuePairs);
+        callingMethodParameters.put("mp", String.valueOf(mp));
+        callingMethodParameters.put("what", String.valueOf(what));
+        callingMethodParameters.put("extra", String.valueOf(extra));
+
+        infoListeners.onNewInfo("onError", callingMethodParameters);
         return false;
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/mediaplayer/forwarder/ErrorInfoForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/mediaplayer/forwarder/ErrorInfoForwarder.java
@@ -1,0 +1,27 @@
+package com.novoda.noplayer.mediaplayer.forwarder;
+
+import android.media.MediaPlayer;
+
+import com.novoda.noplayer.listeners.InfoListeners;
+
+import java.util.HashMap;
+
+class ErrorInfoForwarder implements MediaPlayer.OnErrorListener {
+
+    private final InfoListeners infoListeners;
+
+    public ErrorInfoForwarder(InfoListeners infoListeners) {
+        this.infoListeners = infoListeners;
+    }
+
+    @Override
+    public boolean onError(MediaPlayer mp, int what, int extra) {
+        HashMap<String, String> keyValuePairs = new HashMap<>();
+        keyValuePairs.put("mp", String.valueOf(mp));
+        keyValuePairs.put("what", String.valueOf(what));
+        keyValuePairs.put("extra", String.valueOf(extra));
+
+        infoListeners.onNewInfo("onError", keyValuePairs);
+        return false;
+    }
+}

--- a/core/src/main/java/com/novoda/noplayer/mediaplayer/forwarder/HeartBeatListener.java
+++ b/core/src/main/java/com/novoda/noplayer/mediaplayer/forwarder/HeartBeatListener.java
@@ -1,0 +1,29 @@
+package com.novoda.noplayer.mediaplayer.forwarder;
+
+import com.novoda.noplayer.mediaplayer.CheckBufferHeartbeatCallback;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+public class HeartBeatListener implements CheckBufferHeartbeatCallback.BufferListener {
+
+    private final List<CheckBufferHeartbeatCallback.BufferListener> listeners = new CopyOnWriteArrayList<>();
+
+    public void add(CheckBufferHeartbeatCallback.BufferListener listener) {
+        listeners.add(listener);
+    }
+
+    @Override
+    public void onBufferStart() {
+        for (CheckBufferHeartbeatCallback.BufferListener listener : listeners) {
+            listener.onBufferStart();
+        }
+    }
+
+    @Override
+    public void onBufferComplete() {
+        for (CheckBufferHeartbeatCallback.BufferListener listener : listeners) {
+            listener.onBufferComplete();
+        }
+    }
+}

--- a/core/src/main/java/com/novoda/noplayer/mediaplayer/forwarder/MediaPlayerCompletionListener.java
+++ b/core/src/main/java/com/novoda/noplayer/mediaplayer/forwarder/MediaPlayerCompletionListener.java
@@ -1,0 +1,22 @@
+package com.novoda.noplayer.mediaplayer.forwarder;
+
+import android.media.MediaPlayer;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+public class MediaPlayerCompletionListener implements MediaPlayer.OnCompletionListener {
+
+    private final List<MediaPlayer.OnCompletionListener> listeners = new CopyOnWriteArrayList<>();
+
+    public void add(MediaPlayer.OnCompletionListener listener) {
+        listeners.add(listener);
+    }
+
+    @Override
+    public void onCompletion(MediaPlayer mp) {
+        for (MediaPlayer.OnCompletionListener listener : listeners) {
+            listener.onCompletion(mp);
+        }
+    }
+}

--- a/core/src/main/java/com/novoda/noplayer/mediaplayer/forwarder/MediaPlayerErrorListener.java
+++ b/core/src/main/java/com/novoda/noplayer/mediaplayer/forwarder/MediaPlayerErrorListener.java
@@ -1,0 +1,24 @@
+package com.novoda.noplayer.mediaplayer.forwarder;
+
+import android.media.MediaPlayer;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+public class MediaPlayerErrorListener implements MediaPlayer.OnErrorListener {
+
+    private final List<MediaPlayer.OnErrorListener> listeners = new CopyOnWriteArrayList<>();
+
+    public void add(MediaPlayer.OnErrorListener listener) {
+        listeners.add(listener);
+    }
+
+    @Override
+    public boolean onError(MediaPlayer mp, int what, int extra) {
+        boolean handled = false;
+        for (MediaPlayer.OnErrorListener listener : listeners) {
+            handled = listener.onError(mp, what, extra) || handled;
+        }
+        return handled;
+    }
+}

--- a/core/src/main/java/com/novoda/noplayer/mediaplayer/forwarder/MediaPlayerForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/mediaplayer/forwarder/MediaPlayerForwarder.java
@@ -1,0 +1,76 @@
+package com.novoda.noplayer.mediaplayer.forwarder;
+
+import android.media.MediaPlayer;
+
+import com.novoda.noplayer.Player;
+import com.novoda.noplayer.PlayerState;
+import com.novoda.noplayer.listeners.BufferStateListeners;
+import com.novoda.noplayer.listeners.CompletionListeners;
+import com.novoda.noplayer.listeners.ErrorListeners;
+import com.novoda.noplayer.listeners.InfoListeners;
+import com.novoda.noplayer.listeners.PreparedListeners;
+import com.novoda.noplayer.listeners.VideoSizeChangedListeners;
+import com.novoda.noplayer.mediaplayer.CheckBufferHeartbeatCallback;
+
+public class MediaPlayerForwarder {
+
+    private final MediaPlayerPreparedListener preparedListener;
+    private final HeartBeatListener heartBeatListener;
+    private final MediaPlayerCompletionListener completionListener;
+    private final MediaPlayerErrorListener errorListener;
+    private final VideoSizeChangedListener videoSizeChangedListener;
+
+    public MediaPlayerForwarder() {
+        preparedListener = new MediaPlayerPreparedListener();
+        heartBeatListener = new HeartBeatListener();
+        completionListener = new MediaPlayerCompletionListener();
+        errorListener = new MediaPlayerErrorListener();
+        videoSizeChangedListener = new VideoSizeChangedListener();
+    }
+
+    public void bind(PreparedListeners preparedListeners, final PlayerState playerState) {
+        preparedListener.add(new OnPreparedForwarder(preparedListeners, playerState));
+    }
+
+    public void bind(BufferStateListeners bufferStateListeners, ErrorListeners errorListeners, Player player) {
+        preparedListener.add(new BufferOnPreparedListener(bufferStateListeners));
+        heartBeatListener.add(new BufferHeartbeatListener(bufferStateListeners));
+        errorListener.add(new ErrorForwarder(bufferStateListeners, errorListeners, player));
+    }
+
+    public void bind(CompletionListeners completionListeners) {
+        completionListener.add(new CompletionForwarder(completionListeners));
+    }
+
+    public void bind(VideoSizeChangedListeners videoSizeChangedListeners) {
+        videoSizeChangedListener.add(new VideoSizeChangedForwarder(videoSizeChangedListeners));
+    }
+
+    public void bind(final InfoListeners infoListeners) {
+        preparedListener.add(new OnPreparedInfoForwarder(infoListeners));
+        heartBeatListener.add(new BufferInfoForwarder(infoListeners));
+        completionListener.add(new CompletionInfoForwarder(infoListeners));
+        errorListener.add(new ErrorInfoForwarder(infoListeners));
+        videoSizeChangedListener.add(new VideoSizeChangedInfoForwarder(infoListeners));
+    }
+
+    public MediaPlayer.OnPreparedListener onPreparedListener() {
+        return preparedListener;
+    }
+
+    public CheckBufferHeartbeatCallback.BufferListener onHeartbeatListener() {
+        return heartBeatListener;
+    }
+
+    public MediaPlayer.OnCompletionListener onCompletionListener() {
+        return completionListener;
+    }
+
+    public MediaPlayer.OnErrorListener onErrorListener() {
+        return errorListener;
+    }
+
+    public MediaPlayer.OnVideoSizeChangedListener onSizeChangedListener() {
+        return videoSizeChangedListener;
+    }
+}

--- a/core/src/main/java/com/novoda/noplayer/mediaplayer/forwarder/MediaPlayerPreparedListener.java
+++ b/core/src/main/java/com/novoda/noplayer/mediaplayer/forwarder/MediaPlayerPreparedListener.java
@@ -1,0 +1,22 @@
+package com.novoda.noplayer.mediaplayer.forwarder;
+
+import android.media.MediaPlayer;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+public class MediaPlayerPreparedListener implements MediaPlayer.OnPreparedListener {
+
+    private final List<MediaPlayer.OnPreparedListener> listeners = new CopyOnWriteArrayList<>();
+
+    public void add(MediaPlayer.OnPreparedListener listener) {
+        listeners.add(listener);
+    }
+
+    @Override
+    public void onPrepared(MediaPlayer mp) {
+        for (MediaPlayer.OnPreparedListener listener : listeners) {
+            listener.onPrepared(mp);
+        }
+    }
+}

--- a/core/src/main/java/com/novoda/noplayer/mediaplayer/forwarder/OnPreparedForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/mediaplayer/forwarder/OnPreparedForwarder.java
@@ -1,0 +1,21 @@
+package com.novoda.noplayer.mediaplayer.forwarder;
+
+import android.media.MediaPlayer;
+
+import com.novoda.noplayer.PlayerState;
+import com.novoda.noplayer.listeners.PreparedListeners;
+
+class OnPreparedForwarder implements MediaPlayer.OnPreparedListener {
+    private final PreparedListeners preparedListeners;
+    private final PlayerState playerState;
+
+    public OnPreparedForwarder(PreparedListeners preparedListeners, PlayerState playerState) {
+        this.preparedListeners = preparedListeners;
+        this.playerState = playerState;
+    }
+
+    @Override
+    public void onPrepared(MediaPlayer mp) {
+        preparedListeners.onPrepared(playerState);
+    }
+}

--- a/core/src/main/java/com/novoda/noplayer/mediaplayer/forwarder/OnPreparedInfoForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/mediaplayer/forwarder/OnPreparedInfoForwarder.java
@@ -16,9 +16,10 @@ class OnPreparedInfoForwarder implements MediaPlayer.OnPreparedListener {
 
     @Override
     public void onPrepared(MediaPlayer mp) {
-        HashMap<String, String> keyValuePairs = new HashMap<>();
-        keyValuePairs.put("mp", String.valueOf(mp));
+        HashMap<String, String> callingMethodParameters = new HashMap<>();
 
-        infoListeners.onNewInfo("onPrepared", keyValuePairs);
+        callingMethodParameters.put("mp", String.valueOf(mp));
+
+        infoListeners.onNewInfo("onPrepared", callingMethodParameters);
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/mediaplayer/forwarder/OnPreparedInfoForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/mediaplayer/forwarder/OnPreparedInfoForwarder.java
@@ -1,0 +1,24 @@
+package com.novoda.noplayer.mediaplayer.forwarder;
+
+import android.media.MediaPlayer;
+
+import com.novoda.noplayer.listeners.InfoListeners;
+
+import java.util.HashMap;
+
+class OnPreparedInfoForwarder implements MediaPlayer.OnPreparedListener {
+
+    private final InfoListeners infoListeners;
+
+    public OnPreparedInfoForwarder(InfoListeners infoListeners) {
+        this.infoListeners = infoListeners;
+    }
+
+    @Override
+    public void onPrepared(MediaPlayer mp) {
+        HashMap<String, String> keyValuePairs = new HashMap<>();
+        keyValuePairs.put("mp", String.valueOf(mp));
+
+        infoListeners.onNewInfo("onPrepared", keyValuePairs);
+    }
+}

--- a/core/src/main/java/com/novoda/noplayer/mediaplayer/forwarder/VideoSizeChangedForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/mediaplayer/forwarder/VideoSizeChangedForwarder.java
@@ -1,4 +1,4 @@
-package com.novoda.noplayer.mediaplayer;
+package com.novoda.noplayer.mediaplayer.forwarder;
 
 import android.media.MediaPlayer;
 

--- a/core/src/main/java/com/novoda/noplayer/mediaplayer/forwarder/VideoSizeChangedInfoForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/mediaplayer/forwarder/VideoSizeChangedInfoForwarder.java
@@ -16,11 +16,12 @@ class VideoSizeChangedInfoForwarder implements MediaPlayer.OnVideoSizeChangedLis
 
     @Override
     public void onVideoSizeChanged(MediaPlayer mp, int width, int height) {
-        HashMap<String, String> keyValuePairs = new HashMap<>();
-        keyValuePairs.put("mp", String.valueOf(mp));
-        keyValuePairs.put("width", String.valueOf(width));
-        keyValuePairs.put("height", String.valueOf(height));
+        HashMap<String, String> callingMethodParameters = new HashMap<>();
 
-        infoListeners.onNewInfo("onVideoSizeChanged", keyValuePairs);
+        callingMethodParameters.put("mp", String.valueOf(mp));
+        callingMethodParameters.put("width", String.valueOf(width));
+        callingMethodParameters.put("height", String.valueOf(height));
+
+        infoListeners.onNewInfo("onVideoSizeChanged", callingMethodParameters);
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/mediaplayer/forwarder/VideoSizeChangedInfoForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/mediaplayer/forwarder/VideoSizeChangedInfoForwarder.java
@@ -1,0 +1,26 @@
+package com.novoda.noplayer.mediaplayer.forwarder;
+
+import android.media.MediaPlayer;
+
+import com.novoda.noplayer.listeners.InfoListeners;
+
+import java.util.HashMap;
+
+class VideoSizeChangedInfoForwarder implements MediaPlayer.OnVideoSizeChangedListener {
+
+    private final InfoListeners infoListeners;
+
+    public VideoSizeChangedInfoForwarder(InfoListeners infoListeners) {
+        this.infoListeners = infoListeners;
+    }
+
+    @Override
+    public void onVideoSizeChanged(MediaPlayer mp, int width, int height) {
+        HashMap<String, String> keyValuePairs = new HashMap<>();
+        keyValuePairs.put("mp", String.valueOf(mp));
+        keyValuePairs.put("width", String.valueOf(width));
+        keyValuePairs.put("height", String.valueOf(height));
+
+        infoListeners.onNewInfo("onVideoSizeChanged", keyValuePairs);
+    }
+}

--- a/core/src/main/java/com/novoda/noplayer/mediaplayer/forwarder/VideoSizeChangedListener.java
+++ b/core/src/main/java/com/novoda/noplayer/mediaplayer/forwarder/VideoSizeChangedListener.java
@@ -1,0 +1,22 @@
+package com.novoda.noplayer.mediaplayer.forwarder;
+
+import android.media.MediaPlayer;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+public class VideoSizeChangedListener implements MediaPlayer.OnVideoSizeChangedListener {
+
+    private final List<MediaPlayer.OnVideoSizeChangedListener> listeners = new CopyOnWriteArrayList<>();
+
+    public void add(MediaPlayer.OnVideoSizeChangedListener listener) {
+        listeners.add(listener);
+    }
+
+    @Override
+    public void onVideoSizeChanged(MediaPlayer mp, int width, int height) {
+        for (MediaPlayer.OnVideoSizeChangedListener listener : listeners) {
+            listener.onVideoSizeChanged(mp, width, height);
+        }
+    }
+}

--- a/core/src/main/java/com/novoda/noplayer/player/PlayerFactory.java
+++ b/core/src/main/java/com/novoda/noplayer/player/PlayerFactory.java
@@ -7,6 +7,7 @@ import com.novoda.noplayer.drm.DrmHandler;
 import com.novoda.noplayer.exoplayer.ExoPlayerTwoImpl;
 import com.novoda.noplayer.mediaplayer.AndroidMediaPlayerFacade;
 import com.novoda.noplayer.mediaplayer.AndroidMediaPlayerImpl;
+import com.novoda.noplayer.mediaplayer.forwarder.MediaPlayerForwarder;
 
 public class PlayerFactory {
 
@@ -44,7 +45,7 @@ public class PlayerFactory {
 
     private Player createMediaPlayer() {
         AndroidMediaPlayerFacade androidMediaPlayer = new AndroidMediaPlayerFacade(context);
-        return new AndroidMediaPlayerImpl(androidMediaPlayer);
+        return new AndroidMediaPlayerImpl(androidMediaPlayer, new MediaPlayerForwarder());
     }
 
     static class UnableToCreatePlayerException extends RuntimeException {

--- a/core/src/main/java/com/novoda/noplayer/player/PlayerFactory.java
+++ b/core/src/main/java/com/novoda/noplayer/player/PlayerFactory.java
@@ -5,9 +5,7 @@ import android.content.Context;
 import com.novoda.noplayer.Player;
 import com.novoda.noplayer.drm.DrmHandler;
 import com.novoda.noplayer.exoplayer.ExoPlayerTwoImpl;
-import com.novoda.noplayer.mediaplayer.AndroidMediaPlayerFacade;
 import com.novoda.noplayer.mediaplayer.AndroidMediaPlayerImpl;
-import com.novoda.noplayer.mediaplayer.forwarder.MediaPlayerForwarder;
 
 public class PlayerFactory {
 
@@ -44,11 +42,10 @@ public class PlayerFactory {
     }
 
     private Player createMediaPlayer() {
-        AndroidMediaPlayerFacade androidMediaPlayer = new AndroidMediaPlayerFacade(context);
-        return new AndroidMediaPlayerImpl(androidMediaPlayer, new MediaPlayerForwarder());
+        return AndroidMediaPlayerImpl.newInstance(context);
     }
 
-    static class UnableToCreatePlayerException extends RuntimeException {
+    private static class UnableToCreatePlayerException extends RuntimeException {
 
         static UnableToCreatePlayerException contentNotSupported() {
             return new UnableToCreatePlayerException("No player available to handle content");

--- a/demo/src/main/java/com/novoda/demo/MainActivity.java
+++ b/demo/src/main/java/com/novoda/demo/MainActivity.java
@@ -30,7 +30,7 @@ public class MainActivity extends Activity {
     @Override
     protected void onStart() {
         super.onStart();
-        player = new PlayerFactory(this, PrioritisedPlayers.prioritiseExoPlayer()).create();
+        player = new PlayerFactory(this, PrioritisedPlayers.prioritiseMediaPlayer()).create();
         player.addPreparedListener(new Player.PreparedListener() {
             @Override
             public void onPrepared(PlayerState playerState) {


### PR DESCRIPTION
## Problem
- `ExoPlayer` and `MediaPlayer` handle listeners in different ways.
- The `MediaPlayerFacade` is quite complex and is exposed as a public class.

## Solution
As per #23 we want to have the same forwarding logic in `MediaPlayer` to enforce consistency across both parts of `no-player`.

-  Reduce the scope of `MediaPlayerFacade` to package-protected, it shouldn't be used by clients. 

### Test(s) added 
No tests yet, we want to start adding these soon!

### Screenshots
No UI changes.

### Paired with 
@Dorvaryn and @jackSzm 
