### PR TITLE
ExoPlayer2/ Reducing public scope of listener reading 

### DIFF
--- a/core/src/main/java/com/novoda/noplayer/Listeners.java
+++ b/core/src/main/java/com/novoda/noplayer/Listeners.java
@@ -47,21 +47,4 @@ public interface Listeners {
 
     void removeVideoSizeChangedListener(Player.VideoSizeChangedListener videoSizeChangedListener);
 
-    ErrorListeners getErrorListeners();
-
-    PreparedListeners getPreparedListeners();
-
-    BufferStateListeners getBufferStateListeners();
-
-    CompletionListeners getCompletionListeners();
-
-    StateChangedListeners getStateChangedListeners();
-
-    InfoListeners getInfoListeners();
-
-    HeartbeatCallbacks<Player> getHeartbeatCallbacks();
-
-    VideoSizeChangedListeners getVideoSizeChangedListeners();
-
-    BitrateChangedListeners getBitrateChangedListeners();
 }

--- a/core/src/main/java/com/novoda/noplayer/PlayerListenersHolder.java
+++ b/core/src/main/java/com/novoda/noplayer/PlayerListenersHolder.java
@@ -125,47 +125,38 @@ public class PlayerListenersHolder implements Listeners {
         videoSizeChangedListeners.remove(videoSizeChangedListener);
     }
 
-    @Override
     public ErrorListeners getErrorListeners() {
         return errorListeners;
     }
 
-    @Override
     public PreparedListeners getPreparedListeners() {
         return preparedListeners;
     }
 
-    @Override
     public BufferStateListeners getBufferStateListeners() {
         return bufferStateListeners;
     }
 
-    @Override
     public CompletionListeners getCompletionListeners() {
         return completionListeners;
     }
 
-    @Override
     public StateChangedListeners getStateChangedListeners() {
         return stateChangedListeners;
     }
 
-    @Override
     public InfoListeners getInfoListeners() {
         return infoListeners;
     }
 
-    @Override
     public HeartbeatCallbacks<Player> getHeartbeatCallbacks() {
         return heartbeatCallbacks;
     }
 
-    @Override
     public VideoSizeChangedListeners getVideoSizeChangedListeners() {
         return videoSizeChangedListeners;
     }
 
-    @Override
     public BitrateChangedListeners getBitrateChangedListeners() {
         return bitrateChangedListeners;
     }


### PR DESCRIPTION
## Problem

We're exposing the reading of listener groups on `Listener` when these are only needed for internal usage.

## Solution

Removes the listener getters from the client facing `Listeners` interface.

### Test(s) added 

no tests around removing methods from interface.

### Screenshots

no changes

### Paired with 

@Dorvaryn 