### PR TITLE
Exoplayer2 - Decouple binding from constructor in ExoPlayerImpl

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -24,7 +24,9 @@ android {
 dependencies {
     compile 'com.google.android.exoplayer:exoplayer:r2.4.1'
     compile 'com.novoda:notils-java:3.0.2'
-    compile 'com.novoda:notils-android:3.0.2'
+    compile ('com.novoda:notils-android:3.0.2') {
+        exclude module: 'support-v4'
+    }
     compile 'com.google.android.exoplayer:exoplayer:r1.5.9'
 
     testCompile 'junit:junit:4.12'

--- a/core/src/main/java/com/novoda/noplayer/exoplayer/ExoPlayerTwoImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/exoplayer/ExoPlayerTwoImpl.java
@@ -1,14 +1,8 @@
 package com.novoda.noplayer.exoplayer;
 
-import android.content.Context;
 import android.net.Uri;
-import android.os.Handler;
-import android.os.Looper;
 import android.view.SurfaceHolder;
 
-import com.google.android.exoplayer2.trackselection.DefaultTrackSelector;
-import com.google.android.exoplayer2.trackselection.FixedTrackSelection;
-import com.google.android.exoplayer2.upstream.DefaultDataSourceFactory;
 import com.novoda.noplayer.ContentType;
 import com.novoda.noplayer.Heart;
 import com.novoda.noplayer.LoadTimeout;
@@ -18,14 +12,10 @@ import com.novoda.noplayer.PlayerListenersHolder;
 import com.novoda.noplayer.PlayerState;
 import com.novoda.noplayer.PlayerView;
 import com.novoda.noplayer.SurfaceHolderRequester;
-import com.novoda.noplayer.SystemClock;
 import com.novoda.noplayer.Timeout;
 import com.novoda.noplayer.VideoDuration;
 import com.novoda.noplayer.VideoPosition;
 import com.novoda.noplayer.exoplayer.forwarder.ExoPlayerForwarder;
-import com.novoda.noplayer.exoplayer.mediasource.ExoPlayerAudioTrackSelector;
-import com.novoda.noplayer.exoplayer.mediasource.ExoPlayerTrackSelector;
-import com.novoda.noplayer.exoplayer.mediasource.MediaSourceFactory;
 import com.novoda.noplayer.player.PlayerInformation;
 
 import java.util.List;
@@ -43,33 +33,6 @@ public class ExoPlayerTwoImpl implements Player {
     private int videoWidth;
     private int videoHeight;
 
-    public static ExoPlayerTwoImpl newInstance(Context context) {
-        DefaultDataSourceFactory defaultDataSourceFactory = new DefaultDataSourceFactory(context, "user-agent");
-        Handler handler = new Handler(Looper.getMainLooper());
-        MediaSourceFactory mediaSourceFactory = new MediaSourceFactory(defaultDataSourceFactory, handler);
-
-        DefaultTrackSelector trackSelector = new DefaultTrackSelector();
-        ExoPlayerTrackSelector exoPlayerTrackSelector = new ExoPlayerTrackSelector(trackSelector);
-        FixedTrackSelection.Factory trackSelectionFactory = new FixedTrackSelection.Factory();
-        ExoPlayerAudioTrackSelector exoPlayerAudioTrackSelector = new ExoPlayerAudioTrackSelector(exoPlayerTrackSelector, trackSelectionFactory);
-
-        ExoPlayerCreator exoPlayerCreator = new ExoPlayerCreator(context, trackSelector);
-        ExoPlayerFacade exoPlayerFacade = new ExoPlayerFacade(mediaSourceFactory, exoPlayerAudioTrackSelector, exoPlayerCreator);
-
-        PlayerListenersHolder listenersHolder = new PlayerListenersHolder();
-        ExoPlayerForwarder exoPlayerForwarder = new ExoPlayerForwarder();
-        LoadTimeout loadTimeout = new LoadTimeout(new SystemClock(), new Handler(Looper.getMainLooper()));
-        Heart heart = Heart.newInstance();
-
-        return new ExoPlayerTwoImpl(
-                exoPlayerFacade,
-                listenersHolder,
-                exoPlayerForwarder,
-                loadTimeout,
-                heart
-        );
-    }
-
     ExoPlayerTwoImpl(ExoPlayerFacade exoPlayer,
                      PlayerListenersHolder listenersHolder,
                      ExoPlayerForwarder exoPlayerForwarder,
@@ -80,7 +43,9 @@ public class ExoPlayerTwoImpl implements Player {
         this.loadTimeout = loadTimeoutParam;
         this.forwarder = exoPlayerForwarder;
         this.heart = heart;
+    }
 
+    public void initialise() {
         heart.bind(new Heart.Heartbeat<>(listenersHolder.getHeartbeatCallbacks(), this));
         forwarder.bind(listenersHolder.getPreparedListeners(), this);
         forwarder.bind(listenersHolder.getCompletionListeners(), listenersHolder.getStateChangedListeners());

--- a/core/src/main/java/com/novoda/noplayer/exoplayer/ExoPlayerTwoImplFactory.java
+++ b/core/src/main/java/com/novoda/noplayer/exoplayer/ExoPlayerTwoImplFactory.java
@@ -1,0 +1,47 @@
+package com.novoda.noplayer.exoplayer;
+
+import android.content.Context;
+import android.os.Handler;
+import android.os.Looper;
+
+import com.google.android.exoplayer2.trackselection.DefaultTrackSelector;
+import com.google.android.exoplayer2.trackselection.FixedTrackSelection;
+import com.google.android.exoplayer2.upstream.DefaultDataSourceFactory;
+import com.novoda.noplayer.Heart;
+import com.novoda.noplayer.LoadTimeout;
+import com.novoda.noplayer.PlayerListenersHolder;
+import com.novoda.noplayer.SystemClock;
+import com.novoda.noplayer.exoplayer.forwarder.ExoPlayerForwarder;
+import com.novoda.noplayer.exoplayer.mediasource.ExoPlayerAudioTrackSelector;
+import com.novoda.noplayer.exoplayer.mediasource.ExoPlayerTrackSelector;
+import com.novoda.noplayer.exoplayer.mediasource.MediaSourceFactory;
+
+public class ExoPlayerTwoImplFactory {
+
+    public ExoPlayerTwoImpl create(Context context) {
+        DefaultDataSourceFactory defaultDataSourceFactory = new DefaultDataSourceFactory(context, "user-agent");
+        Handler handler = new Handler(Looper.getMainLooper());
+        MediaSourceFactory mediaSourceFactory = new MediaSourceFactory(defaultDataSourceFactory, handler);
+
+        DefaultTrackSelector trackSelector = new DefaultTrackSelector();
+        ExoPlayerTrackSelector exoPlayerTrackSelector = new ExoPlayerTrackSelector(trackSelector);
+        FixedTrackSelection.Factory trackSelectionFactory = new FixedTrackSelection.Factory();
+        ExoPlayerAudioTrackSelector exoPlayerAudioTrackSelector = new ExoPlayerAudioTrackSelector(exoPlayerTrackSelector, trackSelectionFactory);
+
+        ExoPlayerCreator exoPlayerCreator = new ExoPlayerCreator(context, trackSelector);
+        ExoPlayerFacade exoPlayerFacade = new ExoPlayerFacade(mediaSourceFactory, exoPlayerAudioTrackSelector, exoPlayerCreator);
+
+        PlayerListenersHolder listenersHolder = new PlayerListenersHolder();
+        ExoPlayerForwarder exoPlayerForwarder = new ExoPlayerForwarder();
+        LoadTimeout loadTimeout = new LoadTimeout(new SystemClock(), new Handler(Looper.getMainLooper()));
+        Heart heart = Heart.newInstance();
+
+        return new ExoPlayerTwoImpl(
+                exoPlayerFacade,
+                listenersHolder,
+                exoPlayerForwarder,
+                loadTimeout,
+                heart
+        );
+    }
+}

--- a/core/src/main/java/com/novoda/noplayer/mediaplayer/AndroidMediaPlayerImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/mediaplayer/AndroidMediaPlayerImpl.java
@@ -23,7 +23,7 @@ import com.novoda.noplayer.player.PlayerInformation;
 
 import java.util.List;
 
-public final class AndroidMediaPlayerImpl implements Player {
+public class AndroidMediaPlayerImpl implements Player {
 
     private static final VideoPosition NO_SEEK_TO_POSITION = VideoPosition.INVALID;
     private static final MediaPlayerInformation MEDIA_PLAYER_INFORMATION = new MediaPlayerInformation();

--- a/core/src/main/java/com/novoda/noplayer/player/PlayerFactory.java
+++ b/core/src/main/java/com/novoda/noplayer/player/PlayerFactory.java
@@ -20,7 +20,7 @@ public class PlayerFactory {
     private final MediaPlayerCreator mediaPlayerCreator;
 
     public PlayerFactory(Context context, PrioritizedPlayerTypes prioritizedPlayerTypes) {
-        this(context, prioritizedPlayerTypes, new ExoPlayerCreator(), new MediaPlayerCreator());
+        this(context, prioritizedPlayerTypes, ExoPlayerCreator.newInstance(), MediaPlayerCreator.newInstance());
     }
 
     PlayerFactory(Context context, PrioritizedPlayerTypes prioritizedPlayerTypes, ExoPlayerCreator exoPlayerCreator, MediaPlayerCreator mediaPlayerCreator) {
@@ -95,8 +95,19 @@ public class PlayerFactory {
 
     static class ExoPlayerCreator {
 
+        private final ExoPlayerTwoImplFactory factory;
+
+        static ExoPlayerCreator newInstance() {
+            ExoPlayerTwoImplFactory factory = new ExoPlayerTwoImplFactory();
+            return new ExoPlayerCreator(factory);
+        }
+
+        ExoPlayerCreator(ExoPlayerTwoImplFactory factory) {
+            this.factory = factory;
+        }
+
         Player createExoPlayer(Context context) {
-            ExoPlayerTwoImpl player = new ExoPlayerTwoImplFactory().create(context);
+            ExoPlayerTwoImpl player = factory.create(context);
             player.initialise();
             return player;
         }
@@ -104,8 +115,19 @@ public class PlayerFactory {
 
     static class MediaPlayerCreator {
 
+        private final AndroidMediaPlayerImplFactory factory;
+
+        static MediaPlayerCreator newInstance() {
+            AndroidMediaPlayerImplFactory factory = new AndroidMediaPlayerImplFactory();
+            return new MediaPlayerCreator(factory);
+        }
+
+        MediaPlayerCreator(AndroidMediaPlayerImplFactory factory) {
+            this.factory = factory;
+        }
+
         Player createMediaPlayer(Context context) {
-            AndroidMediaPlayerImpl player = new AndroidMediaPlayerImplFactory().create(context);
+            AndroidMediaPlayerImpl player = factory.create(context);
             player.initialise();
             return player;
         }

--- a/core/src/main/java/com/novoda/noplayer/player/PlayerFactory.java
+++ b/core/src/main/java/com/novoda/noplayer/player/PlayerFactory.java
@@ -8,6 +8,7 @@ import com.novoda.noplayer.drm.DrmSessionCreator;
 import com.novoda.noplayer.drm.DrmType;
 import com.novoda.noplayer.drm.NoDrmSessionCreator;
 import com.novoda.noplayer.exoplayer.ExoPlayerTwoImpl;
+import com.novoda.noplayer.exoplayer.ExoPlayerTwoImplFactory;
 import com.novoda.noplayer.mediaplayer.AndroidMediaPlayerImpl;
 import com.novoda.noplayer.mediaplayer.AndroidMediaPlayerImplFactory;
 
@@ -95,7 +96,9 @@ public class PlayerFactory {
     static class ExoPlayerCreator {
 
         Player createExoPlayer(Context context) {
-            return ExoPlayerTwoImpl.newInstance(context);
+            ExoPlayerTwoImpl player = new ExoPlayerTwoImplFactory().create(context);
+            player.initialise();
+            return player;
         }
     }
 

--- a/core/src/test/java/com/novoda/noplayer/exoplayer/ExoPlayerTwoImplTest.java
+++ b/core/src/test/java/com/novoda/noplayer/exoplayer/ExoPlayerTwoImplTest.java
@@ -79,7 +79,9 @@ public class ExoPlayerTwoImplTest {
         public ExpectedException thrown = ExpectedException.none();
 
         @Test
-        public void whenCreatingExoplayerTwoImpl_thenBindsListenersToForwarder() {
+        public void whenInitialisingPlayer_thenBindsListenersToForwarder() {
+            player.initialise();
+
             verify(forwarder).bind(preparedListeners, player);
             verify(forwarder).bind(completionListeners, stateChangedListeners);
             verify(forwarder).bind(errorListeners, player);
@@ -90,17 +92,16 @@ public class ExoPlayerTwoImplTest {
         }
 
         @Test
-        public void whenLoadingVideo_thenBindsHeart() {
-
-            player.loadVideo(uri, ANY_CONTENT_TYPE);
+        public void whenInitialisingPlayer_thenBindsHeart() {
+            player.initialise();
 
             verify(listenersHolder).getHeartbeatCallbacks();
             verify(heart).bind(any(Heart.Heartbeat.class));
         }
 
         @Test
-        public void givenLoadingVideo_whenVideoIsPrepared_thenCancelsTimeout() {
-            player.loadVideo(uri, ANY_CONTENT_TYPE);
+        public void givenPlayerIsInitialised_whenVideoIsPrepared_thenCancelsTimeout() {
+            player.initialise();
 
             ArgumentCaptor<Player.PreparedListener> argumentCaptor = ArgumentCaptor.forClass(Player.PreparedListener.class);
 
@@ -112,8 +113,8 @@ public class ExoPlayerTwoImplTest {
         }
 
         @Test
-        public void givenLoadingVideo_whenVideoHasError_thenCancelsTimeout() {
-            player.loadVideo(uri, ANY_CONTENT_TYPE);
+        public void givenPlayerIsInitialised_whenVideoHasError_thenCancelsTimeout() {
+            player.initialise();
 
             ArgumentCaptor<Player.ErrorListener> argumentCaptor = ArgumentCaptor.forClass(Player.ErrorListener.class);
 
@@ -125,9 +126,9 @@ public class ExoPlayerTwoImplTest {
         }
 
         @Test
-        public void givenLoadingVideo_whenVideoSizeChanges_thenPlayerVideoWidthAndHeightMatches() {
+        public void givenPlayerIsInitialised_andPlayerViewIsAttached_whenVideoSizeChanges_thenPlayerVideoWidthAndHeightMatches() {
+            player.initialise();
             player.attach(playerView);
-            player.loadVideo(uri, ANY_CONTENT_TYPE);
 
             ArgumentCaptor<Player.VideoSizeChangedListener> argumentCaptor = ArgumentCaptor.forClass(Player.VideoSizeChangedListener.class);
             verify(listenersHolder, times(2)).addVideoSizeChangedListener(argumentCaptor.capture());
@@ -143,10 +144,10 @@ public class ExoPlayerTwoImplTest {
         }
 
         @Test
-        public void whenLoadingVideo_thenAddsPlayerViewVideoSizeChangedListenerToListenersHolder() {
+        public void givenPlayerIsInitialised_whenAttachingPlayerView_thenAddsPlayerViewVideoSizeChangedListenerToListenersHolder() {
+            player.initialise();
+            
             player.attach(playerView);
-
-            player.loadVideo(uri, ANY_CONTENT_TYPE);
 
             ArgumentCaptor<Player.VideoSizeChangedListener> argumentCaptor = ArgumentCaptor.forClass(Player.VideoSizeChangedListener.class);
             verify(listenersHolder, times(2)).addVideoSizeChangedListener(argumentCaptor.capture());
@@ -469,7 +470,7 @@ public class ExoPlayerTwoImplTest {
         @Mock
         ExoPlayerFacade exoPlayerFacade;
 
-        Player player;
+        ExoPlayerTwoImpl player;
 
         @Before
         public void setUp() {

--- a/core/src/test/java/com/novoda/noplayer/player/PlayerFactoryTest.java
+++ b/core/src/test/java/com/novoda/noplayer/player/PlayerFactoryTest.java
@@ -7,6 +7,10 @@ import com.novoda.noplayer.drm.DownloadedModularDrm;
 import com.novoda.noplayer.drm.DrmHandler;
 import com.novoda.noplayer.drm.DrmType;
 import com.novoda.noplayer.drm.StreamingModularDrm;
+import com.novoda.noplayer.exoplayer.ExoPlayerTwoImpl;
+import com.novoda.noplayer.exoplayer.ExoPlayerTwoImplFactory;
+import com.novoda.noplayer.mediaplayer.AndroidMediaPlayerImpl;
+import com.novoda.noplayer.mediaplayer.AndroidMediaPlayerImplFactory;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -23,6 +27,7 @@ import static org.fest.assertions.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 @RunWith(Enclosed.class)
 public class PlayerFactoryTest {
@@ -141,6 +146,62 @@ public class PlayerFactoryTest {
             Player player = playerFactory.create(DrmType.WIDEVINE_MODULAR_DOWNLOAD, DOWNLOADED_MODULAR_DRM);
 
             assertThat(player).isEqualTo(EXO_PLAYER);
+        }
+    }
+
+    public static class ExoPlayerTwoCreatorTest {
+
+        @Rule
+        public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+        @Mock
+        ExoPlayerTwoImplFactory factory;
+        @Mock
+        ExoPlayerTwoImpl player;
+        @Mock
+        Context context;
+
+        private PlayerFactory.ExoPlayerCreator creator;
+
+        @Before
+        public void setUp() {
+            creator = new PlayerFactory.ExoPlayerCreator(factory);
+            given(factory.create(any(Context.class))).willReturn(player);
+        }
+
+        @Test
+        public void whenCreatingExoPlayerTwo_thenInitialisesPlayer() {
+            creator.createExoPlayer(context);
+
+            verify(player).initialise();
+        }
+    }
+
+    public static class MediaPlayerCreatorTest {
+
+        @Rule
+        public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+        @Mock
+        AndroidMediaPlayerImplFactory factory;
+        @Mock
+        AndroidMediaPlayerImpl player;
+        @Mock
+        Context context;
+
+        private PlayerFactory.MediaPlayerCreator creator;
+
+        @Before
+        public void setUp() {
+            creator = new PlayerFactory.MediaPlayerCreator(factory);
+            given(factory.create(any(Context.class))).willReturn(player);
+        }
+
+        @Test
+        public void whenCreatingMediaPlayer_thenInitialisesPlayer() {
+            creator.createMediaPlayer(context);
+
+            verify(player).initialise();
         }
     }
 }


### PR DESCRIPTION
## Problem

As we did on #43 we want to decouple the binding from the constructor on `ExoPlayerTwoImpl`

## Solution

Create an `initialise()` method that will be doing the binding. The instantiation of the class is now done in a factory instead of a `newInstance()`. `initialise()` is called upon creation, on `PlayerFactory`. 

### Test(s) added 

Yes, modified existing ones and made sure that initialisation is happening when it should

### Screenshots

No UI changes

### Paired with 

Nobody