### PR TITLE
Exoplayer2 - Missing Facade Tests

### DIFF
--- a/core/src/main/java/com/novoda/noplayer/mediaplayer/AndroidMediaPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/mediaplayer/AndroidMediaPlayerFacade.java
@@ -33,7 +33,7 @@ class AndroidMediaPlayerFacade {
     private MediaPlayer.OnPreparedListener onPreparedListener;
     private int currentBufferPercentage;
     private MediaPlayer.OnErrorListener onErrorListener;
-    private MediaPlayer.OnVideoSizeChangedListener onSizeChangedListener;
+    private MediaPlayer.OnVideoSizeChangedListener onVideoSizeChangedListener;
 
     private SurfaceHolderRequester surfaceHolderRequester;
     private MediaPlayerCreator mediaPlayerCreator;
@@ -113,10 +113,10 @@ class AndroidMediaPlayerFacade {
     private final MediaPlayer.OnVideoSizeChangedListener internalSizeChangedListener = new MediaPlayer.OnVideoSizeChangedListener() {
         @Override
         public void onVideoSizeChanged(MediaPlayer mp, int width, int height) {
-            if (onSizeChangedListener == null) {
+            if (onVideoSizeChangedListener == null) {
                 throw new IllegalStateException("Should bind a OnVideoSizeChangedListener. Cannot forward events.");
             }
-            onSizeChangedListener.onVideoSizeChanged(mp, width, height);
+            onVideoSizeChangedListener.onVideoSizeChanged(mp, width, height);
         }
     };
 
@@ -162,20 +162,14 @@ class AndroidMediaPlayerFacade {
         }
     };
 
-    void setOnPreparedListener(MediaPlayer.OnPreparedListener listener) {
-        onPreparedListener = listener;
-    }
-
-    void setOnCompletionListener(MediaPlayer.OnCompletionListener listener) {
-        onCompletionListener = listener;
-    }
-
-    void setOnErrorListener(MediaPlayer.OnErrorListener listener) {
-        onErrorListener = listener;
-    }
-
-    void setOnSizeChangedListener(MediaPlayer.OnVideoSizeChangedListener listener) {
-        onSizeChangedListener = listener;
+    void setListeners(MediaPlayer.OnPreparedListener onPreparedListener,
+                      MediaPlayer.OnCompletionListener onCompletionListener,
+                      MediaPlayer.OnErrorListener onErrorListener,
+                      MediaPlayer.OnVideoSizeChangedListener onVideoSizeChangedListener) {
+        this.onPreparedListener = onPreparedListener;
+        this.onCompletionListener = onCompletionListener;
+        this.onErrorListener = onErrorListener;
+        this.onVideoSizeChangedListener = onVideoSizeChangedListener;
     }
 
     void release() {

--- a/core/src/main/java/com/novoda/noplayer/mediaplayer/AndroidMediaPlayerImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/mediaplayer/AndroidMediaPlayerImpl.java
@@ -86,12 +86,7 @@ public final class AndroidMediaPlayerImpl implements Player {
         forwarder.bind(listenersHolder.getVideoSizeChangedListeners());
         forwarder.bind(listenersHolder.getInfoListeners());
 
-        mediaPlayer.setListeners(
-                forwarder.onPreparedListener(),
-                forwarder.onCompletionListener(),
-                forwarder.onErrorListener(),
-                forwarder.onSizeChangedListener()
-        );
+        mediaPlayer.setForwarder(forwarder);
 
         bufferHeartbeatCallback.bind(forwarder.onHeartbeatListener());
         listenersHolder.addHeartbeatCallback(bufferHeartbeatCallback);

--- a/core/src/main/java/com/novoda/noplayer/mediaplayer/AndroidMediaPlayerImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/mediaplayer/AndroidMediaPlayerImpl.java
@@ -86,10 +86,12 @@ public final class AndroidMediaPlayerImpl implements Player {
         forwarder.bind(listenersHolder.getVideoSizeChangedListeners());
         forwarder.bind(listenersHolder.getInfoListeners());
 
-        mediaPlayer.setOnPreparedListener(forwarder.onPreparedListener());
-        mediaPlayer.setOnCompletionListener(forwarder.onCompletionListener());
-        mediaPlayer.setOnErrorListener(forwarder.onErrorListener());
-        mediaPlayer.setOnSizeChangedListener(forwarder.onSizeChangedListener());
+        mediaPlayer.setListeners(
+                forwarder.onPreparedListener(),
+                forwarder.onCompletionListener(),
+                forwarder.onErrorListener(),
+                forwarder.onSizeChangedListener()
+        );
 
         bufferHeartbeatCallback.bind(forwarder.onHeartbeatListener());
         listenersHolder.addHeartbeatCallback(bufferHeartbeatCallback);

--- a/core/src/main/java/com/novoda/noplayer/mediaplayer/MediaPlayerCreator.java
+++ b/core/src/main/java/com/novoda/noplayer/mediaplayer/MediaPlayerCreator.java
@@ -1,0 +1,9 @@
+package com.novoda.noplayer.mediaplayer;
+
+import android.media.MediaPlayer;
+
+class MediaPlayerCreator {
+    MediaPlayer createMediaPlayer() {
+        return new MediaPlayer();
+    }
+}

--- a/core/src/test/java/com/novoda/noplayer/mediaplayer/AndroidMediaPlayerFacadeTest.java
+++ b/core/src/test/java/com/novoda/noplayer/mediaplayer/AndroidMediaPlayerFacadeTest.java
@@ -107,10 +107,7 @@ public class AndroidMediaPlayerFacadeTest {
         }).when(surfaceHolderRequester).requestSurfaceHolder(any(SurfaceHolderRequester.Callback.class));
 
         facade.setSurfaceHolderRequester(surfaceHolderRequester);
-        facade.setOnPreparedListener(preparedListener);
-        facade.setOnSizeChangedListener(videoSizeChangedListener);
-        facade.setOnCompletionListener(completionListener);
-        facade.setOnErrorListener(errorListener);
+        facade.setListeners(preparedListener, completionListener, errorListener, videoSizeChangedListener);
     }
 
     @Test
@@ -207,7 +204,7 @@ public class AndroidMediaPlayerFacadeTest {
     @Test
     public void givenNoBoundPreparedListener_andMediaPlayerIsPrepared_whenPrepared_thenThrowsIllegalStateException() {
         thrown.expect(ExceptionMatcher.matches("Should bind a OnPreparedListener. Cannot forward events.", IllegalStateException.class));
-        facade.setOnPreparedListener(null);
+        facade.setListeners(null, completionListener, errorListener, videoSizeChangedListener);
         givenMediaPlayerIsPrepared();
     }
 
@@ -223,7 +220,7 @@ public class AndroidMediaPlayerFacadeTest {
     @Test
     public void givenNoBoundVideoSizeChangedListener_andMediaPlayerIsPrepared_whenVideoSizeChanges_thenThrowsIllegalStateException() {
         thrown.expect(ExceptionMatcher.matches("Should bind a OnVideoSizeChangedListener. Cannot forward events.", IllegalStateException.class));
-        facade.setOnSizeChangedListener(null);
+        facade.setListeners(preparedListener, completionListener, errorListener, null);
         givenMediaPlayerIsPrepared();
 
         whenVideoSizeChanges();
@@ -241,7 +238,7 @@ public class AndroidMediaPlayerFacadeTest {
     @Test
     public void givenNoBoundCompletionListener_andMediaPlayerIsPrepared_whenCompleted_thenThrowsIllegalStateException() {
         thrown.expect(ExceptionMatcher.matches("Should bind a OnCompletionListener. Cannot forward events.", IllegalStateException.class));
-        facade.setOnCompletionListener(null);
+        facade.setListeners(preparedListener, null, errorListener, videoSizeChangedListener);
         givenMediaPlayerIsPrepared();
 
         whenCompleted();
@@ -259,7 +256,7 @@ public class AndroidMediaPlayerFacadeTest {
     @Test
     public void givenNoBoundErrorListener_andMediaPlayerIsPrepared_whenErroring_thenThrowsIllegalStateException() {
         thrown.expect(ExceptionMatcher.matches("Should bind a OnErrorListener. Cannot forward events.", IllegalStateException.class));
-        facade.setOnErrorListener(null);
+        facade.setListeners(preparedListener, completionListener, null, videoSizeChangedListener);
         givenMediaPlayerIsPrepared();
 
         whenErroring();

--- a/core/src/test/java/com/novoda/noplayer/mediaplayer/AndroidMediaPlayerFacadeTest.java
+++ b/core/src/test/java/com/novoda/noplayer/mediaplayer/AndroidMediaPlayerFacadeTest.java
@@ -15,9 +15,9 @@ import java.util.List;
 import java.util.Map;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
@@ -30,11 +30,7 @@ import static org.fest.assertions.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 public class AndroidMediaPlayerFacadeTest {
 
@@ -62,6 +58,8 @@ public class AndroidMediaPlayerFacadeTest {
 
     @Rule
     public MockitoRule mockitoRule = MockitoJUnit.rule();
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
 
     @Mock
     private Context context;
@@ -122,10 +120,11 @@ public class AndroidMediaPlayerFacadeTest {
         facade.setOnErrorListener(errorListener);
     }
 
-    @Ignore("We should forward to listeners / make logs testable / throw exception.")
     @Test
-    public void givenNoBoundSurfaceHolderRequester_whenPreparing_thenLogsNotAttachedWarning() {
-
+    public void givenNoBoundSurfaceHolderRequester_whenPreparing_thenThrowsIllegalArgumentException() {
+        thrown.expect(ExceptionMatcher.matches("Must set a SurfaceHolderRequester before preparing video", IllegalStateException.class));
+        facade.setSurfaceHolderRequester(null);
+        givenMediaPlayerIsPrepared();
     }
 
     @Test
@@ -187,10 +186,19 @@ public class AndroidMediaPlayerFacadeTest {
         verify(mediaPlayer).prepareAsync();
     }
 
-    @Ignore("We should forward to listeners / make logs testable / throw exception.")
     @Test
-    public void givenException_whenPreparing_thenLogsCreationError() {
+    public void givenExceptionPreparingMediaPlayer_whenPreparingMediaPlayer_thenForwardsOnError() {
+        doAnswer(new Answer<Void>() {
+            @Override
+            public Void answer(InvocationOnMock invocation) throws Throwable {
+                throw new IllegalStateException("cannot prepare async");
+            }
+        }).when(mediaPlayer).prepareAsync();
 
+        givenMediaPlayerIsPrepared();
+        whenErroring();
+
+        verify(errorListener).onError(mediaPlayer, ANY_ERROR_WHAT, ANY_ERROR_EXTRA);
     }
 
     @Test
@@ -203,61 +211,65 @@ public class AndroidMediaPlayerFacadeTest {
         verify(preparedListener).onPrepared(mediaPlayer);
     }
 
-    @Ignore("Should we throw when a listener is not attached?")
     @Test
-    public void givenNoBoundPreparedListener_andMediaPlayerIsPrepared_whenPrepared_thenDoesNotForwardOnPrepared() {
-
+    public void givenNoBoundPreparedListener_andMediaPlayerIsPrepared_whenPrepared_thenThrowsIllegalStateException() {
+        thrown.expect(ExceptionMatcher.matches("Should bind a OnPreparedListener. Cannot forward events.", IllegalStateException.class));
+        facade.setOnPreparedListener(null);
+        givenMediaPlayerIsPrepared();
     }
 
     @Test
     public void givenBoundVideoSizeChangedListener_andMediaPlayerOnPrepared_whenVideoSizeChanges_thenForwardsSizeChanges() {
         givenMediaPlayerIsPrepared();
 
-        ArgumentCaptor<MediaPlayer.OnVideoSizeChangedListener> argumentCaptor = ArgumentCaptor.forClass(MediaPlayer.OnVideoSizeChangedListener.class);
-        verify(mediaPlayer).setOnVideoSizeChangedListener(argumentCaptor.capture());
-        argumentCaptor.getValue().onVideoSizeChanged(mediaPlayer, ANY_WIDTH, ANY_HEIGHT);
+        whenVideoSizeChanges();
 
         verify(videoSizeChangedListener).onVideoSizeChanged(eq(mediaPlayer), eq(ANY_WIDTH), eq(ANY_HEIGHT));
     }
 
-    @Ignore("Should we throw when a listener is not attached?")
     @Test
-    public void givenNoBoundVideoSizeChangedListener_andMediaPlayerIsPrepared_whenVideoSizeChanged_thenDoesNotForwardOnSizeChanges() {
+    public void givenNoBoundVideoSizeChangedListener_andMediaPlayerIsPrepared_whenVideoSizeChanges_thenThrowsIllegalStateException() {
+        thrown.expect(ExceptionMatcher.matches("Should bind a OnVideoSizeChangedListener. Cannot forward events.", IllegalStateException.class));
+        facade.setOnSizeChangedListener(null);
+        givenMediaPlayerIsPrepared();
 
+        whenVideoSizeChanges();
     }
 
     @Test
     public void givenBoundCompletionListener_andMediaPlayerIsPrepared_whenCompleted_thenForwardsCompleted() {
         givenMediaPlayerIsPrepared();
 
-        ArgumentCaptor<MediaPlayer.OnCompletionListener> argumentCaptor = ArgumentCaptor.forClass(MediaPlayer.OnCompletionListener.class);
-        verify(mediaPlayer).setOnCompletionListener(argumentCaptor.capture());
-        argumentCaptor.getValue().onCompletion(mediaPlayer);
+        whenCompleted();
 
         verify(completionListener).onCompletion(mediaPlayer);
     }
 
-    @Ignore("Should we throw when a listener is not attached?")
     @Test
-    public void givenNoBoundCompletionListener_andMediaPlayerIsPrepared_whenCompleted_thenDoesNotForwardCompleted() {
+    public void givenNoBoundCompletionListener_andMediaPlayerIsPrepared_whenCompleted_thenThrowsIllegalStateException() {
+        thrown.expect(ExceptionMatcher.matches("Should bind a OnCompletionListener. Cannot forward events.", IllegalStateException.class));
+        facade.setOnCompletionListener(null);
+        givenMediaPlayerIsPrepared();
 
+        whenCompleted();
     }
 
     @Test
     public void givenBoundErrorListener_andMediaPlayerIsPrepared_whenErroring_thenForwardsError() {
         givenMediaPlayerIsPrepared();
 
-        ArgumentCaptor<MediaPlayer.OnErrorListener> argumentCaptor = ArgumentCaptor.forClass(MediaPlayer.OnErrorListener.class);
-        verify(mediaPlayer).setOnErrorListener(argumentCaptor.capture());
-        argumentCaptor.getValue().onError(mediaPlayer, ANY_ERROR_WHAT, ANY_ERROR_EXTRA);
+        whenErroring();
 
         verify(errorListener).onError(mediaPlayer, ANY_ERROR_WHAT, ANY_ERROR_EXTRA);
     }
 
-    @Ignore("Should we throw when a listener is not attached?")
     @Test
-    public void givenNoBoundErrorListener_andMediaPlayerIsPrepared_whenErroring_thenDoesNotForwardError() {
+    public void givenNoBoundErrorListener_andMediaPlayerIsPrepared_whenErroring_thenThrowsIllegalStateException() {
+        thrown.expect(ExceptionMatcher.matches("Should bind a OnErrorListener. Cannot forward events.", IllegalStateException.class));
+        facade.setOnErrorListener(null);
+        givenMediaPlayerIsPrepared();
 
+        whenErroring();
     }
 
     @Test
@@ -282,10 +294,13 @@ public class AndroidMediaPlayerFacadeTest {
         verify(mediaPlayer).release();
     }
 
-    @Ignore("We should forward to listeners / make logs testable / throw exception.")
     @Test
-    public void givenNoBoundSurfaceHolderRequester_whenStarting_thenLogsNotAttachedWarning() {
+    public void givenNoBoundSurfaceHolderRequester_whenStarting_thenThrowsIllegalStateException() {
+        thrown.expect(ExceptionMatcher.matches("Must set a SurfaceHolderRequester before preparing video", IllegalStateException.class));
+        facade.setSurfaceHolderRequester(null);
+        givenMediaPlayerIsPrepared();
 
+        facade.start();
     }
 
     @Test
@@ -477,5 +492,23 @@ public class AndroidMediaPlayerFacadeTest {
         ArgumentCaptor<MediaPlayer.OnPreparedListener> argumentCaptor = ArgumentCaptor.forClass(MediaPlayer.OnPreparedListener.class);
         verify(mediaPlayer).setOnPreparedListener(argumentCaptor.capture());
         argumentCaptor.getValue().onPrepared(mediaPlayer);
+    }
+
+    private void whenVideoSizeChanges() {
+        ArgumentCaptor<MediaPlayer.OnVideoSizeChangedListener> argumentCaptor = ArgumentCaptor.forClass(MediaPlayer.OnVideoSizeChangedListener.class);
+        verify(mediaPlayer).setOnVideoSizeChangedListener(argumentCaptor.capture());
+        argumentCaptor.getValue().onVideoSizeChanged(mediaPlayer, ANY_WIDTH, ANY_HEIGHT);
+    }
+
+    private void whenCompleted() {
+        ArgumentCaptor<MediaPlayer.OnCompletionListener> argumentCaptor = ArgumentCaptor.forClass(MediaPlayer.OnCompletionListener.class);
+        verify(mediaPlayer).setOnCompletionListener(argumentCaptor.capture());
+        argumentCaptor.getValue().onCompletion(mediaPlayer);
+    }
+
+    private void whenErroring() {
+        ArgumentCaptor<MediaPlayer.OnErrorListener> argumentCaptor = ArgumentCaptor.forClass(MediaPlayer.OnErrorListener.class);
+        verify(mediaPlayer).setOnErrorListener(argumentCaptor.capture());
+        argumentCaptor.getValue().onError(mediaPlayer, ANY_ERROR_WHAT, ANY_ERROR_EXTRA);
     }
 }

--- a/core/src/test/java/com/novoda/noplayer/mediaplayer/AndroidMediaPlayerFacadeTest.java
+++ b/core/src/test/java/com/novoda/noplayer/mediaplayer/AndroidMediaPlayerFacadeTest.java
@@ -68,6 +68,8 @@ public class AndroidMediaPlayerFacadeTest {
     @Mock
     private PlaybackStateChecker playbackStateChecker;
     @Mock
+    private MediaPlayerCreator mediaPlayerCreator;
+    @Mock
     private MediaPlayer mediaPlayer;
     @Mock
     private AudioManager audioManager;
@@ -90,18 +92,9 @@ public class AndroidMediaPlayerFacadeTest {
     public void setUp() {
         setShowLogs(false);
 
-        facade = new AndroidMediaPlayerFacade(
-                context,
-                audioManager,
-                trackSelector,
-                playbackStateChecker
-        ) {
-            @Override
-            protected MediaPlayer createMediaPlayer() {
-                return mediaPlayer;
-            }
-        };
+        facade = new AndroidMediaPlayerFacade(context, audioManager, trackSelector, playbackStateChecker, mediaPlayerCreator);
 
+        given(mediaPlayerCreator.createMediaPlayer()).willReturn(mediaPlayer);
         given(playbackStateChecker.isInPlaybackState(eq(mediaPlayer), any(PlaybackStateChecker.PlaybackState.class))).willReturn(IS_IN_PLAYBACK_STATE);
 
         doAnswer(new Answer<Void>() {

--- a/core/src/test/java/com/novoda/noplayer/mediaplayer/AndroidMediaPlayerImplTest.java
+++ b/core/src/test/java/com/novoda/noplayer/mediaplayer/AndroidMediaPlayerImplTest.java
@@ -159,7 +159,7 @@ public class AndroidMediaPlayerImplTest {
 
     @Test
     public void whenCreatingAndroidMediaPlayerImpl_thenBindsListenersToMediaPlayer() {
-        verify(mediaPlayer).setListeners(onPreparedListener, onCompletionListener, onErrorListener, onSizeChangedListener);
+        verify(mediaPlayer).setForwarder(forwarder);
     }
 
     @Test

--- a/core/src/test/java/com/novoda/noplayer/mediaplayer/AndroidMediaPlayerImplTest.java
+++ b/core/src/test/java/com/novoda/noplayer/mediaplayer/AndroidMediaPlayerImplTest.java
@@ -159,10 +159,7 @@ public class AndroidMediaPlayerImplTest {
 
     @Test
     public void whenCreatingAndroidMediaPlayerImpl_thenBindsListenersToMediaPlayer() {
-        verify(mediaPlayer).setOnPreparedListener(onPreparedListener);
-        verify(mediaPlayer).setOnCompletionListener(onCompletionListener);
-        verify(mediaPlayer).setOnErrorListener(onErrorListener);
-        verify(mediaPlayer).setOnSizeChangedListener(onSizeChangedListener);
+        verify(mediaPlayer).setListeners(onPreparedListener, onCompletionListener, onErrorListener, onSizeChangedListener);
     }
 
     @Test


### PR DESCRIPTION
## Problem

There was some ignored tests about how to react when the `SurfaceHolderRequester` wasn't set, or any of the many listeners that can be set to the facade.

## Solution

Given that in order to have a correct functioning of media player implementation those listeners / requester has to be set we decided to throw an `IllegalArgumentException` if that's the case. 

Then we completed the missing tests.

Additionally we have created a `MediaPlayerCreator` which is a dependency of `AndroidMediaPlayerFacade`, used to lazily create a `MediaPlayer`. This facilitates testing

### Test(s) added 

Yes, all about tests

### Screenshots

No UI changes

### Paired with 

@Mecharyry 