### PR TITLE
ExoPlayer 2 - Fix build by removing notils

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -24,21 +24,10 @@ android {
 dependencies {
     compile 'com.google.android.exoplayer:exoplayer:r2.4.1'
     compile 'com.novoda:notils-java:3.0.2'
-    compile ('com.novoda:notils-android:3.0.2') {
-        exclude group: 'com.android.support', module: 'support-v4'
-    }
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:2.7.22'
     testCompile 'org.easytesting:fest-assert-core:2.0M10'
-
-    androidTestCompile 'org.mockito:mockito-core:2.7.22'
-    androidTestCompile 'org.easytesting:fest-assert-core:2.0M10'
-    androidTestCompile 'com.linkedin.dexmaker:dexmaker:2.2.0'
-    androidTestCompile 'com.linkedin.dexmaker:dexmaker-mockito:2.2.0'
-
-    androidTestCompile 'com.android.support.test:runner:0.5'
-    androidTestCompile 'com.android.support.test:rules:0.5'
 }
 
 project.afterEvaluate({

--- a/core/src/main/java/com/novoda/noplayer/NoPlayerView.java
+++ b/core/src/main/java/com/novoda/noplayer/NoPlayerView.java
@@ -9,7 +9,6 @@ import android.widget.FrameLayout;
 import com.google.android.exoplayer2.ui.AspectRatioFrameLayout;
 import com.google.android.exoplayer2.ui.SubtitleView;
 import com.novoda.noplayer.exoplayer.AspectRatioChangeCalculator;
-import com.novoda.notils.caster.Views;
 
 public class NoPlayerView extends FrameLayout implements AspectRatioChangeCalculator.Listener, PlayerView {
 
@@ -35,11 +34,11 @@ public class NoPlayerView extends FrameLayout implements AspectRatioChangeCalcul
     protected void onFinishInflate() {
         super.onFinishInflate();
         View.inflate(getContext(), R.layout.noplayer_view, this);
-        videoFrame = Views.findById(this, R.id.video_frame);
-        shutterView = Views.findById(this, R.id.shutter);
-        surfaceView = Views.findById(this, R.id.surface_view);
+        videoFrame = (AspectRatioFrameLayout) findViewById(R.id.video_frame);
+        shutterView = findViewById(R.id.shutter);
+        surfaceView = (SurfaceView) findViewById(R.id.surface_view);
         surfaceView.getHolder().addCallback(surfaceHolderProvider);
-        subtitleView = Views.findById(this, R.id.subtitles_layout);
+        subtitleView = (SubtitleView) findViewById(R.id.subtitles_layout);
     }
 
     @Override

--- a/core/src/main/java/com/novoda/noplayer/mediaplayer/AndroidMediaPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/mediaplayer/AndroidMediaPlayerFacade.java
@@ -9,7 +9,7 @@ import android.view.SurfaceHolder;
 import com.novoda.noplayer.PlayerAudioTrack;
 import com.novoda.noplayer.mediaplayer.PlaybackStateChecker.PlaybackState;
 import com.novoda.noplayer.mediaplayer.forwarder.MediaPlayerForwarder;
-import com.novoda.notils.logger.simple.Log;
+import com.novoda.utils.Log;
 
 import java.io.IOException;
 import java.util.List;

--- a/core/src/main/java/com/novoda/noplayer/mediaplayer/AndroidMediaPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/mediaplayer/AndroidMediaPlayerFacade.java
@@ -9,7 +9,7 @@ import android.view.SurfaceHolder;
 import com.novoda.noplayer.PlayerAudioTrack;
 import com.novoda.noplayer.mediaplayer.PlaybackStateChecker.PlaybackState;
 import com.novoda.noplayer.mediaplayer.forwarder.MediaPlayerForwarder;
-import com.novoda.utils.Log;
+import com.novoda.utils.NoPlayerLog;
 
 import java.io.IOException;
 import java.util.List;
@@ -93,7 +93,7 @@ class AndroidMediaPlayerFacade {
     }
 
     private void reportCreationError(Exception ex, Uri videoUri) {
-        Log.w(ex, "Unable to open content: " + videoUri);
+        NoPlayerLog.w(ex, "Unable to open content: " + videoUri);
         currentState = PlaybackState.ERROR;
         internalErrorListener.onError(mediaPlayer, MediaPlayer.MEDIA_ERROR_UNKNOWN, 0);
     }
@@ -137,7 +137,7 @@ class AndroidMediaPlayerFacade {
     private final MediaPlayer.OnErrorListener internalErrorListener = new MediaPlayer.OnErrorListener() {
         @Override
         public boolean onError(MediaPlayer mp, int what, int extra) {
-            Log.d("Error: " + what + "," + extra);
+            NoPlayerLog.d("Error: " + what + "," + extra);
             currentState = PlaybackState.ERROR;
             MediaPlayer.OnErrorListener onErrorForwarder = forwarder.onErrorListener();
             if (onErrorForwarder == null) {

--- a/core/src/main/java/com/novoda/noplayer/mediaplayer/forwarder/VideoSizeChangedForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/mediaplayer/forwarder/VideoSizeChangedForwarder.java
@@ -3,7 +3,7 @@ package com.novoda.noplayer.mediaplayer.forwarder;
 import android.media.MediaPlayer;
 
 import com.novoda.noplayer.listeners.VideoSizeChangedListeners;
-import com.novoda.notils.logger.simple.Log;
+import com.novoda.utils.Log;
 
 class VideoSizeChangedForwarder implements MediaPlayer.OnVideoSizeChangedListener {
 

--- a/core/src/main/java/com/novoda/noplayer/mediaplayer/forwarder/VideoSizeChangedForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/mediaplayer/forwarder/VideoSizeChangedForwarder.java
@@ -3,7 +3,7 @@ package com.novoda.noplayer.mediaplayer.forwarder;
 import android.media.MediaPlayer;
 
 import com.novoda.noplayer.listeners.VideoSizeChangedListeners;
-import com.novoda.utils.Log;
+import com.novoda.utils.NoPlayerLog;
 
 class VideoSizeChangedForwarder implements MediaPlayer.OnVideoSizeChangedListener {
 
@@ -21,7 +21,7 @@ class VideoSizeChangedForwarder implements MediaPlayer.OnVideoSizeChangedListene
         if (bothDimensionsHaveChanged(width, height)) {
             videoSizeChangedListeners.onVideoSizeChanged(width, height, 0, 1);
         } else {
-            Log.w("Video size changed but we have swallowed the event due to only 1 dimension changing");
+            NoPlayerLog.w("Video size changed but we have swallowed the event due to only 1 dimension changing");
         }
         previousWidth = width;
         previousHeight = height;

--- a/core/src/main/java/com/novoda/utils/Log.java
+++ b/core/src/main/java/com/novoda/utils/Log.java
@@ -1,0 +1,136 @@
+package com.novoda.utils;
+
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+public abstract class Log {
+
+    private static final int DEPTH = 5;
+    private static final int CLASS_SUFFIX = 5;
+
+    private static boolean isEnabled = true;
+
+    public static void setLoggingEnabled(boolean enabled) {
+        isEnabled = enabled;
+    }
+
+    private static String logMessage(String message, Throwable throwable) {
+        String detailedMessage = getDetailedLog(message);
+        if (throwable != null) {
+            detailedMessage += "\n" + getStackTraceString(throwable);
+        }
+        return detailedMessage;
+    }
+
+    private static String getDetailedLog(String message) {
+        Thread current = Thread.currentThread();
+        final StackTraceElement trace = current.getStackTrace()[DEPTH];
+        final String filename = trace.getFileName();
+        return "[" + current.getName() + "][" + filename.substring(0, filename.length() - CLASS_SUFFIX) + "."
+                + trace.getMethodName() + ":" + trace.getLineNumber() + "] " + message;
+    }
+
+    private static String getStackTraceString(Throwable throwable) {
+
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+        try {
+            throwable.printStackTrace(pw);
+            return sw.toString().trim();
+        } finally {
+            pw.close();
+        }
+    }
+
+    public static void d(String msg) {
+        if (!isEnabled) {
+            return;
+        }
+        android.util.Log.d("No-Player", logMessage(msg, null));
+    }
+
+    public static void d(Throwable throwable, String msg) {
+        if (!isEnabled) {
+            return;
+        }
+        android.util.Log.d("No-Player", logMessage(msg, throwable));
+    }
+
+    public static void e(String msg) {
+        if (!isEnabled) {
+            return;
+        }
+        android.util.Log.e("No-Player", logMessage(msg, null));
+    }
+
+    public static void e(Throwable throwable, String msg) {
+        if (!isEnabled) {
+            return;
+        }
+        android.util.Log.e("No-Player", logMessage(msg, throwable));
+    }
+
+    public static void i(String msg) {
+        if (!isEnabled) {
+            return;
+        }
+        android.util.Log.i("No-Player", logMessage(msg, null));
+    }
+
+    public static void i(Throwable throwable, String msg) {
+        if (!isEnabled) {
+            return;
+        }
+        android.util.Log.i("No-Player", logMessage(msg, throwable));
+    }
+
+    public static void v(String msg) {
+        if (!isEnabled) {
+            return;
+        }
+        android.util.Log.v("No-Player", logMessage(msg, null));
+    }
+
+    public static void v(Throwable throwable, String msg) {
+        if (!isEnabled) {
+            return;
+        }
+        android.util.Log.v("No-Player", logMessage(msg, throwable));
+    }
+
+    public static void w(String msg) {
+        if (!isEnabled) {
+            return;
+        }
+        android.util.Log.w("No-Player", logMessage(msg, null));
+    }
+
+    public static void w(Throwable throwable, String msg) {
+        if (!isEnabled) {
+            return;
+        }
+        android.util.Log.w("No-Player", logMessage(msg, throwable));
+    }
+
+    public static void wtf(String msg) {
+        if (!isEnabled) {
+            return;
+        }
+        android.util.Log.wtf("No-Player", logMessage(msg, null));
+    }
+
+    public static void wtf(Throwable throwable) {
+        if (!isEnabled) {
+            return;
+        }
+        android.util.Log.wtf("No-Player", logMessage("", throwable));
+    }
+
+    public static void wtf(Throwable throwable, String msg) {
+        if (!isEnabled) {
+            return;
+        }
+        android.util.Log.wtf("No-Player", logMessage(msg, throwable));
+    }
+}

--- a/core/src/main/java/com/novoda/utils/NoPlayerLog.java
+++ b/core/src/main/java/com/novoda/utils/NoPlayerLog.java
@@ -4,7 +4,7 @@ package com.novoda.utils;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 
-public abstract class Log {
+public abstract class NoPlayerLog {
 
     private static final int DEPTH = 5;
     private static final int CLASS_SUFFIX = 5;

--- a/core/src/main/java/com/novoda/utils/NoPlayerLog.java
+++ b/core/src/main/java/com/novoda/utils/NoPlayerLog.java
@@ -6,6 +6,7 @@ import java.io.StringWriter;
 
 public abstract class NoPlayerLog {
 
+    private static final String TAG = "No-Player";
     private static final int DEPTH = 5;
     private static final int CLASS_SUFFIX = 5;
 
@@ -47,90 +48,90 @@ public abstract class NoPlayerLog {
         if (!isEnabled) {
             return;
         }
-        android.util.Log.d("No-Player", logMessage(msg, null));
+        android.util.Log.d(TAG, logMessage(msg, null));
     }
 
     public static void d(Throwable throwable, String msg) {
         if (!isEnabled) {
             return;
         }
-        android.util.Log.d("No-Player", logMessage(msg, throwable));
+        android.util.Log.d(TAG, logMessage(msg, throwable));
     }
 
     public static void e(String msg) {
         if (!isEnabled) {
             return;
         }
-        android.util.Log.e("No-Player", logMessage(msg, null));
+        android.util.Log.e(TAG, logMessage(msg, null));
     }
 
     public static void e(Throwable throwable, String msg) {
         if (!isEnabled) {
             return;
         }
-        android.util.Log.e("No-Player", logMessage(msg, throwable));
+        android.util.Log.e(TAG, logMessage(msg, throwable));
     }
 
     public static void i(String msg) {
         if (!isEnabled) {
             return;
         }
-        android.util.Log.i("No-Player", logMessage(msg, null));
+        android.util.Log.i(TAG, logMessage(msg, null));
     }
 
     public static void i(Throwable throwable, String msg) {
         if (!isEnabled) {
             return;
         }
-        android.util.Log.i("No-Player", logMessage(msg, throwable));
+        android.util.Log.i(TAG, logMessage(msg, throwable));
     }
 
     public static void v(String msg) {
         if (!isEnabled) {
             return;
         }
-        android.util.Log.v("No-Player", logMessage(msg, null));
+        android.util.Log.v(TAG, logMessage(msg, null));
     }
 
     public static void v(Throwable throwable, String msg) {
         if (!isEnabled) {
             return;
         }
-        android.util.Log.v("No-Player", logMessage(msg, throwable));
+        android.util.Log.v(TAG, logMessage(msg, throwable));
     }
 
     public static void w(String msg) {
         if (!isEnabled) {
             return;
         }
-        android.util.Log.w("No-Player", logMessage(msg, null));
+        android.util.Log.w(TAG, logMessage(msg, null));
     }
 
     public static void w(Throwable throwable, String msg) {
         if (!isEnabled) {
             return;
         }
-        android.util.Log.w("No-Player", logMessage(msg, throwable));
+        android.util.Log.w(TAG, logMessage(msg, throwable));
     }
 
     public static void wtf(String msg) {
         if (!isEnabled) {
             return;
         }
-        android.util.Log.wtf("No-Player", logMessage(msg, null));
+        android.util.Log.wtf(TAG, logMessage(msg, null));
     }
 
     public static void wtf(Throwable throwable) {
         if (!isEnabled) {
             return;
         }
-        android.util.Log.wtf("No-Player", logMessage("", throwable));
+        android.util.Log.wtf(TAG, logMessage("", throwable));
     }
 
     public static void wtf(Throwable throwable, String msg) {
         if (!isEnabled) {
             return;
         }
-        android.util.Log.wtf("No-Player", logMessage(msg, throwable));
+        android.util.Log.wtf(TAG, logMessage(msg, throwable));
     }
 }

--- a/core/src/test/java/com/novoda/noplayer/mediaplayer/AndroidMediaPlayerFacadeTest.java
+++ b/core/src/test/java/com/novoda/noplayer/mediaplayer/AndroidMediaPlayerFacadeTest.java
@@ -9,6 +9,7 @@ import android.view.SurfaceHolder;
 import com.novoda.noplayer.PlayerAudioTrack;
 import com.novoda.noplayer.SurfaceHolderRequester;
 import com.novoda.noplayer.mediaplayer.forwarder.MediaPlayerForwarder;
+import com.novoda.utils.Log;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -28,7 +29,6 @@ import org.mockito.stubbing.Answer;
 
 import utils.ExceptionMatcher;
 
-import static com.novoda.notils.logger.simple.Log.setShowLogs;
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -98,7 +98,7 @@ public class AndroidMediaPlayerFacadeTest {
 
     @Before
     public void setUp() {
-        setShowLogs(false);
+        Log.setLoggingEnabled(false);
 
         facade = new AndroidMediaPlayerFacade(context, forwarder, audioManager, trackSelector, playbackStateChecker, mediaPlayerCreator);
 

--- a/core/src/test/java/com/novoda/noplayer/mediaplayer/AndroidMediaPlayerFacadeTest.java
+++ b/core/src/test/java/com/novoda/noplayer/mediaplayer/AndroidMediaPlayerFacadeTest.java
@@ -9,7 +9,7 @@ import android.view.SurfaceHolder;
 import com.novoda.noplayer.PlayerAudioTrack;
 import com.novoda.noplayer.SurfaceHolderRequester;
 import com.novoda.noplayer.mediaplayer.forwarder.MediaPlayerForwarder;
-import com.novoda.utils.Log;
+import com.novoda.utils.NoPlayerLog;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -98,7 +98,7 @@ public class AndroidMediaPlayerFacadeTest {
 
     @Before
     public void setUp() {
-        Log.setLoggingEnabled(false);
+        NoPlayerLog.setLoggingEnabled(false);
 
         facade = new AndroidMediaPlayerFacade(context, forwarder, audioManager, trackSelector, playbackStateChecker, mediaPlayerCreator);
 

--- a/core/src/test/java/com/novoda/noplayer/mediaplayer/AndroidMediaPlayerImplTest.java
+++ b/core/src/test/java/com/novoda/noplayer/mediaplayer/AndroidMediaPlayerImplTest.java
@@ -28,7 +28,7 @@ import com.novoda.noplayer.listeners.VideoSizeChangedListeners;
 import com.novoda.noplayer.mediaplayer.forwarder.MediaPlayerForwarder;
 import com.novoda.noplayer.player.PlayerInformation;
 import com.novoda.noplayer.player.PlayerType;
-import com.novoda.notils.logger.simple.Log;
+import com.novoda.utils.Log;
 
 import java.util.Collections;
 import java.util.List;
@@ -50,7 +50,12 @@ import org.mockito.stubbing.Answer;
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 @RunWith(Enclosed.class)
 public class AndroidMediaPlayerImplTest {
@@ -105,7 +110,7 @@ public class AndroidMediaPlayerImplTest {
 
         @Before
         public void setUp() {
-            Log.setShowLogs(false);
+            Log.setLoggingEnabled(false);
             given(listenersHolder.getPreparedListeners()).willReturn(preparedListeners);
             given(listenersHolder.getBufferStateListeners()).willReturn(bufferStateListeners);
             given(listenersHolder.getErrorListeners()).willReturn(errorListeners);
@@ -677,7 +682,7 @@ public class AndroidMediaPlayerImplTest {
 
         @Before
         public void setUp() {
-            Log.setShowLogs(false);
+            Log.setLoggingEnabled(false);
             SurfaceHolderRequester surfaceHolderRequester = mock(SurfaceHolderRequester.class);
             given(playerView.getSurfaceHolderRequester()).willReturn(surfaceHolderRequester);
             given(playerView.getStateChangedListener()).willReturn(stateChangeListener);

--- a/core/src/test/java/com/novoda/noplayer/mediaplayer/AndroidMediaPlayerImplTest.java
+++ b/core/src/test/java/com/novoda/noplayer/mediaplayer/AndroidMediaPlayerImplTest.java
@@ -28,7 +28,7 @@ import com.novoda.noplayer.listeners.VideoSizeChangedListeners;
 import com.novoda.noplayer.mediaplayer.forwarder.MediaPlayerForwarder;
 import com.novoda.noplayer.player.PlayerInformation;
 import com.novoda.noplayer.player.PlayerType;
-import com.novoda.utils.Log;
+import com.novoda.utils.NoPlayerLog;
 
 import java.util.Collections;
 import java.util.List;
@@ -110,7 +110,7 @@ public class AndroidMediaPlayerImplTest {
 
         @Before
         public void setUp() {
-            Log.setLoggingEnabled(false);
+            NoPlayerLog.setLoggingEnabled(false);
             given(listenersHolder.getPreparedListeners()).willReturn(preparedListeners);
             given(listenersHolder.getBufferStateListeners()).willReturn(bufferStateListeners);
             given(listenersHolder.getErrorListeners()).willReturn(errorListeners);
@@ -682,7 +682,7 @@ public class AndroidMediaPlayerImplTest {
 
         @Before
         public void setUp() {
-            Log.setLoggingEnabled(false);
+            NoPlayerLog.setLoggingEnabled(false);
             SurfaceHolderRequester surfaceHolderRequester = mock(SurfaceHolderRequester.class);
             given(playerView.getSurfaceHolderRequester()).willReturn(surfaceHolderRequester);
             given(playerView.getStateChangedListener()).willReturn(stateChangeListener);

--- a/demo/src/main/java/com/novoda/demo/MainActivity.java
+++ b/demo/src/main/java/com/novoda/demo/MainActivity.java
@@ -15,7 +15,7 @@ import com.novoda.noplayer.PlayerState;
 import com.novoda.noplayer.PlayerView;
 import com.novoda.noplayer.player.PlayerFactory;
 import com.novoda.noplayer.player.PrioritizedPlayerTypes;
-import com.novoda.utils.Log;
+import com.novoda.utils.NoPlayerLog;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -32,7 +32,7 @@ public class MainActivity extends Activity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        Log.setLoggingEnabled(true);
+        NoPlayerLog.setLoggingEnabled(true);
         setContentView(R.layout.activity_main);
         playerView = (PlayerView) findViewById(R.id.player_view);
         audioSelectionButton = findViewById(R.id.button_audio_selection);

--- a/demo/src/main/java/com/novoda/demo/MainActivity.java
+++ b/demo/src/main/java/com/novoda/demo/MainActivity.java
@@ -15,8 +15,7 @@ import com.novoda.noplayer.PlayerState;
 import com.novoda.noplayer.PlayerView;
 import com.novoda.noplayer.player.PlayerFactory;
 import com.novoda.noplayer.player.PrioritizedPlayerTypes;
-import com.novoda.notils.caster.Views;
-import com.novoda.notils.logger.simple.Log;
+import com.novoda.utils.Log;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -33,10 +32,10 @@ public class MainActivity extends Activity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        Log.setShowLogs(true);
+        Log.setLoggingEnabled(true);
         setContentView(R.layout.activity_main);
         playerView = (PlayerView) findViewById(R.id.player_view);
-        audioSelectionButton = Views.findById(this, R.id.button_audio_selection);
+        audioSelectionButton = findViewById(R.id.button_audio_selection);
     }
 
     @Override


### PR DESCRIPTION
## Problem

We are having a lot of issues because of the `notils` support library versions clashing with libraries support versions.

## Solution

We are not using notils a lot, instead I have "ported" the Logging function to an `utils.Log` class

### Test(s) added 

Modified some existing tests 

### Screenshots

No UI changes

### Paired with 

Nobody