### PR TITLE
ALL-3936/Error listeners

### DIFF
--- a/core/src/main/java/com/novoda/noplayer/drm/DownloadDrmSessionCreator.java
+++ b/core/src/main/java/com/novoda/noplayer/drm/DownloadDrmSessionCreator.java
@@ -16,6 +16,6 @@ class DownloadDrmSessionCreator implements DrmSessionCreator {
 
     @Override
     public DrmSessionManager<FrameworkMediaCrypto> create(DefaultDrmSessionManager.EventListener eventListener) {
-        return new LocalDrmSessionManager(downloadedModularDrm.getKeySetId(), mediaDrmCreator.create(WIDEVINE_MODULAR_UUID), eventListener, WIDEVINE_MODULAR_UUID);
+        return LocalDrmSessionManager.newInstance(downloadedModularDrm.getKeySetId(), mediaDrmCreator.create(WIDEVINE_MODULAR_UUID), eventListener, WIDEVINE_MODULAR_UUID);
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/drm/DownloadDrmSessionCreator.java
+++ b/core/src/main/java/com/novoda/noplayer/drm/DownloadDrmSessionCreator.java
@@ -20,6 +20,6 @@ class DownloadDrmSessionCreator implements DrmSessionCreator {
 
     @Override
     public DrmSessionManager<FrameworkMediaCrypto> create(DefaultDrmSessionManager.EventListener eventListener) {
-        return new LocalDrmSessionManager(downloadedModularDrm.getKeySetId(), mediaDrmCreator.create(WIDEVINE_MODULAR_UUID));
+        return new LocalDrmSessionManager(downloadedModularDrm.getKeySetId(), mediaDrmCreator.create(WIDEVINE_MODULAR_UUID), eventListener);
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/drm/DownloadDrmSessionCreator.java
+++ b/core/src/main/java/com/novoda/noplayer/drm/DownloadDrmSessionCreator.java
@@ -4,11 +4,7 @@ import com.google.android.exoplayer2.drm.DefaultDrmSessionManager;
 import com.google.android.exoplayer2.drm.DrmSessionManager;
 import com.google.android.exoplayer2.drm.FrameworkMediaCrypto;
 
-import java.util.UUID;
-
 class DownloadDrmSessionCreator implements DrmSessionCreator {
-
-    private static final UUID WIDEVINE_MODULAR_UUID = new UUID(0xEDEF8BA979D64ACEL, 0xA3C827DCD51D21EDL);
 
     private final DownloadedModularDrm downloadedModularDrm;
     private final FrameworkMediaDrmCreator mediaDrmCreator;
@@ -20,6 +16,6 @@ class DownloadDrmSessionCreator implements DrmSessionCreator {
 
     @Override
     public DrmSessionManager<FrameworkMediaCrypto> create(DefaultDrmSessionManager.EventListener eventListener) {
-        return new LocalDrmSessionManager(downloadedModularDrm.getKeySetId(), mediaDrmCreator.create(WIDEVINE_MODULAR_UUID), eventListener);
+        return new LocalDrmSessionManager(downloadedModularDrm.getKeySetId(), mediaDrmCreator.create(WIDEVINE_MODULAR_UUID), eventListener, WIDEVINE_MODULAR_UUID);
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/drm/DownloadDrmSessionCreator.java
+++ b/core/src/main/java/com/novoda/noplayer/drm/DownloadDrmSessionCreator.java
@@ -1,24 +1,25 @@
 package com.novoda.noplayer.drm;
 
+import com.google.android.exoplayer2.drm.DefaultDrmSessionManager;
 import com.google.android.exoplayer2.drm.DrmSessionManager;
 import com.google.android.exoplayer2.drm.FrameworkMediaCrypto;
 
 import java.util.UUID;
 
-public class DownloadDrmSessionCreator implements DrmSessionCreator {
+class DownloadDrmSessionCreator implements DrmSessionCreator {
 
     private static final UUID WIDEVINE_MODULAR_UUID = new UUID(0xEDEF8BA979D64ACEL, 0xA3C827DCD51D21EDL);
 
     private final DownloadedModularDrm downloadedModularDrm;
     private final FrameworkMediaDrmCreator mediaDrmCreator;
 
-    public DownloadDrmSessionCreator(DownloadedModularDrm downloadedModularDrm, FrameworkMediaDrmCreator mediaDrmCreator) {
+    DownloadDrmSessionCreator(DownloadedModularDrm downloadedModularDrm, FrameworkMediaDrmCreator mediaDrmCreator) {
         this.downloadedModularDrm = downloadedModularDrm;
         this.mediaDrmCreator = mediaDrmCreator;
     }
 
     @Override
-    public DrmSessionManager<FrameworkMediaCrypto> create() {
+    public DrmSessionManager<FrameworkMediaCrypto> create(DefaultDrmSessionManager.EventListener eventListener) {
         return new LocalDrmSessionManager(downloadedModularDrm.getKeySetId(), mediaDrmCreator.create(WIDEVINE_MODULAR_UUID));
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/drm/DownloadDrmSessionCreator.java
+++ b/core/src/main/java/com/novoda/noplayer/drm/DownloadDrmSessionCreator.java
@@ -16,6 +16,6 @@ class DownloadDrmSessionCreator implements DrmSessionCreator {
 
     @Override
     public DrmSessionManager<FrameworkMediaCrypto> create(DefaultDrmSessionManager.EventListener eventListener) {
-        return LocalDrmSessionManager.newInstance(downloadedModularDrm.getKeySetId(), mediaDrmCreator.create(WIDEVINE_MODULAR_UUID), eventListener, WIDEVINE_MODULAR_UUID);
+        return LocalDrmSessionManager.newInstance(downloadedModularDrm.getKeySetId(), mediaDrmCreator.create(WIDEVINE_MODULAR_UUID), WIDEVINE_MODULAR_UUID, eventListener);
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/drm/DrmSessionCreator.java
+++ b/core/src/main/java/com/novoda/noplayer/drm/DrmSessionCreator.java
@@ -6,7 +6,11 @@ import com.google.android.exoplayer2.drm.DefaultDrmSessionManager;
 import com.google.android.exoplayer2.drm.DrmSessionManager;
 import com.google.android.exoplayer2.drm.FrameworkMediaCrypto;
 
+import java.util.UUID;
+
 public interface DrmSessionCreator {
+
+    UUID WIDEVINE_MODULAR_UUID = new UUID(0xEDEF8BA979D64ACEL, 0xA3C827DCD51D21EDL);
 
     @Nullable
     DrmSessionManager<FrameworkMediaCrypto> create(DefaultDrmSessionManager.EventListener eventListener);

--- a/core/src/main/java/com/novoda/noplayer/drm/DrmSessionCreator.java
+++ b/core/src/main/java/com/novoda/noplayer/drm/DrmSessionCreator.java
@@ -2,13 +2,14 @@ package com.novoda.noplayer.drm;
 
 import android.support.annotation.Nullable;
 
+import com.google.android.exoplayer2.drm.DefaultDrmSessionManager;
 import com.google.android.exoplayer2.drm.DrmSessionManager;
 import com.google.android.exoplayer2.drm.FrameworkMediaCrypto;
 
 public interface DrmSessionCreator {
 
     @Nullable
-    DrmSessionManager<FrameworkMediaCrypto> create();
+    DrmSessionManager<FrameworkMediaCrypto> create(DefaultDrmSessionManager.EventListener eventListener);
 
     class DrmSessionManagerCreationException extends RuntimeException {
 

--- a/core/src/main/java/com/novoda/noplayer/drm/LocalDrmSessionManager.java
+++ b/core/src/main/java/com/novoda/noplayer/drm/LocalDrmSessionManager.java
@@ -25,16 +25,19 @@ class LocalDrmSessionManager implements DrmSessionManager<FrameworkMediaCrypto> 
     private final UUID drmScheme;
     private final Handler handler;
 
-    static LocalDrmSessionManager newInstance(KeySetId keySetIdToRestore, ExoMediaDrm<FrameworkMediaCrypto> mediaDrm, DefaultDrmSessionManager.EventListener eventListener, UUID drmScheme) {
+    static LocalDrmSessionManager newInstance(KeySetId keySetIdToRestore,
+                                              ExoMediaDrm<FrameworkMediaCrypto> mediaDrm,
+                                              UUID drmScheme,
+                                              DefaultDrmSessionManager.EventListener eventListener) {
         Handler handler = new Handler(Looper.getMainLooper());
-        return new LocalDrmSessionManager(keySetIdToRestore, mediaDrm, eventListener, drmScheme, handler);
+        return new LocalDrmSessionManager(keySetIdToRestore, mediaDrm, drmScheme, handler, eventListener);
     }
 
     private LocalDrmSessionManager(KeySetId keySetIdToRestore,
                                    ExoMediaDrm<FrameworkMediaCrypto> mediaDrm,
-                                   DefaultDrmSessionManager.EventListener eventListener,
                                    UUID drmScheme,
-                                   Handler handler) {
+                                   Handler handler,
+                                   DefaultDrmSessionManager.EventListener eventListener) {
         this.keySetIdToRestore = keySetIdToRestore;
         this.mediaDrm = mediaDrm;
         this.eventListener = eventListener;

--- a/core/src/main/java/com/novoda/noplayer/drm/LocalDrmSessionManager.java
+++ b/core/src/main/java/com/novoda/noplayer/drm/LocalDrmSessionManager.java
@@ -18,16 +18,16 @@ import java.util.UUID;
 
 class LocalDrmSessionManager implements DrmSessionManager<FrameworkMediaCrypto> {
 
-    private static final UUID WIDEVINE_MODULAR_UUID = new UUID(0xEDEF8BA979D64ACEL, 0xA3C827DCD51D21EDL);
-
     private final KeySetId keySetIdToRestore;
     private final ExoMediaDrm<FrameworkMediaCrypto> mediaDrm;
     private final DefaultDrmSessionManager.EventListener eventListener;
+    private final UUID drmScheme;
 
-    LocalDrmSessionManager(KeySetId keySetIdToRestore, ExoMediaDrm<FrameworkMediaCrypto> mediaDrm, DefaultDrmSessionManager.EventListener eventListener) {
+    LocalDrmSessionManager(KeySetId keySetIdToRestore, ExoMediaDrm<FrameworkMediaCrypto> mediaDrm, DefaultDrmSessionManager.EventListener eventListener, UUID drmScheme) {
         this.keySetIdToRestore = keySetIdToRestore;
         this.mediaDrm = mediaDrm;
         this.eventListener = eventListener;
+        this.drmScheme = drmScheme;
     }
 
     @TargetApi(Build.VERSION_CODES.KITKAT)
@@ -37,7 +37,7 @@ class LocalDrmSessionManager implements DrmSessionManager<FrameworkMediaCrypto> 
 
         try {
             SessionId sessionId = SessionId.of(mediaDrm.openSession());
-            FrameworkMediaCrypto mediaCrypto = mediaDrm.createMediaCrypto(WIDEVINE_MODULAR_UUID, sessionId.asBytes());
+            FrameworkMediaCrypto mediaCrypto = mediaDrm.createMediaCrypto(drmScheme, sessionId.asBytes());
 
             mediaDrm.restoreKeys(sessionId.asBytes(), keySetIdToRestore.asBytes());
 

--- a/core/src/main/java/com/novoda/noplayer/drm/NoDrmSessionCreator.java
+++ b/core/src/main/java/com/novoda/noplayer/drm/NoDrmSessionCreator.java
@@ -2,16 +2,17 @@ package com.novoda.noplayer.drm;
 
 import android.support.annotation.Nullable;
 
+import com.google.android.exoplayer2.drm.DefaultDrmSessionManager;
 import com.google.android.exoplayer2.drm.DrmSessionManager;
 import com.google.android.exoplayer2.drm.FrameworkMediaCrypto;
 
-public class NoDrmSessionCreator implements DrmSessionCreator {
+class NoDrmSessionCreator implements DrmSessionCreator {
 
     private static final DrmSessionManager<FrameworkMediaCrypto> NO_DRM_SESSION = null;
 
     @Nullable
     @Override
-    public DrmSessionManager<FrameworkMediaCrypto> create() {
+    public DrmSessionManager<FrameworkMediaCrypto> create(DefaultDrmSessionManager.EventListener eventListener) {
         return NO_DRM_SESSION;
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/drm/StreamingDrmSessionCreator.java
+++ b/core/src/main/java/com/novoda/noplayer/drm/StreamingDrmSessionCreator.java
@@ -10,11 +10,9 @@ import com.google.android.exoplayer2.drm.FrameworkMediaDrm;
 import com.google.android.exoplayer2.drm.MediaDrmCallback;
 
 import java.util.HashMap;
-import java.util.UUID;
 
 class StreamingDrmSessionCreator implements DrmSessionCreator {
 
-    private static final UUID WIDEVINE_MODULAR_UUID = new UUID(0xEDEF8BA979D64ACEL, 0xA3C827DCD51D21EDL);
     private static final HashMap<String, String> NO_OPTIONAL_PARAMETERS = null;
 
     private final MediaDrmCallback mediaDrmCallback;

--- a/core/src/main/java/com/novoda/noplayer/drm/StreamingDrmSessionCreator.java
+++ b/core/src/main/java/com/novoda/noplayer/drm/StreamingDrmSessionCreator.java
@@ -12,17 +12,16 @@ import com.google.android.exoplayer2.drm.MediaDrmCallback;
 import java.util.HashMap;
 import java.util.UUID;
 
-public class StreamingDrmSessionCreator implements DrmSessionCreator {
+class StreamingDrmSessionCreator implements DrmSessionCreator {
 
     private static final UUID WIDEVINE_MODULAR_UUID = new UUID(0xEDEF8BA979D64ACEL, 0xA3C827DCD51D21EDL);
     private static final HashMap<String, String> NO_OPTIONAL_PARAMETERS = null;
-    private static final DefaultDrmSessionManager.EventListener TODO_ERROR_EVENT_LISTENER = null;
 
     private final MediaDrmCallback mediaDrmCallback;
     private final FrameworkMediaDrmCreator frameworkMediaDrmCreator;
     private final Handler handler;
 
-    public static StreamingDrmSessionCreator newInstance(MediaDrmCallback mediaDrmCallback, FrameworkMediaDrmCreator frameworkMediaDrmCreator) {
+    static StreamingDrmSessionCreator newInstance(MediaDrmCallback mediaDrmCallback, FrameworkMediaDrmCreator frameworkMediaDrmCreator) {
         Handler handler = new Handler(Looper.getMainLooper());
         return new StreamingDrmSessionCreator(mediaDrmCallback, frameworkMediaDrmCreator, handler);
     }
@@ -34,7 +33,7 @@ public class StreamingDrmSessionCreator implements DrmSessionCreator {
     }
 
     @Override
-    public DrmSessionManager<FrameworkMediaCrypto> create() {
+    public DrmSessionManager<FrameworkMediaCrypto> create(DefaultDrmSessionManager.EventListener eventListener) {
         FrameworkMediaDrm frameworkMediaDrm = frameworkMediaDrmCreator.create(WIDEVINE_MODULAR_UUID);
 
         return new DefaultDrmSessionManager<>(
@@ -43,7 +42,7 @@ public class StreamingDrmSessionCreator implements DrmSessionCreator {
                 mediaDrmCallback,
                 NO_OPTIONAL_PARAMETERS,
                 handler,
-                TODO_ERROR_EVENT_LISTENER
+                eventListener
         );
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/exoplayer/ExoPlayerCreator.java
+++ b/core/src/main/java/com/novoda/noplayer/exoplayer/ExoPlayerCreator.java
@@ -11,6 +11,7 @@ import com.google.android.exoplayer2.drm.DrmSessionManager;
 import com.google.android.exoplayer2.drm.FrameworkMediaCrypto;
 import com.google.android.exoplayer2.trackselection.DefaultTrackSelector;
 import com.novoda.noplayer.drm.DrmSessionCreator;
+import com.novoda.noplayer.exoplayer.forwarder.ExoPlayerDrmSessionEventListener;
 
 class ExoPlayerCreator {
 
@@ -23,8 +24,8 @@ class ExoPlayerCreator {
     }
 
     @NonNull
-    public SimpleExoPlayer create(DrmSessionCreator drmSessionCreator) {
-        DrmSessionManager<FrameworkMediaCrypto> drmSessionManager = drmSessionCreator.create();
+    public SimpleExoPlayer create(DrmSessionCreator drmSessionCreator, ExoPlayerDrmSessionEventListener exoPlayerDrmSessionEventListener) {
+        DrmSessionManager<FrameworkMediaCrypto> drmSessionManager = drmSessionCreator.create(exoPlayerDrmSessionEventListener);
         DefaultRenderersFactory renderersFactory = new DefaultRenderersFactory(context, drmSessionManager);
         DefaultLoadControl loadControl = new DefaultLoadControl();
         return ExoPlayerFactory.newSimpleInstance(renderersFactory, trackSelector, loadControl);

--- a/core/src/main/java/com/novoda/noplayer/exoplayer/ExoPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/exoplayer/ExoPlayerFacade.java
@@ -101,7 +101,7 @@ class ExoPlayerFacade {
     }
 
     void loadVideo(DrmSessionCreator drmSessionCreator, Uri uri, ContentType contentType, ExoPlayerForwarder forwarder) {
-        exoPlayer = exoPlayerCreator.create(drmSessionCreator);
+        exoPlayer = exoPlayerCreator.create(drmSessionCreator, forwarder.drmSessionEventListener());
         rendererTypeRequester = rendererTypeRequesterCreator.createfrom(exoPlayer);
         exoPlayer.addListener(forwarder.exoPlayerEventListener());
         exoPlayer.setVideoDebugListener(forwarder.videoRendererEventListener());

--- a/core/src/main/java/com/novoda/noplayer/exoplayer/forwarder/DrmSessionErrorForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/exoplayer/forwarder/DrmSessionErrorForwarder.java
@@ -1,0 +1,38 @@
+package com.novoda.noplayer.exoplayer.forwarder;
+
+import com.google.android.exoplayer2.drm.DefaultDrmSessionManager;
+import com.novoda.noplayer.Player;
+import com.novoda.noplayer.exoplayer.playererror.DrmInitiatingError;
+import com.novoda.noplayer.listeners.ErrorListeners;
+
+class DrmSessionErrorForwarder implements DefaultDrmSessionManager.EventListener {
+
+    private final Player player;
+    private final ErrorListeners errorListeners;
+
+    DrmSessionErrorForwarder(Player player, ErrorListeners errorListeners) {
+        this.player = player;
+        this.errorListeners = errorListeners;
+    }
+
+    @Override
+    public void onDrmKeysLoaded() {
+        // TODO: Are we interested?
+    }
+
+    @Override
+    public void onDrmSessionManagerError(Exception e) {
+        Player.PlayerError playerError = new DrmInitiatingError(e);
+        errorListeners.onError(player, playerError);
+    }
+
+    @Override
+    public void onDrmKeysRestored() {
+        // TODO: Are we interested?
+    }
+
+    @Override
+    public void onDrmKeysRemoved() {
+        // TODO: Are we interested?
+    }
+}

--- a/core/src/main/java/com/novoda/noplayer/exoplayer/forwarder/ExoPlayerDrmSessionEventListener.java
+++ b/core/src/main/java/com/novoda/noplayer/exoplayer/forwarder/ExoPlayerDrmSessionEventListener.java
@@ -1,0 +1,43 @@
+package com.novoda.noplayer.exoplayer.forwarder;
+
+import com.google.android.exoplayer2.drm.DefaultDrmSessionManager;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+public class ExoPlayerDrmSessionEventListener implements DefaultDrmSessionManager.EventListener {
+
+    private final List<DefaultDrmSessionManager.EventListener> listeners = new CopyOnWriteArrayList<>();
+
+    public void add(DefaultDrmSessionManager.EventListener listener) {
+        listeners.add(listener);
+    }
+
+    @Override
+    public void onDrmKeysLoaded() {
+        for (DefaultDrmSessionManager.EventListener listener : listeners) {
+            listener.onDrmKeysLoaded();
+        }
+    }
+
+    @Override
+    public void onDrmSessionManagerError(Exception e) {
+        for (DefaultDrmSessionManager.EventListener listener : listeners) {
+            listener.onDrmSessionManagerError(e);
+        }
+    }
+
+    @Override
+    public void onDrmKeysRestored() {
+        for (DefaultDrmSessionManager.EventListener listener : listeners) {
+            listener.onDrmKeysRestored();
+        }
+    }
+
+    @Override
+    public void onDrmKeysRemoved() {
+        for (DefaultDrmSessionManager.EventListener listener : listeners) {
+            listener.onDrmKeysRemoved();
+        }
+    }
+}

--- a/core/src/main/java/com/novoda/noplayer/exoplayer/forwarder/ExoPlayerForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/exoplayer/forwarder/ExoPlayerForwarder.java
@@ -17,12 +17,14 @@ public class ExoPlayerForwarder {
     private final MediaSourceEventListener mediaSourceEventListener;
     private final ExoPlayerVideoRendererEventListener videoRendererEventListener;
     private final ExoPlayerExtractorMediaSourceListener extractorMediaSourceListener;
+    private final ExoPlayerDrmSessionEventListener drmSessionEventListener;
 
     public ExoPlayerForwarder() {
         exoPlayerEventListener = new EventListener();
         mediaSourceEventListener = new MediaSourceEventListener();
         videoRendererEventListener = new ExoPlayerVideoRendererEventListener();
         extractorMediaSourceListener = new ExoPlayerExtractorMediaSourceListener();
+        drmSessionEventListener = new ExoPlayerDrmSessionEventListener();
     }
 
     public EventListener exoPlayerEventListener() {
@@ -41,6 +43,10 @@ public class ExoPlayerForwarder {
         return extractorMediaSourceListener;
     }
 
+    public ExoPlayerDrmSessionEventListener drmSessionEventListener() {
+        return drmSessionEventListener;
+    }
+
     public void bind(PreparedListeners preparedListeners, PlayerState playerState) {
         exoPlayerEventListener.add(new OnPrepareForwarder(preparedListeners, playerState));
     }
@@ -53,6 +59,7 @@ public class ExoPlayerForwarder {
     public void bind(ErrorListeners errorListeners, Player player) {
         exoPlayerEventListener.add(new PlayerOnErrorForwarder(player, errorListeners));
         extractorMediaSourceListener.add(new MediaSourceOnErrorForwarder(player, errorListeners));
+        drmSessionEventListener.add(new DrmSessionErrorForwarder(player, errorListeners));
     }
 
     public void bind(BufferStateListeners bufferStateListeners) {

--- a/core/src/main/java/com/novoda/noplayer/exoplayer/playererror/DrmInitiatingError.java
+++ b/core/src/main/java/com/novoda/noplayer/exoplayer/playererror/DrmInitiatingError.java
@@ -4,32 +4,19 @@ import com.novoda.noplayer.Player;
 
 public class DrmInitiatingError implements Player.PlayerError {
 
-    private final int errorCode;
     private final Throwable cause;
 
-    public static DrmInitiatingError newInstance(int errorCode, String message) {
-        return new DrmInitiatingError(errorCode, new DrmErrorTrackingThrowable(message));
-    }
-
-    DrmInitiatingError(int errorCode, Throwable cause) {
-        this.errorCode = errorCode;
+    public DrmInitiatingError(Throwable cause) {
         this.cause = cause;
     }
 
     @Override
     public String getType() {
-        return String.valueOf(errorCode);
+        return "DrmInitiatingError";
     }
 
     @Override
     public Throwable getCause() {
         return cause;
-    }
-
-    private static class DrmErrorTrackingThrowable extends Throwable {
-
-        public DrmErrorTrackingThrowable(String detailMessage) {
-            super(detailMessage);
-        }
     }
 }

--- a/core/src/test/java/com/novoda/noplayer/exoplayer/ExoPlayerFacadeTest.java
+++ b/core/src/test/java/com/novoda/noplayer/exoplayer/ExoPlayerFacadeTest.java
@@ -11,6 +11,7 @@ import com.novoda.noplayer.PlayerSubtitleTrack;
 import com.novoda.noplayer.VideoDuration;
 import com.novoda.noplayer.VideoPosition;
 import com.novoda.noplayer.drm.DrmSessionCreator;
+import com.novoda.noplayer.exoplayer.forwarder.ExoPlayerDrmSessionEventListener;
 import com.novoda.noplayer.exoplayer.forwarder.ExoPlayerForwarder;
 import com.novoda.noplayer.exoplayer.mediasource.ExoPlayerAudioTrackSelector;
 import com.novoda.noplayer.exoplayer.mediasource.ExoPlayerSubtitleTrackSelector;
@@ -388,13 +389,16 @@ public class ExoPlayerFacadeTest {
         RendererTypeRequesterCreator rendererTypeRequesterCreator;
         @Mock
         DrmSessionCreator drmSessionCreator;
+        @Mock
+        ExoPlayerDrmSessionEventListener drmSessionEventListener;
 
         ExoPlayerFacade facade;
 
         @Before
         public void setUp() {
             ExoPlayerCreator exoPlayerCreator = mock(ExoPlayerCreator.class);
-            given(exoPlayerCreator.create(drmSessionCreator)).willReturn(exoPlayer);
+            given(exoPlayerForwarder.drmSessionEventListener()).willReturn(drmSessionEventListener);
+            given(exoPlayerCreator.create(drmSessionCreator, drmSessionEventListener)).willReturn(exoPlayer);
             when(rendererTypeRequesterCreator.createfrom(exoPlayer)).thenReturn(rendererTypeRequester);
             facade = new ExoPlayerFacade(
                     mediaSourceFactory,


### PR DESCRIPTION
## Problem
We created a `LocalDrmSession` but we ignored bubbling any errors up to our `no-player` error listeners. 

## Solution
Create a `DrmSessionErrorForwarder` to transform and forward our `ExoPlayer` DRM error into a `no-player` specific `Player.Error`.

We had `UUID`in three or four places for `Widevine`, we have now exposed it in a common interface. 

### Test(s) added 
No, we would need to wrap a lot of `ExoPlayer` classes in order to test the DRM part. We will do this at the end.

### Screenshots
No UI changes.

### Paired with 
@ouchadam 
