### PR TITLE
Exoplayer2/Streaming & Local widevine modular drm support

### DIFF
--- a/core/src/main/java/com/novoda/noplayer/drm/DownloadDrmSessionCreator.java
+++ b/core/src/main/java/com/novoda/noplayer/drm/DownloadDrmSessionCreator.java
@@ -17,7 +17,7 @@ public class DownloadDrmSessionCreator implements DrmSessionCreator {
         try {
             return new LocalDrmSession(downloadedModularDrm.getKeySetId());
         } catch (UnsupportedDrmException e) {
-            return null;
+            throw new DrmSessionManagerCreationException(e);
         }
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/drm/DownloadDrmSessionCreator.java
+++ b/core/src/main/java/com/novoda/noplayer/drm/DownloadDrmSessionCreator.java
@@ -1,0 +1,23 @@
+package com.novoda.noplayer.drm;
+
+import com.google.android.exoplayer2.drm.DrmSessionManager;
+import com.google.android.exoplayer2.drm.FrameworkMediaCrypto;
+import com.google.android.exoplayer2.drm.UnsupportedDrmException;
+
+public class DownloadDrmSessionCreator implements DrmSessionCreator {
+
+    private final DownloadedModularDrm downloadedModularDrm;
+
+    public DownloadDrmSessionCreator(DownloadedModularDrm downloadedModularDrm) {
+        this.downloadedModularDrm = downloadedModularDrm;
+    }
+
+    @Override
+    public DrmSessionManager<FrameworkMediaCrypto> create() {
+        try {
+            return new LocalDrmSession(downloadedModularDrm.getKeySetId());
+        } catch (UnsupportedDrmException e) {
+            return null;
+        }
+    }
+}

--- a/core/src/main/java/com/novoda/noplayer/drm/DrmSessionCreator.java
+++ b/core/src/main/java/com/novoda/noplayer/drm/DrmSessionCreator.java
@@ -6,4 +6,11 @@ import com.google.android.exoplayer2.drm.FrameworkMediaCrypto;
 public interface DrmSessionCreator {
 
     DrmSessionManager<FrameworkMediaCrypto> create();
+
+    class DrmSessionManagerCreationException extends RuntimeException {
+
+        DrmSessionManagerCreationException(Throwable cause) {
+            super(cause);
+        }
+    }
 }

--- a/core/src/main/java/com/novoda/noplayer/drm/DrmSessionCreator.java
+++ b/core/src/main/java/com/novoda/noplayer/drm/DrmSessionCreator.java
@@ -1,5 +1,9 @@
 package com.novoda.noplayer.drm;
 
+import com.google.android.exoplayer2.drm.DefaultDrmSessionManager;
+import com.google.android.exoplayer2.drm.FrameworkMediaCrypto;
+
 public interface DrmSessionCreator {
 
+    DefaultDrmSessionManager<FrameworkMediaCrypto> create();
 }

--- a/core/src/main/java/com/novoda/noplayer/drm/DrmSessionCreator.java
+++ b/core/src/main/java/com/novoda/noplayer/drm/DrmSessionCreator.java
@@ -1,9 +1,9 @@
 package com.novoda.noplayer.drm;
 
-import com.google.android.exoplayer2.drm.DefaultDrmSessionManager;
+import com.google.android.exoplayer2.drm.DrmSessionManager;
 import com.google.android.exoplayer2.drm.FrameworkMediaCrypto;
 
 public interface DrmSessionCreator {
 
-    DefaultDrmSessionManager<FrameworkMediaCrypto> create();
+    DrmSessionManager<FrameworkMediaCrypto> create();
 }

--- a/core/src/main/java/com/novoda/noplayer/drm/DrmSessionCreator.java
+++ b/core/src/main/java/com/novoda/noplayer/drm/DrmSessionCreator.java
@@ -1,10 +1,13 @@
 package com.novoda.noplayer.drm;
 
+import android.support.annotation.Nullable;
+
 import com.google.android.exoplayer2.drm.DrmSessionManager;
 import com.google.android.exoplayer2.drm.FrameworkMediaCrypto;
 
 public interface DrmSessionCreator {
 
+    @Nullable
     DrmSessionManager<FrameworkMediaCrypto> create();
 
     class DrmSessionManagerCreationException extends RuntimeException {

--- a/core/src/main/java/com/novoda/noplayer/drm/FrameworkMediaDrmCreator.java
+++ b/core/src/main/java/com/novoda/noplayer/drm/FrameworkMediaDrmCreator.java
@@ -1,0 +1,24 @@
+package com.novoda.noplayer.drm;
+
+import com.google.android.exoplayer2.drm.FrameworkMediaDrm;
+import com.google.android.exoplayer2.drm.UnsupportedDrmException;
+
+import java.util.UUID;
+
+public class FrameworkMediaDrmCreator {
+
+    public FrameworkMediaDrm create(UUID uuid) {
+        try {
+            return FrameworkMediaDrm.newInstance(uuid);
+        } catch (UnsupportedDrmException e) {
+            throw new FrameworkMediaDrmException(e.getMessage(), e.getCause());
+        }
+    }
+
+    private class FrameworkMediaDrmException extends RuntimeException {
+
+        FrameworkMediaDrmException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+}

--- a/core/src/main/java/com/novoda/noplayer/drm/LocalDrmSession.java
+++ b/core/src/main/java/com/novoda/noplayer/drm/LocalDrmSession.java
@@ -97,6 +97,7 @@ class LocalDrmSession implements DrmSessionManager<FrameworkMediaCrypto>, DrmSes
     }
 
     private void onError(Exception e) {
+        // TODO add listener and callback with exception see DefaultDrmSessionManager onError
         state = STATE_ERROR;
         lastKnownException = e;
     }

--- a/core/src/main/java/com/novoda/noplayer/drm/LocalDrmSession.java
+++ b/core/src/main/java/com/novoda/noplayer/drm/LocalDrmSession.java
@@ -15,6 +15,8 @@ import com.google.android.exoplayer2.drm.FrameworkMediaDrm;
 import com.google.android.exoplayer2.drm.UnsupportedDrmException;
 
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
@@ -68,7 +70,7 @@ class LocalDrmSession implements DrmSessionManager<FrameworkMediaCrypto>, DrmSes
 
     @Override
     public Map<String, String> queryKeyStatus() {
-        return null;
+        return Collections.unmodifiableMap(new HashMap<String, String>());
     }
 
     @Override

--- a/core/src/main/java/com/novoda/noplayer/drm/LocalDrmSession.java
+++ b/core/src/main/java/com/novoda/noplayer/drm/LocalDrmSession.java
@@ -1,0 +1,103 @@
+package com.novoda.noplayer.drm;
+
+import android.annotation.TargetApi;
+import android.media.MediaCryptoException;
+import android.media.MediaDrmException;
+import android.os.Build;
+import android.os.Looper;
+
+import com.google.android.exoplayer2.drm.DrmInitData;
+import com.google.android.exoplayer2.drm.DrmSession;
+import com.google.android.exoplayer2.drm.DrmSessionManager;
+import com.google.android.exoplayer2.drm.ExoMediaDrm;
+import com.google.android.exoplayer2.drm.FrameworkMediaCrypto;
+import com.google.android.exoplayer2.drm.FrameworkMediaDrm;
+import com.google.android.exoplayer2.drm.UnsupportedDrmException;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.UUID;
+
+@TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR2)
+public class LocalDrmSession implements DrmSessionManager<FrameworkMediaCrypto>, DrmSession<FrameworkMediaCrypto> {
+
+    private static final UUID WIDEVINE_MODULAR_UUID = new UUID(0xEDEF8BA979D64ACEL, 0xA3C827DCD51D21EDL);
+
+    private final ExoMediaDrm<FrameworkMediaCrypto> mediaDrm;
+    private final byte[] keySetIdToRestore;
+
+    private int state = STATE_CLOSED;
+    private byte[] sessionId;
+    private FrameworkMediaCrypto mediaCrypto;
+    private Exception lastKnownException;
+
+    public LocalDrmSession(byte[] keySetIdToRestore) throws UnsupportedDrmException {
+        this.keySetIdToRestore = Arrays.copyOf(keySetIdToRestore, keySetIdToRestore.length);
+        this.mediaDrm = FrameworkMediaDrm.newInstance(WIDEVINE_MODULAR_UUID);
+    }
+
+    @Override
+    public int getState() {
+        return state;
+    }
+
+    @Override
+    public FrameworkMediaCrypto getMediaCrypto() {
+        if (state != STATE_OPENED && state != STATE_OPENED_WITH_KEYS) {
+            throw new IllegalStateException();
+        }
+        return mediaCrypto;
+    }
+
+    @Override
+    public boolean requiresSecureDecoderComponent(String mimeType) {
+        if (state != STATE_OPENED && state != STATE_OPENED_WITH_KEYS) {
+            throw new IllegalStateException();
+        }
+        return mediaCrypto.requiresSecureDecoderComponent(mimeType);
+    }
+
+    @Override
+    public DrmSessionException getError() {
+        return new DrmSessionException(lastKnownException);
+    }
+
+    @Override
+    public Map<String, String> queryKeyStatus() {
+        return null;
+    }
+
+    @Override
+    public byte[] getOfflineLicenseKeySetId() {
+        return keySetIdToRestore;
+    }
+
+    @Override
+    public DrmSession<FrameworkMediaCrypto> acquireSession(Looper playbackLooper, DrmInitData drmInitData) {
+        try {
+            state = STATE_OPENING;
+            sessionId = mediaDrm.openSession();
+            mediaCrypto = mediaDrm.createMediaCrypto(WIDEVINE_MODULAR_UUID, sessionId);
+            state = STATE_OPENED;
+
+            mediaDrm.restoreKeys(sessionId, keySetIdToRestore);
+            state = STATE_OPENED_WITH_KEYS;
+        } catch (MediaDrmException | MediaCryptoException e) {
+            onError(e);
+        }
+        return this;
+    }
+
+    @Override
+    public void releaseSession(DrmSession<FrameworkMediaCrypto> drmSession) {
+        if (sessionId != null) {
+            mediaDrm.closeSession(sessionId);
+            sessionId = null;
+        }
+    }
+
+    private void onError(Exception e) {
+        state = STATE_ERROR;
+        lastKnownException = e;
+    }
+}

--- a/core/src/main/java/com/novoda/noplayer/drm/LocalDrmSession.java
+++ b/core/src/main/java/com/novoda/noplayer/drm/LocalDrmSession.java
@@ -98,6 +98,7 @@ class LocalDrmSession implements DrmSessionManager<FrameworkMediaCrypto>, DrmSes
     public void releaseSession(DrmSession<FrameworkMediaCrypto> drmSession) {
         if (sessionId != null) {
             mediaDrm.closeSession(sessionId);
+            state = STATE_CLOSED;
             sessionId = null;
         }
     }

--- a/core/src/main/java/com/novoda/noplayer/drm/LocalDrmSession.java
+++ b/core/src/main/java/com/novoda/noplayer/drm/LocalDrmSession.java
@@ -19,7 +19,7 @@ import java.util.Map;
 import java.util.UUID;
 
 @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR2)
-public class LocalDrmSession implements DrmSessionManager<FrameworkMediaCrypto>, DrmSession<FrameworkMediaCrypto> {
+class LocalDrmSession implements DrmSessionManager<FrameworkMediaCrypto>, DrmSession<FrameworkMediaCrypto> {
 
     private static final UUID WIDEVINE_MODULAR_UUID = new UUID(0xEDEF8BA979D64ACEL, 0xA3C827DCD51D21EDL);
 
@@ -31,7 +31,7 @@ public class LocalDrmSession implements DrmSessionManager<FrameworkMediaCrypto>,
     private FrameworkMediaCrypto mediaCrypto;
     private Exception lastKnownException;
 
-    public LocalDrmSession(byte[] keySetIdToRestore) throws UnsupportedDrmException {
+    LocalDrmSession(byte[] keySetIdToRestore) throws UnsupportedDrmException {
         this.keySetIdToRestore = Arrays.copyOf(keySetIdToRestore, keySetIdToRestore.length);
         this.mediaDrm = FrameworkMediaDrm.newInstance(WIDEVINE_MODULAR_UUID);
     }

--- a/core/src/main/java/com/novoda/noplayer/drm/LocalDrmSession.java
+++ b/core/src/main/java/com/novoda/noplayer/drm/LocalDrmSession.java
@@ -43,15 +43,19 @@ class LocalDrmSession implements DrmSessionManager<FrameworkMediaCrypto>, DrmSes
 
     @Override
     public FrameworkMediaCrypto getMediaCrypto() {
-        if (state != STATE_OPENED && state != STATE_OPENED_WITH_KEYS) {
+        if (notInSession()) {
             throw new IllegalStateException();
         }
         return mediaCrypto;
     }
 
+    private boolean notInSession() {
+        return state != STATE_OPENED && state != STATE_OPENED_WITH_KEYS;
+    }
+
     @Override
     public boolean requiresSecureDecoderComponent(String mimeType) {
-        if (state != STATE_OPENED && state != STATE_OPENED_WITH_KEYS) {
+        if (notInSession()) {
             throw new IllegalStateException();
         }
         return mediaCrypto.requiresSecureDecoderComponent(mimeType);

--- a/core/src/main/java/com/novoda/noplayer/drm/NoDrmSessionCreator.java
+++ b/core/src/main/java/com/novoda/noplayer/drm/NoDrmSessionCreator.java
@@ -1,5 +1,12 @@
 package com.novoda.noplayer.drm;
 
+import com.google.android.exoplayer2.drm.DefaultDrmSessionManager;
+import com.google.android.exoplayer2.drm.FrameworkMediaCrypto;
+
 public class NoDrmSessionCreator implements DrmSessionCreator {
 
+    @Override
+    public DefaultDrmSessionManager<FrameworkMediaCrypto> create() {
+        return null;
+    }
 }

--- a/core/src/main/java/com/novoda/noplayer/drm/NoDrmSessionCreator.java
+++ b/core/src/main/java/com/novoda/noplayer/drm/NoDrmSessionCreator.java
@@ -1,12 +1,12 @@
 package com.novoda.noplayer.drm;
 
-import com.google.android.exoplayer2.drm.DefaultDrmSessionManager;
+import com.google.android.exoplayer2.drm.DrmSessionManager;
 import com.google.android.exoplayer2.drm.FrameworkMediaCrypto;
 
 public class NoDrmSessionCreator implements DrmSessionCreator {
 
     @Override
-    public DefaultDrmSessionManager<FrameworkMediaCrypto> create() {
+    public DrmSessionManager<FrameworkMediaCrypto> create() {
         return null;
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/drm/ProvisioningModularDrmCallback.java
+++ b/core/src/main/java/com/novoda/noplayer/drm/ProvisioningModularDrmCallback.java
@@ -1,12 +1,14 @@
 package com.novoda.noplayer.drm;
 
-import android.media.MediaDrm;
-
+import com.google.android.exoplayer2.drm.ExoMediaDrm;
+import com.google.android.exoplayer2.drm.MediaDrmCallback;
+import com.novoda.noplayer.drm.provision.ModularDrmKeyRequest;
+import com.novoda.noplayer.drm.provision.ModularDrmProvisionRequest;
 import com.novoda.noplayer.drm.provision.ProvisionExecutor;
 
 import java.util.UUID;
 
-public class ProvisioningModularDrmCallback {
+public class ProvisioningModularDrmCallback implements MediaDrmCallback {
 
     private final StreamingModularDrm streamingModularDrm;
     private final ProvisionExecutor provisionExecutor;
@@ -16,11 +18,14 @@ public class ProvisioningModularDrmCallback {
         this.provisionExecutor = provisionExecutor;
     }
 
-    public byte[] executeProvisionRequest(UUID uuid, MediaDrm.ProvisionRequest request) throws Exception {
-        return provisionExecutor.execute(request);
+    @Override
+    public byte[] executeProvisionRequest(UUID uuid, ExoMediaDrm.ProvisionRequest request) throws Exception {
+        ModularDrmProvisionRequest provisionRequest = new ModularDrmProvisionRequest(request.getDefaultUrl(), request.getData());
+        return provisionExecutor.execute(provisionRequest);
     }
 
-    public byte[] executeKeyRequest(UUID uuid, MediaDrm.KeyRequest request) throws Exception {
-        return streamingModularDrm.executeKeyRequest(request);
+    @Override
+    public byte[] executeKeyRequest(UUID uuid, ExoMediaDrm.KeyRequest request) throws Exception {
+        return streamingModularDrm.executeKeyRequest(new ModularDrmKeyRequest(request.getDefaultUrl(), request.getData()));
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/drm/StreamingDrmSessionCreator.java
+++ b/core/src/main/java/com/novoda/noplayer/drm/StreamingDrmSessionCreator.java
@@ -4,6 +4,7 @@ import android.os.Handler;
 import android.os.Looper;
 
 import com.google.android.exoplayer2.drm.DefaultDrmSessionManager;
+import com.google.android.exoplayer2.drm.DrmSessionManager;
 import com.google.android.exoplayer2.drm.FrameworkMediaCrypto;
 import com.google.android.exoplayer2.drm.FrameworkMediaDrm;
 import com.google.android.exoplayer2.drm.MediaDrmCallback;
@@ -22,7 +23,7 @@ public class StreamingDrmSessionCreator implements DrmSessionCreator {
     }
 
     @Override
-    public DefaultDrmSessionManager<FrameworkMediaCrypto> create() {
+    public DrmSessionManager<FrameworkMediaCrypto> create() {
         Looper eventLooper = Looper.myLooper() != null ? Looper.myLooper() : Looper.getMainLooper();
         Handler mainHandler = new Handler(eventLooper);
         try {

--- a/core/src/main/java/com/novoda/noplayer/drm/StreamingDrmSessionCreator.java
+++ b/core/src/main/java/com/novoda/noplayer/drm/StreamingDrmSessionCreator.java
@@ -15,7 +15,7 @@ import java.util.UUID;
 public class StreamingDrmSessionCreator implements DrmSessionCreator {
 
     private static final UUID WIDEVINE_MODULAR_UUID = new UUID(0xEDEF8BA979D64ACEL, 0xA3C827DCD51D21EDL);
-    private static final HashMap<String, String> NO_OPTIONAL_PARAMETERS = null;
+    private static final HashMap<String, String> NO_OPTIONAL_PARAMETERS = new HashMap<>();
     private static final DefaultDrmSessionManager.EventListener TODO_ERROR_EVENT_LISTENER = null;
 
     private final MediaDrmCallback mediaDrmCallback;

--- a/core/src/main/java/com/novoda/noplayer/drm/StreamingDrmSessionCreator.java
+++ b/core/src/main/java/com/novoda/noplayer/drm/StreamingDrmSessionCreator.java
@@ -20,17 +20,22 @@ public class StreamingDrmSessionCreator implements DrmSessionCreator {
 
     private final MediaDrmCallback mediaDrmCallback;
     private final FrameworkMediaDrmCreator frameworkMediaDrmCreator;
+    private final Handler handler;
 
-    public StreamingDrmSessionCreator(MediaDrmCallback mediaDrmCallback, FrameworkMediaDrmCreator frameworkMediaDrmCreator) {
+    public static StreamingDrmSessionCreator newInstance(MediaDrmCallback mediaDrmCallback, FrameworkMediaDrmCreator frameworkMediaDrmCreator) {
+        Looper eventLooper = Looper.myLooper() != null ? Looper.myLooper() : Looper.getMainLooper();
+        Handler handler = new Handler(eventLooper);
+        return new StreamingDrmSessionCreator(mediaDrmCallback, frameworkMediaDrmCreator, handler);
+    }
+
+    private StreamingDrmSessionCreator(MediaDrmCallback mediaDrmCallback, FrameworkMediaDrmCreator frameworkMediaDrmCreator, Handler handler) {
         this.mediaDrmCallback = mediaDrmCallback;
         this.frameworkMediaDrmCreator = frameworkMediaDrmCreator;
+        this.handler = handler;
     }
 
     @Override
     public DrmSessionManager<FrameworkMediaCrypto> create() {
-        Looper eventLooper = Looper.myLooper() != null ? Looper.myLooper() : Looper.getMainLooper();
-        Handler mainHandler = new Handler(eventLooper);
-
         FrameworkMediaDrm frameworkMediaDrm = frameworkMediaDrmCreator.create(WIDEVINE_MODULAR_UUID);
 
         return new DefaultDrmSessionManager<>(
@@ -38,7 +43,7 @@ public class StreamingDrmSessionCreator implements DrmSessionCreator {
                 frameworkMediaDrm,
                 mediaDrmCallback,
                 NO_OPTIONAL_PARAMETERS,
-                mainHandler,
+                handler,
                 TODO_ERROR_EVENT_LISTENER
         );
     }

--- a/core/src/main/java/com/novoda/noplayer/drm/StreamingDrmSessionCreator.java
+++ b/core/src/main/java/com/novoda/noplayer/drm/StreamingDrmSessionCreator.java
@@ -1,0 +1,42 @@
+package com.novoda.noplayer.drm;
+
+import android.os.Handler;
+import android.os.Looper;
+
+import com.google.android.exoplayer2.drm.DefaultDrmSessionManager;
+import com.google.android.exoplayer2.drm.FrameworkMediaCrypto;
+import com.google.android.exoplayer2.drm.FrameworkMediaDrm;
+import com.google.android.exoplayer2.drm.MediaDrmCallback;
+import com.google.android.exoplayer2.drm.UnsupportedDrmException;
+
+import java.util.UUID;
+
+public class StreamingDrmSessionCreator implements DrmSessionCreator {
+
+    private static final UUID WIDEVINE_MODULAR_UUID = new UUID(0xEDEF8BA979D64ACEL, 0xA3C827DCD51D21EDL);
+
+    private final MediaDrmCallback mediaDrmCallback;
+
+    public StreamingDrmSessionCreator(MediaDrmCallback mediaDrmCallback) {
+        this.mediaDrmCallback = mediaDrmCallback;
+    }
+
+    @Override
+    public DefaultDrmSessionManager<FrameworkMediaCrypto> create() {
+        Looper eventLooper = Looper.myLooper() != null ? Looper.myLooper() : Looper.getMainLooper();
+        Handler mainHandler = new Handler(eventLooper);
+        try {
+            FrameworkMediaDrm frameworkMediaDrm = FrameworkMediaDrm.newInstance(WIDEVINE_MODULAR_UUID);
+            return new DefaultDrmSessionManager<>(
+                    WIDEVINE_MODULAR_UUID,
+                    frameworkMediaDrm,
+                    mediaDrmCallback,
+                    null,
+                    mainHandler,
+                    null
+            );
+        } catch (UnsupportedDrmException e) {
+            throw new RuntimeException();
+        }
+    }
+}

--- a/core/src/main/java/com/novoda/noplayer/drm/StreamingDrmSessionCreator.java
+++ b/core/src/main/java/com/novoda/noplayer/drm/StreamingDrmSessionCreator.java
@@ -8,7 +8,6 @@ import com.google.android.exoplayer2.drm.DrmSessionManager;
 import com.google.android.exoplayer2.drm.FrameworkMediaCrypto;
 import com.google.android.exoplayer2.drm.FrameworkMediaDrm;
 import com.google.android.exoplayer2.drm.MediaDrmCallback;
-import com.google.android.exoplayer2.drm.UnsupportedDrmException;
 
 import java.util.HashMap;
 import java.util.UUID;
@@ -20,27 +19,27 @@ public class StreamingDrmSessionCreator implements DrmSessionCreator {
     private static final DefaultDrmSessionManager.EventListener TODO_ERROR_EVENT_LISTENER = null;
 
     private final MediaDrmCallback mediaDrmCallback;
+    private final FrameworkMediaDrmCreator frameworkMediaDrmCreator;
 
-    public StreamingDrmSessionCreator(MediaDrmCallback mediaDrmCallback) {
+    public StreamingDrmSessionCreator(MediaDrmCallback mediaDrmCallback, FrameworkMediaDrmCreator frameworkMediaDrmCreator) {
         this.mediaDrmCallback = mediaDrmCallback;
+        this.frameworkMediaDrmCreator = frameworkMediaDrmCreator;
     }
 
     @Override
     public DrmSessionManager<FrameworkMediaCrypto> create() {
         Looper eventLooper = Looper.myLooper() != null ? Looper.myLooper() : Looper.getMainLooper();
         Handler mainHandler = new Handler(eventLooper);
-        try {
-            FrameworkMediaDrm frameworkMediaDrm = FrameworkMediaDrm.newInstance(WIDEVINE_MODULAR_UUID);
-            return new DefaultDrmSessionManager<>(
-                    WIDEVINE_MODULAR_UUID,
-                    frameworkMediaDrm,
-                    mediaDrmCallback,
-                    NO_OPTIONAL_PARAMETERS,
-                    mainHandler,
-                    TODO_ERROR_EVENT_LISTENER
-            );
-        } catch (UnsupportedDrmException e) {
-            throw new RuntimeException();
-        }
+
+        FrameworkMediaDrm frameworkMediaDrm = frameworkMediaDrmCreator.create(WIDEVINE_MODULAR_UUID);
+
+        return new DefaultDrmSessionManager<>(
+                WIDEVINE_MODULAR_UUID,
+                frameworkMediaDrm,
+                mediaDrmCallback,
+                NO_OPTIONAL_PARAMETERS,
+                mainHandler,
+                TODO_ERROR_EVENT_LISTENER
+        );
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/drm/StreamingDrmSessionCreator.java
+++ b/core/src/main/java/com/novoda/noplayer/drm/StreamingDrmSessionCreator.java
@@ -10,11 +10,14 @@ import com.google.android.exoplayer2.drm.FrameworkMediaDrm;
 import com.google.android.exoplayer2.drm.MediaDrmCallback;
 import com.google.android.exoplayer2.drm.UnsupportedDrmException;
 
+import java.util.HashMap;
 import java.util.UUID;
 
 public class StreamingDrmSessionCreator implements DrmSessionCreator {
 
     private static final UUID WIDEVINE_MODULAR_UUID = new UUID(0xEDEF8BA979D64ACEL, 0xA3C827DCD51D21EDL);
+    private static final HashMap<String, String> NO_OPTIONAL_PARAMETERS = null;
+    private static final DefaultDrmSessionManager.EventListener TODO_ERROR_EVENT_LISTENER = null;
 
     private final MediaDrmCallback mediaDrmCallback;
 
@@ -32,9 +35,9 @@ public class StreamingDrmSessionCreator implements DrmSessionCreator {
                     WIDEVINE_MODULAR_UUID,
                     frameworkMediaDrm,
                     mediaDrmCallback,
-                    null,
+                    NO_OPTIONAL_PARAMETERS,
                     mainHandler,
-                    null
+                    TODO_ERROR_EVENT_LISTENER
             );
         } catch (UnsupportedDrmException e) {
             throw new RuntimeException();

--- a/core/src/main/java/com/novoda/noplayer/drm/StreamingModularDrm.java
+++ b/core/src/main/java/com/novoda/noplayer/drm/StreamingModularDrm.java
@@ -1,8 +1,8 @@
 package com.novoda.noplayer.drm;
 
-import android.media.MediaDrm;
+import com.novoda.noplayer.drm.provision.ModularDrmKeyRequest;
 
 public interface StreamingModularDrm extends DrmHandler {
 
-    byte[] executeKeyRequest(MediaDrm.KeyRequest request) throws DrmRequestException;
+    byte[] executeKeyRequest(ModularDrmKeyRequest request) throws DrmRequestException;
 }

--- a/core/src/main/java/com/novoda/noplayer/drm/provision/ModularDrmKeyRequest.java
+++ b/core/src/main/java/com/novoda/noplayer/drm/provision/ModularDrmKeyRequest.java
@@ -10,11 +10,11 @@ public class ModularDrmKeyRequest {
         this.data = data;
     }
 
-    public String getUrl() {
+    public String url() {
         return url;
     }
 
-    public byte[] getData() {
+    public byte[] data() {
         return data;
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/drm/provision/ModularDrmKeyRequest.java
+++ b/core/src/main/java/com/novoda/noplayer/drm/provision/ModularDrmKeyRequest.java
@@ -1,0 +1,20 @@
+package com.novoda.noplayer.drm.provision;
+
+public class ModularDrmKeyRequest {
+
+    private final String url;
+    private final byte[] data;
+
+    public ModularDrmKeyRequest(String url, byte[] data) {
+        this.url = url;
+        this.data = data;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public byte[] getData() {
+        return data;
+    }
+}

--- a/core/src/main/java/com/novoda/noplayer/drm/provision/ModularDrmKeyRequest.java
+++ b/core/src/main/java/com/novoda/noplayer/drm/provision/ModularDrmKeyRequest.java
@@ -1,5 +1,7 @@
 package com.novoda.noplayer.drm.provision;
 
+import java.util.Arrays;
+
 public class ModularDrmKeyRequest {
 
     private final String url;
@@ -16,5 +18,37 @@ public class ModularDrmKeyRequest {
 
     public byte[] data() {
         return data;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        ModularDrmKeyRequest that = (ModularDrmKeyRequest) o;
+
+        if (url != null ? !url.equals(that.url) : that.url != null) {
+            return false;
+        }
+        return Arrays.equals(data, that.data);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = url != null ? url.hashCode() : 0;
+        result = 31 * result + Arrays.hashCode(data);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "ModularDrmKeyRequest{" +
+                "url='" + url + '\'' +
+                ", data=" + Arrays.toString(data) +
+                '}';
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/drm/provision/ModularDrmProvisionRequest.java
+++ b/core/src/main/java/com/novoda/noplayer/drm/provision/ModularDrmProvisionRequest.java
@@ -1,5 +1,7 @@
 package com.novoda.noplayer.drm.provision;
 
+import java.util.Arrays;
+
 public class ModularDrmProvisionRequest {
 
     private final String url;
@@ -10,11 +12,43 @@ public class ModularDrmProvisionRequest {
         this.data = data;
     }
 
-    public String getUrl() {
+    public String url() {
         return url;
     }
 
-    public byte[] getData() {
+    public byte[] data() {
         return data;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        ModularDrmProvisionRequest that = (ModularDrmProvisionRequest) o;
+
+        if (url != null ? !url.equals(that.url) : that.url != null) {
+            return false;
+        }
+        return Arrays.equals(data, that.data);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = url != null ? url.hashCode() : 0;
+        result = 31 * result + Arrays.hashCode(data);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "ModularDrmProvisionRequest{" +
+                "url='" + url + '\'' +
+                ", data=" + Arrays.toString(data) +
+                '}';
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/drm/provision/ModularDrmProvisionRequest.java
+++ b/core/src/main/java/com/novoda/noplayer/drm/provision/ModularDrmProvisionRequest.java
@@ -1,0 +1,20 @@
+package com.novoda.noplayer.drm.provision;
+
+public class ModularDrmProvisionRequest {
+
+    private final String url;
+    private final byte[] data;
+
+    public ModularDrmProvisionRequest(String url, byte[] data) {
+        this.url = url;
+        this.data = data;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public byte[] getData() {
+        return data;
+    }
+}

--- a/core/src/main/java/com/novoda/noplayer/drm/provision/ProvisionExecutor.java
+++ b/core/src/main/java/com/novoda/noplayer/drm/provision/ProvisionExecutor.java
@@ -38,6 +38,6 @@ public class ProvisionExecutor {
 
     @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR2)
     private String buildProvisioningUrl(ModularDrmProvisionRequest request) {
-        return request.getUrl() + PARAMETER_SIGNED_REQUEST + new String(request.getData(), Charset.forName("UTF-8"));
+        return request.url() + PARAMETER_SIGNED_REQUEST + new String(request.data(), Charset.forName("UTF-8"));
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/drm/provision/ProvisionExecutor.java
+++ b/core/src/main/java/com/novoda/noplayer/drm/provision/ProvisionExecutor.java
@@ -1,7 +1,6 @@
 package com.novoda.noplayer.drm.provision;
 
 import android.annotation.TargetApi;
-import android.media.MediaDrm;
 import android.os.Build;
 
 import java.io.IOException;
@@ -25,7 +24,7 @@ public class ProvisionExecutor {
         this.capabilities = capabilities;
     }
 
-    public byte[] execute(MediaDrm.ProvisionRequest request) throws IOException, UnableToProvisionException {
+    public byte[] execute(ModularDrmProvisionRequest request) throws IOException, UnableToProvisionException {
         if (isIncapabaleOfProvisioning()) {
             throw new UnableToProvisionException();
         }
@@ -38,7 +37,7 @@ public class ProvisionExecutor {
     }
 
     @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR2)
-    private String buildProvisioningUrl(MediaDrm.ProvisionRequest request) {
-        return request.getDefaultUrl() + PARAMETER_SIGNED_REQUEST + new String(request.getData(), Charset.forName("UTF-8"));
+    private String buildProvisioningUrl(ModularDrmProvisionRequest request) {
+        return request.getUrl() + PARAMETER_SIGNED_REQUEST + new String(request.getData(), Charset.forName("UTF-8"));
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/exoplayer/ExoPlayerCreator.java
+++ b/core/src/main/java/com/novoda/noplayer/exoplayer/ExoPlayerCreator.java
@@ -7,6 +7,7 @@ import com.google.android.exoplayer2.DefaultRenderersFactory;
 import com.google.android.exoplayer2.ExoPlayerFactory;
 import com.google.android.exoplayer2.SimpleExoPlayer;
 import com.google.android.exoplayer2.trackselection.DefaultTrackSelector;
+import com.novoda.noplayer.drm.DrmSessionCreator;
 
 class ExoPlayerCreator {
 
@@ -18,8 +19,8 @@ class ExoPlayerCreator {
         this.trackSelector = trackSelector;
     }
 
-    public SimpleExoPlayer create() {
-        DefaultRenderersFactory renderersFactory = new DefaultRenderersFactory(context);
+    public SimpleExoPlayer create(DrmSessionCreator drmSessionCreator) {
+        DefaultRenderersFactory renderersFactory = new DefaultRenderersFactory(context, drmSessionCreator.create());
         DefaultLoadControl loadControl = new DefaultLoadControl();
         return ExoPlayerFactory.newSimpleInstance(renderersFactory, trackSelector, loadControl);
     }

--- a/core/src/main/java/com/novoda/noplayer/exoplayer/ExoPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/exoplayer/ExoPlayerFacade.java
@@ -10,6 +10,7 @@ import com.novoda.noplayer.ContentType;
 import com.novoda.noplayer.PlayerAudioTrack;
 import com.novoda.noplayer.VideoDuration;
 import com.novoda.noplayer.VideoPosition;
+import com.novoda.noplayer.drm.DrmSessionCreator;
 import com.novoda.noplayer.exoplayer.forwarder.ExoPlayerForwarder;
 import com.novoda.noplayer.exoplayer.mediasource.ExoPlayerAudioTrackSelector;
 import com.novoda.noplayer.exoplayer.mediasource.MediaSourceFactory;
@@ -93,8 +94,8 @@ class ExoPlayerFacade {
         }
     }
 
-    public void loadVideo(Uri uri, ContentType contentType, ExoPlayerForwarder forwarder) {
-        exoPlayer = exoPlayerCreator.create();
+    public void loadVideo(DrmSessionCreator drmSessionCreator, Uri uri, ContentType contentType, ExoPlayerForwarder forwarder) {
+        exoPlayer = exoPlayerCreator.create(drmSessionCreator);
         exoPlayer.addListener(forwarder.exoPlayerEventListener());
         exoPlayer.setVideoDebugListener(forwarder.videoRendererEventListener());
         MediaSource mediaSource = mediaSourceFactory.create(

--- a/core/src/main/java/com/novoda/noplayer/exoplayer/ExoPlayerTwoImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/exoplayer/ExoPlayerTwoImpl.java
@@ -39,7 +39,8 @@ public class ExoPlayerTwoImpl implements Player {
                      PlayerListenersHolder listenersHolder,
                      ExoPlayerForwarder exoPlayerForwarder,
                      LoadTimeout loadTimeoutParam,
-                     Heart heart, DrmSessionCreator drmSessionCreator) {
+                     Heart heart,
+                     DrmSessionCreator drmSessionCreator) {
         this.exoPlayer = exoPlayer;
         this.listenersHolder = listenersHolder;
         this.loadTimeout = loadTimeoutParam;

--- a/core/src/main/java/com/novoda/noplayer/exoplayer/ExoPlayerTwoImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/exoplayer/ExoPlayerTwoImpl.java
@@ -22,6 +22,7 @@ import com.novoda.noplayer.SystemClock;
 import com.novoda.noplayer.Timeout;
 import com.novoda.noplayer.VideoDuration;
 import com.novoda.noplayer.VideoPosition;
+import com.novoda.noplayer.drm.DrmSessionCreator;
 import com.novoda.noplayer.exoplayer.forwarder.ExoPlayerForwarder;
 import com.novoda.noplayer.exoplayer.mediasource.ExoPlayerAudioTrackSelector;
 import com.novoda.noplayer.exoplayer.mediasource.ExoPlayerTrackSelector;
@@ -37,13 +38,14 @@ public class ExoPlayerTwoImpl implements Player {
     private final ExoPlayerForwarder forwarder;
     private final Heart heart;
     private final LoadTimeout loadTimeout;
+    private final DrmSessionCreator drmSessionCreator;
 
     private SurfaceHolderRequester surfaceHolderRequester;
 
     private int videoWidth;
     private int videoHeight;
 
-    public static ExoPlayerTwoImpl newInstance(Context context) {
+    public static ExoPlayerTwoImpl newInstance(Context context, DrmSessionCreator drmSessionCreator) {
         DefaultDataSourceFactory defaultDataSourceFactory = new DefaultDataSourceFactory(context, "user-agent");
         Handler handler = new Handler(Looper.getMainLooper());
         MediaSourceFactory mediaSourceFactory = new MediaSourceFactory(defaultDataSourceFactory, handler);
@@ -66,7 +68,8 @@ public class ExoPlayerTwoImpl implements Player {
                 listenersHolder,
                 exoPlayerForwarder,
                 loadTimeout,
-                heart
+                heart,
+                drmSessionCreator
         );
     }
 
@@ -74,12 +77,13 @@ public class ExoPlayerTwoImpl implements Player {
                      PlayerListenersHolder listenersHolder,
                      ExoPlayerForwarder exoPlayerForwarder,
                      LoadTimeout loadTimeoutParam,
-                     Heart heart) {
+                     Heart heart, DrmSessionCreator drmSessionCreator) {
         this.exoPlayer = exoPlayer;
         this.listenersHolder = listenersHolder;
         this.loadTimeout = loadTimeoutParam;
         this.forwarder = exoPlayerForwarder;
         this.heart = heart;
+        this.drmSessionCreator = drmSessionCreator;
 
         heart.bind(new Heart.Heartbeat<>(listenersHolder.getHeartbeatCallbacks(), this));
         forwarder.bind(listenersHolder.getPreparedListeners(), this);
@@ -197,7 +201,7 @@ public class ExoPlayerTwoImpl implements Player {
             reset();
         }
         listenersHolder.getPreparedListeners().resetPreparedState();
-        exoPlayer.loadVideo(uri, contentType, forwarder);
+        exoPlayer.loadVideo(drmSessionCreator, uri, contentType, forwarder);
     }
 
     @Override

--- a/core/src/main/java/com/novoda/noplayer/player/DrmSessionCreatorFactory.java
+++ b/core/src/main/java/com/novoda/noplayer/player/DrmSessionCreatorFactory.java
@@ -1,0 +1,35 @@
+package com.novoda.noplayer.player;
+
+import com.novoda.noplayer.drm.DownloadDrmSessionCreator;
+import com.novoda.noplayer.drm.DownloadedModularDrm;
+import com.novoda.noplayer.drm.DrmHandler;
+import com.novoda.noplayer.drm.DrmSessionCreator;
+import com.novoda.noplayer.drm.DrmType;
+import com.novoda.noplayer.drm.FrameworkMediaDrmCreator;
+import com.novoda.noplayer.drm.NoDrmSessionCreator;
+import com.novoda.noplayer.drm.ProvisioningModularDrmCallback;
+import com.novoda.noplayer.drm.StreamingDrmSessionCreator;
+import com.novoda.noplayer.drm.StreamingModularDrm;
+import com.novoda.noplayer.drm.provision.ProvisionExecutor;
+
+class DrmSessionCreatorFactory {
+
+    DrmSessionCreator createFor(DrmType drmType, DrmHandler drmHandler) {
+        switch (drmType) {
+            case NONE:
+            case WIDEVINE_CLASSIC:
+                return new NoDrmSessionCreator();
+            case WIDEVINE_MODULAR_STREAM:
+                ProvisionExecutor provisionExecutor = ProvisionExecutor.newInstance();
+                ProvisioningModularDrmCallback mediaDrmCallback = new ProvisioningModularDrmCallback(
+                        (StreamingModularDrm) drmHandler,
+                        provisionExecutor
+                );
+                return StreamingDrmSessionCreator.newInstance(mediaDrmCallback, new FrameworkMediaDrmCreator());
+            case WIDEVINE_MODULAR_DOWNLOAD:
+                return new DownloadDrmSessionCreator((DownloadedModularDrm) drmHandler);
+            default:
+                throw PlayerFactory.UnableToCreatePlayerException.noDrmHandlerFor(drmType);
+        }
+    }
+}

--- a/core/src/main/java/com/novoda/noplayer/player/PlayerFactory.java
+++ b/core/src/main/java/com/novoda/noplayer/player/PlayerFactory.java
@@ -3,10 +3,15 @@ package com.novoda.noplayer.player;
 import android.content.Context;
 
 import com.novoda.noplayer.Player;
+import com.novoda.noplayer.drm.DownloadedModularDrm;
 import com.novoda.noplayer.drm.DrmHandler;
 import com.novoda.noplayer.drm.DrmSessionCreator;
 import com.novoda.noplayer.drm.DrmType;
 import com.novoda.noplayer.drm.NoDrmSessionCreator;
+import com.novoda.noplayer.drm.ProvisioningModularDrmCallback;
+import com.novoda.noplayer.drm.StreamingDrmSessionCreator;
+import com.novoda.noplayer.drm.StreamingModularDrm;
+import com.novoda.noplayer.drm.provision.ProvisionExecutor;
 import com.novoda.noplayer.exoplayer.ExoPlayerTwoImpl;
 import com.novoda.noplayer.mediaplayer.AndroidMediaPlayerImpl;
 import com.novoda.noplayer.mediaplayer.AndroidMediaPlayerImplFactory;
@@ -47,9 +52,8 @@ public class PlayerFactory {
             case MEDIA_PLAYER:
                 return mediaPlayerCreator.createMediaPlayer(context);
             case EXO_PLAYER:
-                // TODO handle DRM
-                // DrmSessionCreator drmSessionCreator = createDrmSessionCreatorFor(drmType, drmHandler);
-                return exoPlayerCreator.createExoPlayer(context);
+                DrmSessionCreator drmSessionCreator = createDrmSessionCreatorFor(drmType, drmHandler);
+                return exoPlayerCreator.createExoPlayer(context, drmSessionCreator);
             default:
                 throw UnableToCreatePlayerException.unhandledPlayerType(playerType);
         }
@@ -61,12 +65,15 @@ public class PlayerFactory {
             case WIDEVINE_CLASSIC:
                 return new NoDrmSessionCreator();
             case WIDEVINE_MODULAR_STREAM:
-//                ProvisionExecutor provisionExecutor = ProvisionExecutor.newInstance();
-//                ProvisioningModularDrmCallback mediaDrmCallback = new ProvisioningModularDrmCallback((StreamingModularDrm) drmHandler, provisionExecutor);
-//                return new StreamingDrmSessionCreator(mediaDrmCallback);
-                return new NoDrmSessionCreator();
+                ProvisionExecutor provisionExecutor = ProvisionExecutor.newInstance();
+                ProvisioningModularDrmCallback mediaDrmCallback = new ProvisioningModularDrmCallback(
+                        (StreamingModularDrm) drmHandler,
+                        provisionExecutor
+                );
+                return new StreamingDrmSessionCreator(mediaDrmCallback);
             case WIDEVINE_MODULAR_DOWNLOAD:
-//                return new LocalDrmSessionCreator((DownloadedModularDrm) drmHandler);
+                // TODO
+                // return new LocalDrmSessionCreator((DownloadedModularDrm) drmHandler);
                 return new NoDrmSessionCreator();
             default:
                 throw UnableToCreatePlayerException.noDrmHandlerFor(drmType);
@@ -94,8 +101,8 @@ public class PlayerFactory {
 
     static class ExoPlayerCreator {
 
-        Player createExoPlayer(Context context) {
-            return ExoPlayerTwoImpl.newInstance(context);
+        Player createExoPlayer(Context context, DrmSessionCreator drmSessionCreator) {
+            return ExoPlayerTwoImpl.newInstance(context, drmSessionCreator);
         }
     }
 

--- a/core/src/main/java/com/novoda/noplayer/player/PlayerFactory.java
+++ b/core/src/main/java/com/novoda/noplayer/player/PlayerFactory.java
@@ -73,7 +73,7 @@ public class PlayerFactory {
                         (StreamingModularDrm) drmHandler,
                         provisionExecutor
                 );
-                return new StreamingDrmSessionCreator(mediaDrmCallback, new FrameworkMediaDrmCreator());
+                return StreamingDrmSessionCreator.newInstance(mediaDrmCallback, new FrameworkMediaDrmCreator());
             case WIDEVINE_MODULAR_DOWNLOAD:
                 return new DownloadDrmSessionCreator((DownloadedModularDrm) drmHandler);
             default:

--- a/core/src/main/java/com/novoda/noplayer/player/PlayerFactory.java
+++ b/core/src/main/java/com/novoda/noplayer/player/PlayerFactory.java
@@ -8,6 +8,7 @@ import com.novoda.noplayer.drm.DownloadedModularDrm;
 import com.novoda.noplayer.drm.DrmHandler;
 import com.novoda.noplayer.drm.DrmSessionCreator;
 import com.novoda.noplayer.drm.DrmType;
+import com.novoda.noplayer.drm.FrameworkMediaDrmCreator;
 import com.novoda.noplayer.drm.NoDrmSessionCreator;
 import com.novoda.noplayer.drm.ProvisioningModularDrmCallback;
 import com.novoda.noplayer.drm.StreamingDrmSessionCreator;
@@ -72,7 +73,7 @@ public class PlayerFactory {
                         (StreamingModularDrm) drmHandler,
                         provisionExecutor
                 );
-                return new StreamingDrmSessionCreator(mediaDrmCallback);
+                return new StreamingDrmSessionCreator(mediaDrmCallback, new FrameworkMediaDrmCreator());
             case WIDEVINE_MODULAR_DOWNLOAD:
                 return new DownloadDrmSessionCreator((DownloadedModularDrm) drmHandler);
             default:

--- a/core/src/main/java/com/novoda/noplayer/player/PlayerFactory.java
+++ b/core/src/main/java/com/novoda/noplayer/player/PlayerFactory.java
@@ -3,17 +3,9 @@ package com.novoda.noplayer.player;
 import android.content.Context;
 
 import com.novoda.noplayer.Player;
-import com.novoda.noplayer.drm.DownloadDrmSessionCreator;
-import com.novoda.noplayer.drm.DownloadedModularDrm;
 import com.novoda.noplayer.drm.DrmHandler;
 import com.novoda.noplayer.drm.DrmSessionCreator;
 import com.novoda.noplayer.drm.DrmType;
-import com.novoda.noplayer.drm.FrameworkMediaDrmCreator;
-import com.novoda.noplayer.drm.NoDrmSessionCreator;
-import com.novoda.noplayer.drm.ProvisioningModularDrmCallback;
-import com.novoda.noplayer.drm.StreamingDrmSessionCreator;
-import com.novoda.noplayer.drm.StreamingModularDrm;
-import com.novoda.noplayer.drm.provision.ProvisionExecutor;
 import com.novoda.noplayer.exoplayer.ExoPlayerTwoImpl;
 import com.novoda.noplayer.exoplayer.ExoPlayerTwoImplFactory;
 import com.novoda.noplayer.mediaplayer.AndroidMediaPlayerImpl;
@@ -25,16 +17,22 @@ public class PlayerFactory {
     private final PrioritizedPlayerTypes prioritizedPlayerTypes;
     private final ExoPlayerCreator exoPlayerCreator;
     private final MediaPlayerCreator mediaPlayerCreator;
+    private final DrmSessionCreatorFactory drmSessionCreatorFactory;
 
     public PlayerFactory(Context context, PrioritizedPlayerTypes prioritizedPlayerTypes) {
-        this(context, prioritizedPlayerTypes, ExoPlayerCreator.newInstance(), MediaPlayerCreator.newInstance());
+        this(context, prioritizedPlayerTypes, ExoPlayerCreator.newInstance(), MediaPlayerCreator.newInstance(), new DrmSessionCreatorFactory());
     }
 
-    PlayerFactory(Context context, PrioritizedPlayerTypes prioritizedPlayerTypes, ExoPlayerCreator exoPlayerCreator, MediaPlayerCreator mediaPlayerCreator) {
+    PlayerFactory(Context context,
+                  PrioritizedPlayerTypes prioritizedPlayerTypes,
+                  ExoPlayerCreator exoPlayerCreator,
+                  MediaPlayerCreator mediaPlayerCreator,
+                  DrmSessionCreatorFactory drmSessionCreatorFactory) {
         this.context = context;
         this.prioritizedPlayerTypes = prioritizedPlayerTypes;
         this.exoPlayerCreator = exoPlayerCreator;
         this.mediaPlayerCreator = mediaPlayerCreator;
+        this.drmSessionCreatorFactory = drmSessionCreatorFactory;
     }
 
     public Player create() {
@@ -55,29 +53,10 @@ public class PlayerFactory {
             case MEDIA_PLAYER:
                 return mediaPlayerCreator.createMediaPlayer(context);
             case EXO_PLAYER:
-                DrmSessionCreator drmSessionCreator = createDrmSessionCreatorFor(drmType, drmHandler);
+                DrmSessionCreator drmSessionCreator = drmSessionCreatorFactory.createFor(drmType, drmHandler);
                 return exoPlayerCreator.createExoPlayer(context, drmSessionCreator);
             default:
                 throw UnableToCreatePlayerException.unhandledPlayerType(playerType);
-        }
-    }
-
-    private DrmSessionCreator createDrmSessionCreatorFor(DrmType drmType, DrmHandler drmHandler) {
-        switch (drmType) {
-            case NONE:
-            case WIDEVINE_CLASSIC:
-                return new NoDrmSessionCreator();
-            case WIDEVINE_MODULAR_STREAM:
-                ProvisionExecutor provisionExecutor = ProvisionExecutor.newInstance();
-                ProvisioningModularDrmCallback mediaDrmCallback = new ProvisioningModularDrmCallback(
-                        (StreamingModularDrm) drmHandler,
-                        provisionExecutor
-                );
-                return StreamingDrmSessionCreator.newInstance(mediaDrmCallback, new FrameworkMediaDrmCreator());
-            case WIDEVINE_MODULAR_DOWNLOAD:
-                return new DownloadDrmSessionCreator((DownloadedModularDrm) drmHandler);
-            default:
-                throw UnableToCreatePlayerException.noDrmHandlerFor(drmType);
         }
     }
 

--- a/core/src/main/java/com/novoda/noplayer/player/PlayerFactory.java
+++ b/core/src/main/java/com/novoda/noplayer/player/PlayerFactory.java
@@ -3,6 +3,7 @@ package com.novoda.noplayer.player;
 import android.content.Context;
 
 import com.novoda.noplayer.Player;
+import com.novoda.noplayer.drm.DownloadDrmSessionCreator;
 import com.novoda.noplayer.drm.DownloadedModularDrm;
 import com.novoda.noplayer.drm.DrmHandler;
 import com.novoda.noplayer.drm.DrmSessionCreator;
@@ -72,9 +73,7 @@ public class PlayerFactory {
                 );
                 return new StreamingDrmSessionCreator(mediaDrmCallback);
             case WIDEVINE_MODULAR_DOWNLOAD:
-                // TODO
-                // return new LocalDrmSessionCreator((DownloadedModularDrm) drmHandler);
-                return new NoDrmSessionCreator();
+                return new DownloadDrmSessionCreator((DownloadedModularDrm) drmHandler);
             default:
                 throw UnableToCreatePlayerException.noDrmHandlerFor(drmType);
         }

--- a/core/src/test/java/com/novoda/noplayer/drm/provision/ProvisionExecutorTest.java
+++ b/core/src/test/java/com/novoda/noplayer/drm/provision/ProvisionExecutorTest.java
@@ -1,7 +1,5 @@
 package com.novoda.noplayer.drm.provision;
 
-import android.media.MediaDrm;
-
 import java.io.IOException;
 
 import org.junit.Before;
@@ -32,7 +30,7 @@ public class ProvisionExecutorTest {
     HttpPoster httpPoster;
 
     @Mock
-    MediaDrm.ProvisionRequest provisionRequest;
+    ModularDrmProvisionRequest provisionRequest;
 
     @Mock
     ProvisioningCapabilities capabilities;
@@ -41,7 +39,7 @@ public class ProvisionExecutorTest {
     public void setUp() {
         provisionUrlCaptor = ArgumentCaptor.forClass(String.class);
         when(provisionRequest.getData()).thenReturn(PROVISION_DATA);
-        when(provisionRequest.getDefaultUrl()).thenReturn(PROVISION_URL);
+        when(provisionRequest.getUrl()).thenReturn(PROVISION_URL);
 
         provisionExecutor = new ProvisionExecutor(httpPoster, capabilities);
     }

--- a/core/src/test/java/com/novoda/noplayer/drm/provision/ProvisionExecutorTest.java
+++ b/core/src/test/java/com/novoda/noplayer/drm/provision/ProvisionExecutorTest.java
@@ -38,8 +38,8 @@ public class ProvisionExecutorTest {
     @Before
     public void setUp() {
         provisionUrlCaptor = ArgumentCaptor.forClass(String.class);
-        when(provisionRequest.getData()).thenReturn(PROVISION_DATA);
-        when(provisionRequest.getUrl()).thenReturn(PROVISION_URL);
+        when(provisionRequest.data()).thenReturn(PROVISION_DATA);
+        when(provisionRequest.url()).thenReturn(PROVISION_URL);
 
         provisionExecutor = new ProvisionExecutor(httpPoster, capabilities);
     }

--- a/core/src/test/java/com/novoda/noplayer/exoplayer/ExoPlayerFacadeTest.java
+++ b/core/src/test/java/com/novoda/noplayer/exoplayer/ExoPlayerFacadeTest.java
@@ -9,6 +9,7 @@ import com.novoda.noplayer.ContentType;
 import com.novoda.noplayer.PlayerAudioTrack;
 import com.novoda.noplayer.VideoDuration;
 import com.novoda.noplayer.VideoPosition;
+import com.novoda.noplayer.drm.DrmSessionCreator;
 import com.novoda.noplayer.exoplayer.forwarder.ExoPlayerForwarder;
 import com.novoda.noplayer.exoplayer.mediasource.ExoPlayerAudioTrackSelector;
 import com.novoda.noplayer.exoplayer.mediasource.MediaSourceFactory;
@@ -72,7 +73,7 @@ public class ExoPlayerFacadeTest {
         @Test
         public void whenLoadingVideo_thenAddsPlayerEventListener() {
 
-            facade.loadVideo(uri, ANY_CONTENT_TYPE, exoPlayerForwarder);
+            facade.loadVideo(drmSessionCreator, uri, ANY_CONTENT_TYPE, exoPlayerForwarder);
 
             verify(exoPlayer).addListener(exoPlayerForwarder.exoPlayerEventListener());
         }
@@ -80,7 +81,7 @@ public class ExoPlayerFacadeTest {
         @Test
         public void whenLoadingVideo_thenSetsVideoDebugListener() {
 
-            facade.loadVideo(uri, ANY_CONTENT_TYPE, exoPlayerForwarder);
+            facade.loadVideo(drmSessionCreator, uri, ANY_CONTENT_TYPE, exoPlayerForwarder);
 
             verify(exoPlayer).setVideoDebugListener(exoPlayerForwarder.videoRendererEventListener());
         }
@@ -89,7 +90,7 @@ public class ExoPlayerFacadeTest {
         public void givenMediaSource_whenLoadingVideo_thenPreparesInternalExoPlayer() {
             MediaSource mediaSource = givenMediaSource();
 
-            facade.loadVideo(uri, ANY_CONTENT_TYPE, exoPlayerForwarder);
+            facade.loadVideo(drmSessionCreator, uri, ANY_CONTENT_TYPE, exoPlayerForwarder);
 
             verify(exoPlayer).prepare(mediaSource, RESET_POSITION, DO_NOT_RESET_STATE);
         }
@@ -173,7 +174,7 @@ public class ExoPlayerFacadeTest {
 
         private void givenPlayerIsLoaded() {
             givenMediaSource();
-            facade.loadVideo(uri, ANY_CONTENT_TYPE, exoPlayerForwarder);
+            facade.loadVideo(drmSessionCreator, uri, ANY_CONTENT_TYPE, exoPlayerForwarder);
         }
 
         @Test
@@ -293,6 +294,8 @@ public class ExoPlayerFacadeTest {
         @Mock
         ExoPlayerAudioTrackSelector trackSelector;
         @Mock
+        DrmSessionCreator drmSessionCreator;
+        @Mock
         Uri uri;
         @Mock
         SurfaceHolder surfaceHolder;
@@ -302,7 +305,7 @@ public class ExoPlayerFacadeTest {
         @Before
         public void setUp() {
             ExoPlayerCreator exoPlayerCreator = mock(ExoPlayerCreator.class);
-            given(exoPlayerCreator.create()).willReturn(exoPlayer);
+            given(exoPlayerCreator.create(drmSessionCreator)).willReturn(exoPlayer);
             facade = new ExoPlayerFacade(
                     mediaSourceFactory,
                     trackSelector,

--- a/core/src/test/java/com/novoda/noplayer/exoplayer/ExoPlayerTwoImplTest.java
+++ b/core/src/test/java/com/novoda/noplayer/exoplayer/ExoPlayerTwoImplTest.java
@@ -14,6 +14,7 @@ import com.novoda.noplayer.PlayerView;
 import com.novoda.noplayer.SurfaceHolderRequester;
 import com.novoda.noplayer.Timeout;
 import com.novoda.noplayer.VideoPosition;
+import com.novoda.noplayer.drm.DrmSessionCreator;
 import com.novoda.noplayer.exoplayer.forwarder.ExoPlayerForwarder;
 import com.novoda.noplayer.listeners.BitrateChangedListeners;
 import com.novoda.noplayer.listeners.BufferStateListeners;
@@ -171,7 +172,7 @@ public class ExoPlayerTwoImplTest {
 
             player.loadVideo(uri, ANY_CONTENT_TYPE);
 
-            verify(exoPlayerFacade).loadVideo(uri, ANY_CONTENT_TYPE, forwarder);
+            verify(exoPlayerFacade).loadVideo(drmSessionCreator, uri, ANY_CONTENT_TYPE, forwarder);
         }
 
         @Test
@@ -179,7 +180,7 @@ public class ExoPlayerTwoImplTest {
 
             player.loadVideoWithTimeout(uri, ANY_CONTENT_TYPE, ANY_TIMEOUT, ANY_LOAD_TIMEOUT_CALLBACK);
 
-            verify(exoPlayerFacade).loadVideo(uri, ANY_CONTENT_TYPE, forwarder);
+            verify(exoPlayerFacade).loadVideo(drmSessionCreator, uri, ANY_CONTENT_TYPE, forwarder);
         }
 
         @Test
@@ -467,6 +468,8 @@ public class ExoPlayerTwoImplTest {
         @Mock
         BitrateChangedListeners bitrateChangedListeners;
         @Mock
+        DrmSessionCreator drmSessionCreator;
+        @Mock
         ExoPlayerFacade exoPlayerFacade;
 
         Player player;
@@ -499,7 +502,8 @@ public class ExoPlayerTwoImplTest {
                     listenersHolder,
                     forwarder,
                     loadTimeout,
-                    heart
+                    heart,
+                    drmSessionCreator
             );
         }
     }

--- a/core/src/test/java/com/novoda/noplayer/player/PlayerFactoryTest.java
+++ b/core/src/test/java/com/novoda/noplayer/player/PlayerFactoryTest.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import com.novoda.noplayer.Player;
 import com.novoda.noplayer.drm.DownloadedModularDrm;
 import com.novoda.noplayer.drm.DrmHandler;
+import com.novoda.noplayer.drm.DrmSessionCreator;
 import com.novoda.noplayer.drm.DrmType;
 import com.novoda.noplayer.drm.StreamingModularDrm;
 
@@ -50,7 +51,7 @@ public class PlayerFactoryTest {
 
         @Before
         public void setUp() {
-            given(exoPlayerCreator.createExoPlayer(any(Context.class))).willReturn(EXO_PLAYER);
+            given(exoPlayerCreator.createExoPlayer(any(Context.class), any(DrmSessionCreator.class))).willReturn(EXO_PLAYER);
             given(mediaPlayerCreator.createMediaPlayer(any(Context.class))).willReturn(MEDIA_PLAYER);
             playerFactory = new PlayerFactory(context, prioritizedPlayerTypes(), exoPlayerCreator, mediaPlayerCreator);
         }

--- a/core/src/test/java/com/novoda/noplayer/player/PlayerFactoryTest.java
+++ b/core/src/test/java/com/novoda/noplayer/player/PlayerFactoryTest.java
@@ -25,6 +25,7 @@ import org.mockito.junit.MockitoRule;
 import static com.novoda.noplayer.player.PrioritizedPlayerTypes.prioritizeExoPlayer;
 import static com.novoda.noplayer.player.PrioritizedPlayerTypes.prioritizeMediaPlayer;
 import static org.fest.assertions.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
@@ -45,20 +46,22 @@ public class PlayerFactoryTest {
 
         @Mock
         Context context;
-
         @Mock
         PlayerFactory.ExoPlayerCreator exoPlayerCreator;
-
         @Mock
         PlayerFactory.MediaPlayerCreator mediaPlayerCreator;
+        @Mock
+        DrmSessionCreatorFactory drmSessionCreatorFactory;
 
         PlayerFactory playerFactory;
 
         @Before
         public void setUp() {
-            given(exoPlayerCreator.createExoPlayer(any(Context.class), any(DrmSessionCreator.class))).willReturn(EXO_PLAYER);
+            DrmSessionCreator drmSessionCreator = mock(DrmSessionCreator.class);
+            given(drmSessionCreatorFactory.createFor(any(DrmType.class), any(DrmHandler.class))).willReturn(drmSessionCreator);
+            given(exoPlayerCreator.createExoPlayer(any(Context.class), eq(drmSessionCreator))).willReturn(EXO_PLAYER);
             given(mediaPlayerCreator.createMediaPlayer(any(Context.class))).willReturn(MEDIA_PLAYER);
-            playerFactory = new PlayerFactory(context, prioritizedPlayerTypes(), exoPlayerCreator, mediaPlayerCreator);
+            playerFactory = new PlayerFactory(context, prioritizedPlayerTypes(), exoPlayerCreator, mediaPlayerCreator, drmSessionCreatorFactory);
         }
 
         abstract PrioritizedPlayerTypes prioritizedPlayerTypes();

--- a/demo/src/main/java/com/novoda/demo/DataPostingModularDrm.java
+++ b/demo/src/main/java/com/novoda/demo/DataPostingModularDrm.java
@@ -26,7 +26,7 @@ class DataPostingModularDrm implements StreamingModularDrm {
     public byte[] executeKeyRequest(ModularDrmKeyRequest request) throws DrmRequestException {
         DefaultHttpDataSourceFactory dataSourceFactory = new DefaultHttpDataSourceFactory("user-agent");
         try {
-            return executePost(dataSourceFactory, url, request.getData());
+            return executePost(dataSourceFactory, url, request.data());
         } catch (IOException e) {
             throw DrmRequestException.from(e);
         }

--- a/demo/src/main/java/com/novoda/demo/DataPostingModularDrm.java
+++ b/demo/src/main/java/com/novoda/demo/DataPostingModularDrm.java
@@ -1,6 +1,5 @@
 package com.novoda.demo;
 
-import android.media.MediaDrm;
 import android.net.Uri;
 
 import com.google.android.exoplayer2.C;
@@ -11,6 +10,7 @@ import com.google.android.exoplayer2.upstream.HttpDataSource;
 import com.google.android.exoplayer2.util.Util;
 import com.novoda.noplayer.drm.DrmRequestException;
 import com.novoda.noplayer.drm.StreamingModularDrm;
+import com.novoda.noplayer.drm.provision.ModularDrmKeyRequest;
 
 import java.io.IOException;
 
@@ -23,7 +23,7 @@ class DataPostingModularDrm implements StreamingModularDrm {
     }
 
     @Override
-    public byte[] executeKeyRequest(MediaDrm.KeyRequest request) throws DrmRequestException {
+    public byte[] executeKeyRequest(ModularDrmKeyRequest request) throws DrmRequestException {
         DefaultHttpDataSourceFactory dataSourceFactory = new DefaultHttpDataSourceFactory("user-agent");
         try {
             return executePost(dataSourceFactory, url, request.getData());

--- a/demo/src/main/java/com/novoda/demo/DataPostingModularDrm.java
+++ b/demo/src/main/java/com/novoda/demo/DataPostingModularDrm.java
@@ -1,0 +1,45 @@
+package com.novoda.demo;
+
+import android.media.MediaDrm;
+import android.net.Uri;
+
+import com.google.android.exoplayer2.C;
+import com.google.android.exoplayer2.upstream.DataSourceInputStream;
+import com.google.android.exoplayer2.upstream.DataSpec;
+import com.google.android.exoplayer2.upstream.DefaultHttpDataSourceFactory;
+import com.google.android.exoplayer2.upstream.HttpDataSource;
+import com.google.android.exoplayer2.util.Util;
+import com.novoda.noplayer.drm.DrmRequestException;
+import com.novoda.noplayer.drm.StreamingModularDrm;
+
+import java.io.IOException;
+
+class DataPostingModularDrm implements StreamingModularDrm {
+
+    private final String url;
+
+    DataPostingModularDrm(String url) {
+        this.url = url;
+    }
+
+    @Override
+    public byte[] executeKeyRequest(MediaDrm.KeyRequest request) throws DrmRequestException {
+        DefaultHttpDataSourceFactory dataSourceFactory = new DefaultHttpDataSourceFactory("user-agent");
+        try {
+            return executePost(dataSourceFactory, url, request.getData());
+        } catch (IOException e) {
+            throw DrmRequestException.from(e);
+        }
+    }
+
+    private byte[] executePost(HttpDataSource.Factory dataSourceFactory, String url, byte[] data) throws IOException {
+        HttpDataSource dataSource = dataSourceFactory.createDataSource();
+        DataSpec dataSpec = new DataSpec(Uri.parse(url), data, 0, 0, C.LENGTH_UNSET, null, DataSpec.FLAG_ALLOW_GZIP);
+        DataSourceInputStream inputStream = new DataSourceInputStream(dataSource, dataSpec);
+        try {
+            return Util.toByteArray(inputStream);
+        } finally {
+            Util.closeQuietly(inputStream);
+        }
+    }
+}

--- a/demo/src/main/java/com/novoda/demo/MainActivity.java
+++ b/demo/src/main/java/com/novoda/demo/MainActivity.java
@@ -13,6 +13,7 @@ import com.novoda.noplayer.Player;
 import com.novoda.noplayer.PlayerAudioTrack;
 import com.novoda.noplayer.PlayerState;
 import com.novoda.noplayer.PlayerView;
+import com.novoda.noplayer.drm.DrmType;
 import com.novoda.noplayer.player.PlayerFactory;
 import com.novoda.noplayer.player.PrioritizedPlayerTypes;
 import com.novoda.notils.caster.Views;
@@ -25,6 +26,8 @@ public class MainActivity extends Activity {
 
     private static final String URI_VIDEO_MP4 = "http://yt-dash-mse-test.commondatastorage.googleapis.com/media/car-20120827-85.mp4";
     private static final String URI_VIDEO_MPD = "https://storage.googleapis.com/content-samples/multi-audio/manifest.mpd";
+    private static final String URI_VIDEO_WIDEVINE_EXAMPLE_MODULAR_MPD = "https://storage.googleapis.com/wvmedia/cenc/h264/tears/tears.mpd";
+    private static final String EXAMPLE_MODULAR_LSP = "https://proxy.uat.widevine.com/proxy?provider=widevine_test";
 
     private Player player;
     private PlayerView playerView;
@@ -43,7 +46,8 @@ public class MainActivity extends Activity {
     protected void onStart() {
         super.onStart();
         // TODO: Add switch in UI to avoid redeploy.
-        player = new PlayerFactory(this, PrioritizedPlayerTypes.prioritizeExoPlayer()).create();
+        PlayerFactory playerFactory = new PlayerFactory(this, PrioritizedPlayerTypes.prioritizeExoPlayer());
+        player = playerFactory.create(DrmType.WIDEVINE_MODULAR_STREAM, new DataPostingModularDrm(EXAMPLE_MODULAR_LSP));
         player.getListeners().addPreparedListener(new Player.PreparedListener() {
             @Override
             public void onPrepared(PlayerState playerState) {
@@ -55,7 +59,7 @@ public class MainActivity extends Activity {
 
         audioSelectionButton.setOnClickListener(showAudioSelectionDialog);
 
-        Uri uri = Uri.parse(URI_VIDEO_MPD);
+        Uri uri = Uri.parse(URI_VIDEO_WIDEVINE_EXAMPLE_MODULAR_MPD);
         player.loadVideo(uri, ContentType.DASH);
     }
 


### PR DESCRIPTION
## Problem

We removed the widevine modular streaming and download support whilst migrating to ExoPlayer2.

## Solution

- Adds a widevine modular example to the demo.

- Passes a `DrmSessionCreator` to the ExoPlayer `RenderersFactory` to enable DRM content. 

- Wraps the `Key` and `Provision` Drm requests to avoid exposing internal api changes. 

- Reintroduces the `LocalDrmSession` but ported to `ExoPlayer2`'s `DrmSessionManager` and `DrmSession`

- TODO propagate errors via an event listener inside the `LocalDrmSession`
- TODO handle errors in the `StreamingDrmSessionCreator`

### Test(s) added 

updated the existing but tests should be written around these classes, but I've gotta bounce 🌴 🌞 

### Screenshots



### Paired with 

nobody, 🌴 🌞  