### PR TITLE
Demo audio track selection

### DIFF
--- a/demo/src/main/java/com/novoda/demo/MainActivity.java
+++ b/demo/src/main/java/com/novoda/demo/MainActivity.java
@@ -1,24 +1,34 @@
 package com.novoda.demo;
 
 import android.app.Activity;
+import android.app.AlertDialog;
+import android.content.DialogInterface;
 import android.net.Uri;
 import android.os.Bundle;
+import android.view.View;
+import android.widget.ArrayAdapter;
 
 import com.novoda.noplayer.ContentType;
 import com.novoda.noplayer.Player;
+import com.novoda.noplayer.PlayerAudioTrack;
 import com.novoda.noplayer.PlayerState;
 import com.novoda.noplayer.PlayerView;
 import com.novoda.noplayer.player.PlayerFactory;
 import com.novoda.noplayer.player.PrioritisedPlayers;
+import com.novoda.notils.caster.Views;
 import com.novoda.notils.logger.simple.Log;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class MainActivity extends Activity {
 
     private static final String URI_VIDEO_MP4 = "http://yt-dash-mse-test.commondatastorage.googleapis.com/media/car-20120827-85.mp4";
-    private static final String URI_VIDEO_MPD = "https://storage.googleapis.com/content-samples/multi-audio/multi-audio.mpd";
+    private static final String URI_VIDEO_MPD = "https://storage.googleapis.com/content-samples/multi-audio/manifest.mpd";
 
     private Player player;
     private PlayerView playerView;
+    private View audioSelectionButton;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -26,6 +36,7 @@ public class MainActivity extends Activity {
         Log.setShowLogs(true);
         setContentView(R.layout.activity_main);
         playerView = (PlayerView) findViewById(R.id.player_view);
+        audioSelectionButton = Views.findById(this, R.id.button_audio_selection);
     }
 
     @Override
@@ -39,15 +50,51 @@ public class MainActivity extends Activity {
                 player.play();
             }
         });
+
         player.attach(playerView);
+
+        audioSelectionButton.setOnClickListener(showAudioSelectionDialog);
 
         Uri uri = Uri.parse(URI_VIDEO_MPD);
         player.loadVideo(uri, ContentType.DASH);
     }
 
+    private final View.OnClickListener showAudioSelectionDialog = new View.OnClickListener() {
+
+        @Override
+        public void onClick(View v) {
+            showAudioSelectionDialog();
+        }
+
+        private void showAudioSelectionDialog() {
+            final List<PlayerAudioTrack> audioTracks = player.getAudioTracks();
+            ArrayAdapter<String> adapter = new ArrayAdapter<>(MainActivity.this, R.layout.list_item);
+            adapter.addAll(mapAudioTrackToLabel(audioTracks));
+            AlertDialog audioSelectionDialog = new AlertDialog.Builder(MainActivity.this)
+                    .setTitle("Select audio track")
+                    .setAdapter(adapter, new DialogInterface.OnClickListener() {
+                        @Override
+                        public void onClick(DialogInterface dialog, int position) {
+                            PlayerAudioTrack audioTrack = audioTracks.get(position);
+                            player.selectAudioTrack(audioTrack);
+                        }
+                    }).create();
+            audioSelectionDialog.show();
+        }
+
+        private List<String> mapAudioTrackToLabel(List<PlayerAudioTrack> audioTracks) {
+            List<String> labels = new ArrayList<>();
+            for (PlayerAudioTrack audioTrack : audioTracks) {
+                labels.add("Group: " + audioTrack.groupIndex() + " Format: " + audioTrack.formatIndex());
+            }
+            return labels;
+        }
+    };
+
     @Override
     protected void onStop() {
         super.onStop();
         player.release();
+        audioSelectionButton.setOnClickListener(null);
     }
 }

--- a/demo/src/main/res/layout/activity_main.xml
+++ b/demo/src/main/res/layout/activity_main.xml
@@ -1,10 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <merge xmlns:android="http://schemas.android.com/apk/res/android">
 
-  <com.novoda.noplayer.NoPlayerView
-    android:id="@+id/player_view"
-    android:layout_width="wrap_content"
+  <LinearLayout
+    android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_gravity="center" />
+    android:orientation="vertical">
+
+    <LinearLayout
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:orientation="horizontal">
+
+      <Button
+        android:id="@+id/button_audio_selection"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Audio" />
+
+    </LinearLayout>
+
+    <com.novoda.noplayer.NoPlayerView
+      android:id="@+id/player_view"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_gravity="center" />
+
+  </LinearLayout>
 
 </merge>

--- a/demo/src/main/res/layout/activity_main.xml
+++ b/demo/src/main/res/layout/activity_main.xml
@@ -3,7 +3,7 @@
 
   <LinearLayout
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
+    android:layout_height="match_parent"
     android:orientation="vertical">
 
     <LinearLayout

--- a/demo/src/main/res/layout/list_item.xml
+++ b/demo/src/main/res/layout/list_item.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+  android:id="@android:id/text1"
+  android:layout_width="match_parent"
+  android:layout_height="match_parent"
+  android:background="@android:color/white"
+  android:textColor="@android:color/black"
+  android:textSize="20sp"
+  android:padding="8dp" />


### PR DESCRIPTION
## Problem

The player supports audio track selecting but it's not present in the demo.

## Solution

To add the ability to switch audio tracks to the demo.

### Test(s) added 

nil tests around the demo code

### Screenshots

| Before | After |
| ------ | ----- |
|![device-2017-06-01-162946](https://cloud.githubusercontent.com/assets/1848238/26687416/8b133678-46e7-11e7-805b-53971e21f8ee.png)|![device-2017-06-01-162642](https://cloud.githubusercontent.com/assets/1848238/26687385/76ffb76a-46e7-11e7-81b1-d306693db46a.png)|

### Paired with 
@Dorvaryn 