### PR TITLE
ALL-3936/Player Builder

### DIFF
--- a/core/src/main/java/com/novoda/noplayer/exoplayer/ExoPlayerCreator.java
+++ b/core/src/main/java/com/novoda/noplayer/exoplayer/ExoPlayerCreator.java
@@ -9,6 +9,7 @@ import com.google.android.exoplayer2.SimpleExoPlayer;
 import com.google.android.exoplayer2.drm.DefaultDrmSessionManager;
 import com.google.android.exoplayer2.drm.DrmSessionManager;
 import com.google.android.exoplayer2.drm.FrameworkMediaCrypto;
+import com.google.android.exoplayer2.mediacodec.MediaCodecSelector;
 import com.google.android.exoplayer2.trackselection.DefaultTrackSelector;
 import com.novoda.noplayer.exoplayer.drm.DrmSessionCreator;
 
@@ -26,14 +27,14 @@ class ExoPlayerCreator {
         this.trackSelector = trackSelector;
     }
 
-    public SimpleExoPlayer create(DrmSessionCreator drmSessionCreator, DefaultDrmSessionManager.EventListener drmSessionEventListener, boolean downgradeSecureDecoder) {
+    public SimpleExoPlayer create(DrmSessionCreator drmSessionCreator, DefaultDrmSessionManager.EventListener drmSessionEventListener, MediaCodecSelector mediaCodecSelector) {
         DrmSessionManager<FrameworkMediaCrypto> drmSessionManager = drmSessionCreator.create(drmSessionEventListener);
         RenderersFactory renderersFactory = new SimpleRenderersFactory(
                 context,
                 drmSessionManager,
                 EXTENSION_RENDERER_MODE_OFF,
                 DEFAULT_ALLOWED_VIDEO_JOINING_TIME_MS,
-                SecurityDowngradingCodecSelector.newInstance(downgradeSecureDecoder)
+                mediaCodecSelector
         );
 
         DefaultLoadControl loadControl = new DefaultLoadControl();

--- a/core/src/main/java/com/novoda/noplayer/exoplayer/ExoPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/exoplayer/ExoPlayerFacade.java
@@ -5,6 +5,7 @@ import android.support.annotation.Nullable;
 import android.view.SurfaceHolder;
 
 import com.google.android.exoplayer2.SimpleExoPlayer;
+import com.google.android.exoplayer2.mediacodec.MediaCodecSelector;
 import com.google.android.exoplayer2.source.MediaSource;
 import com.novoda.noplayer.ContentType;
 import com.novoda.noplayer.model.PlayerAudioTrack;
@@ -100,8 +101,8 @@ class ExoPlayerFacade {
         exoPlayer.stop();
     }
 
-    void loadVideo(DrmSessionCreator drmSessionCreator, Uri uri, ContentType contentType, ExoPlayerForwarder forwarder, boolean downgradeSecureDecoder) {
-        exoPlayer = exoPlayerCreator.create(drmSessionCreator, forwarder.drmSessionEventListener(), downgradeSecureDecoder);
+    void loadVideo(DrmSessionCreator drmSessionCreator, Uri uri, ContentType contentType, ExoPlayerForwarder forwarder, MediaCodecSelector mediaCodecSelector) {
+        exoPlayer = exoPlayerCreator.create(drmSessionCreator, forwarder.drmSessionEventListener(), mediaCodecSelector);
         rendererTypeRequester = rendererTypeRequesterCreator.createfrom(exoPlayer);
         exoPlayer.addListener(forwarder.exoPlayerEventListener());
         exoPlayer.setVideoDebugListener(forwarder.videoRendererEventListener());

--- a/core/src/main/java/com/novoda/noplayer/exoplayer/ExoPlayerTwoImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/exoplayer/ExoPlayerTwoImpl.java
@@ -4,6 +4,7 @@ import android.net.Uri;
 import android.support.annotation.Nullable;
 import android.view.SurfaceHolder;
 
+import com.google.android.exoplayer2.mediacodec.MediaCodecSelector;
 import com.novoda.noplayer.ContentType;
 import com.novoda.noplayer.Heart;
 import com.novoda.noplayer.Player;
@@ -30,7 +31,7 @@ class ExoPlayerTwoImpl implements Player {
     private final ExoPlayerForwarder forwarder;
     private final Heart heart;
     private final DrmSessionCreator drmSessionCreator;
-    private final boolean downgradeSecureDecoder;
+    private final MediaCodecSelector mediaCodecSelector;
     private final LoadTimeout loadTimeout;
 
     private SurfaceHolderRequester surfaceHolderRequester;
@@ -47,14 +48,14 @@ class ExoPlayerTwoImpl implements Player {
                      LoadTimeout loadTimeoutParam,
                      Heart heart,
                      DrmSessionCreator drmSessionCreator,
-                     boolean downgradeSecureDecoder) {
+                     MediaCodecSelector mediaCodecSelector) {
         this.exoPlayer = exoPlayer;
         this.listenersHolder = listenersHolder;
         this.loadTimeout = loadTimeoutParam;
         this.forwarder = exoPlayerForwarder;
         this.heart = heart;
         this.drmSessionCreator = drmSessionCreator;
-        this.downgradeSecureDecoder = downgradeSecureDecoder;
+        this.mediaCodecSelector = mediaCodecSelector;
     }
 
     void initialise() {
@@ -174,7 +175,7 @@ class ExoPlayerTwoImpl implements Player {
             reset();
         }
         listenersHolder.getPreparedListeners().resetPreparedState();
-        exoPlayer.loadVideo(drmSessionCreator, uri, contentType, forwarder, downgradeSecureDecoder);
+        exoPlayer.loadVideo(drmSessionCreator, uri, contentType, forwarder, mediaCodecSelector);
     }
 
     @Override

--- a/core/src/main/java/com/novoda/noplayer/exoplayer/NoPlayerExoPlayerCreator.java
+++ b/core/src/main/java/com/novoda/noplayer/exoplayer/NoPlayerExoPlayerCreator.java
@@ -3,6 +3,7 @@ package com.novoda.noplayer.exoplayer;
 import android.content.Context;
 import android.os.Handler;
 
+import com.google.android.exoplayer2.mediacodec.MediaCodecSelector;
 import com.google.android.exoplayer2.trackselection.DefaultTrackSelector;
 import com.google.android.exoplayer2.trackselection.FixedTrackSelection;
 import com.google.android.exoplayer2.upstream.DefaultDataSourceFactory;
@@ -51,6 +52,8 @@ public class NoPlayerExoPlayerCreator {
 
             DefaultTrackSelector trackSelector = new DefaultTrackSelector();
 
+            MediaCodecSelector mediaCodecSelector = downgradeSecureDecoder ? SecurityDowngradingCodecSelector.newInstance() : MediaCodecSelector.DEFAULT;
+
             ExoPlayerTrackSelector exoPlayerTrackSelector = ExoPlayerTrackSelector.newInstance(trackSelector);
             FixedTrackSelection.Factory trackSelectionFactory = new FixedTrackSelection.Factory();
             ExoPlayerAudioTrackSelector exoPlayerAudioTrackSelector = new ExoPlayerAudioTrackSelector(exoPlayerTrackSelector, trackSelectionFactory);
@@ -81,7 +84,7 @@ public class NoPlayerExoPlayerCreator {
                     loadTimeout,
                     heart,
                     drmSessionCreator,
-                    downgradeSecureDecoder
+                    mediaCodecSelector
             );
         }
     }

--- a/core/src/main/java/com/novoda/noplayer/exoplayer/SecurityDowngradingCodecSelector.java
+++ b/core/src/main/java/com/novoda/noplayer/exoplayer/SecurityDowngradingCodecSelector.java
@@ -6,6 +6,8 @@ import com.google.android.exoplayer2.mediacodec.MediaCodecUtil;
 
 class SecurityDowngradingCodecSelector implements MediaCodecSelector {
 
+    private static final boolean USE_INSECURE_DECODER = false;
+
     private final InternalMediaCodecUtil internalMediaCodecUtil;
 
     public static SecurityDowngradingCodecSelector newInstance() {
@@ -20,7 +22,7 @@ class SecurityDowngradingCodecSelector implements MediaCodecSelector {
     @Override
     public MediaCodecInfo getDecoderInfo(String mimeType, boolean contentRequiresSecureDecoder)
             throws MediaCodecUtil.DecoderQueryException {
-        return internalMediaCodecUtil.getDecoderInfo(mimeType, false);
+        return internalMediaCodecUtil.getDecoderInfo(mimeType, USE_INSECURE_DECODER);
     }
 
     @Override

--- a/core/src/main/java/com/novoda/noplayer/exoplayer/SecurityDowngradingCodecSelector.java
+++ b/core/src/main/java/com/novoda/noplayer/exoplayer/SecurityDowngradingCodecSelector.java
@@ -7,22 +7,20 @@ import com.google.android.exoplayer2.mediacodec.MediaCodecUtil;
 class SecurityDowngradingCodecSelector implements MediaCodecSelector {
 
     private final InternalMediaCodecUtil internalMediaCodecUtil;
-    private final boolean downgradeSecureDecoder;
 
-    public static SecurityDowngradingCodecSelector newInstance(boolean downgradeSecureDecoder) {
+    public static SecurityDowngradingCodecSelector newInstance() {
         InternalMediaCodecUtil internalMediaCodecUtil = new InternalMediaCodecUtil();
-        return new SecurityDowngradingCodecSelector(internalMediaCodecUtil, downgradeSecureDecoder);
+        return new SecurityDowngradingCodecSelector(internalMediaCodecUtil);
     }
 
-    SecurityDowngradingCodecSelector(InternalMediaCodecUtil internalMediaCodecUtil, boolean downgradeSecureDecoder) {
+    SecurityDowngradingCodecSelector(InternalMediaCodecUtil internalMediaCodecUtil) {
         this.internalMediaCodecUtil = internalMediaCodecUtil;
-        this.downgradeSecureDecoder = downgradeSecureDecoder;
     }
 
     @Override
     public MediaCodecInfo getDecoderInfo(String mimeType, boolean contentRequiresSecureDecoder)
             throws MediaCodecUtil.DecoderQueryException {
-        return internalMediaCodecUtil.getDecoderInfo(mimeType, contentRequiresSecureDecoder && !downgradeSecureDecoder);
+        return internalMediaCodecUtil.getDecoderInfo(mimeType, false);
     }
 
     @Override

--- a/core/src/main/java/com/novoda/noplayer/exoplayer/drm/DrmSessionCreatorFactory.java
+++ b/core/src/main/java/com/novoda/noplayer/exoplayer/drm/DrmSessionCreatorFactory.java
@@ -10,7 +10,7 @@ import com.novoda.noplayer.drm.StreamingModularDrm;
 import com.novoda.noplayer.drm.provision.HttpPoster;
 import com.novoda.noplayer.drm.provision.ProvisionExecutor;
 import com.novoda.noplayer.drm.provision.ProvisioningCapabilities;
-import com.novoda.noplayer.player.PlayerFactory;
+import com.novoda.noplayer.player.UnableToCreatePlayerException;
 import com.novoda.utils.AndroidDeviceVersion;
 
 public class DrmSessionCreatorFactory {
@@ -36,7 +36,7 @@ public class DrmSessionCreatorFactory {
                 assertThatApiLevelIsJellyBeanEighteenOrAbove(drmType);
                 return createModularDownload((DownloadedModularDrm) drmHandler);
             default:
-                throw PlayerFactory.UnableToCreatePlayerException.noDrmHandlerFor(drmType);
+                throw UnableToCreatePlayerException.noDrmHandlerFor(drmType);
         }
     }
 
@@ -44,7 +44,7 @@ public class DrmSessionCreatorFactory {
         if (androidDeviceVersion.isJellyBeanEighteenOrAbove()) {
             return;
         }
-        throw PlayerFactory.UnableToCreatePlayerException.deviceDoesNotMeetTargetApiException(
+        throw UnableToCreatePlayerException.deviceDoesNotMeetTargetApiException(
                 drmType,
                 Build.VERSION_CODES.JELLY_BEAN_MR2,
                 androidDeviceVersion

--- a/core/src/main/java/com/novoda/noplayer/player/NoPlayerCreator.java
+++ b/core/src/main/java/com/novoda/noplayer/player/NoPlayerCreator.java
@@ -10,7 +10,7 @@ import com.novoda.noplayer.exoplayer.drm.DrmSessionCreator;
 import com.novoda.noplayer.exoplayer.drm.DrmSessionCreatorFactory;
 import com.novoda.noplayer.mediaplayer.NoPlayerMediaPlayerCreator;
 
-class PlayerFactory {
+class NoPlayerCreator {
 
     private final Context context;
     private final PrioritizedPlayerTypes prioritizedPlayerTypes;
@@ -18,11 +18,11 @@ class PlayerFactory {
     private final NoPlayerMediaPlayerCreator noPlayerMediaPlayerCreator;
     private final DrmSessionCreatorFactory drmSessionCreatorFactory;
 
-    PlayerFactory(Context context,
-                  PrioritizedPlayerTypes prioritizedPlayerTypes,
-                  NoPlayerExoPlayerCreator noPlayerExoPlayerCreator,
-                  NoPlayerMediaPlayerCreator noPlayerMediaPlayerCreator,
-                  DrmSessionCreatorFactory drmSessionCreatorFactory) {
+    NoPlayerCreator(Context context,
+                    PrioritizedPlayerTypes prioritizedPlayerTypes,
+                    NoPlayerExoPlayerCreator noPlayerExoPlayerCreator,
+                    NoPlayerMediaPlayerCreator noPlayerMediaPlayerCreator,
+                    DrmSessionCreatorFactory drmSessionCreatorFactory) {
         this.context = context;
         this.prioritizedPlayerTypes = prioritizedPlayerTypes;
         this.noPlayerExoPlayerCreator = noPlayerExoPlayerCreator;

--- a/core/src/main/java/com/novoda/noplayer/player/PlayerBuilder.java
+++ b/core/src/main/java/com/novoda/noplayer/player/PlayerBuilder.java
@@ -20,30 +20,23 @@ import java.util.List;
 
 public class PlayerBuilder {
 
-    private DrmType drmType;
-    private DrmHandler drmHandler;
+    private DrmType drmType = DrmType.NONE;
+    private DrmHandler drmHandler = DrmHandler.NO_DRM;
     private PrioritizedPlayerTypes prioritizedPlayerTypes = PrioritizedPlayerTypes.prioritizeExoPlayer();
     private boolean downgradeSecureDecoder = false;
 
     public PlayerBuilder withWidevineClassicDrm() {
-        drmType = DrmType.WIDEVINE_CLASSIC;
-        drmHandler = DrmHandler.NO_DRM;
-        return this;
+        return withDrm(DrmType.WIDEVINE_CLASSIC, DrmHandler.NO_DRM);
     }
 
     public PlayerBuilder withWidevineModularStreamingDrm(StreamingModularDrm streamingModularDrm) {
-        drmType = DrmType.WIDEVINE_MODULAR_STREAM;
-        drmHandler = streamingModularDrm;
-        return this;
+        return withDrm(DrmType.WIDEVINE_MODULAR_STREAM, streamingModularDrm);
     }
 
     public PlayerBuilder withWidevineModularDownloadDrm(DownloadedModularDrm downloadedModularDrm) {
-        drmType = DrmType.WIDEVINE_MODULAR_DOWNLOAD;
-        drmHandler = downloadedModularDrm;
-        return this;
+        return withDrm(DrmType.WIDEVINE_MODULAR_DOWNLOAD, downloadedModularDrm);
     }
 
-    @Deprecated
     public PlayerBuilder withDrm(DrmType drmType, DrmHandler drmHandler) {
         this.drmType = drmType;
         this.drmHandler = drmHandler;

--- a/core/src/main/java/com/novoda/noplayer/player/PlayerBuilder.java
+++ b/core/src/main/java/com/novoda/noplayer/player/PlayerBuilder.java
@@ -66,13 +66,13 @@ public class PlayerBuilder {
     public Player build(Context context) {
         Handler handler = new Handler(Looper.getMainLooper());
         DrmSessionCreatorFactory drmSessionCreatorFactory = new DrmSessionCreatorFactory(AndroidDeviceVersion.newInstance(), handler);
-        PlayerFactory playerFactory = new PlayerFactory(
+        NoPlayerCreator noPlayerCreator = new NoPlayerCreator(
                 context,
                 prioritizedPlayerTypes,
                 NoPlayerExoPlayerCreator.newInstance(handler),
                 NoPlayerMediaPlayerCreator.newInstance(handler),
                 drmSessionCreatorFactory
         );
-        return playerFactory.create(drmType, drmHandler, downgradeSecureDecoder);
+        return noPlayerCreator.create(drmType, drmHandler, downgradeSecureDecoder);
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/player/PlayerBuilder.java
+++ b/core/src/main/java/com/novoda/noplayer/player/PlayerBuilder.java
@@ -1,0 +1,78 @@
+package com.novoda.noplayer.player;
+
+import android.content.Context;
+import android.os.Handler;
+import android.os.Looper;
+
+import com.novoda.noplayer.Player;
+import com.novoda.noplayer.drm.DownloadedModularDrm;
+import com.novoda.noplayer.drm.DrmHandler;
+import com.novoda.noplayer.drm.DrmType;
+import com.novoda.noplayer.drm.StreamingModularDrm;
+import com.novoda.noplayer.exoplayer.NoPlayerExoPlayerCreator;
+import com.novoda.noplayer.exoplayer.drm.DrmSessionCreatorFactory;
+import com.novoda.noplayer.mediaplayer.NoPlayerMediaPlayerCreator;
+import com.novoda.utils.AndroidDeviceVersion;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class PlayerBuilder {
+
+    private DrmType drmType;
+    private DrmHandler drmHandler;
+    private PrioritizedPlayerTypes prioritizedPlayerTypes = PrioritizedPlayerTypes.prioritizeExoPlayer();
+    private boolean downgradeSecureDecoder = false;
+
+    public PlayerBuilder withWidevineClassicDrm() {
+        drmType = DrmType.WIDEVINE_CLASSIC;
+        drmHandler = DrmHandler.NO_DRM;
+        return this;
+    }
+
+    public PlayerBuilder withWidevineModularStreamingDrm(StreamingModularDrm streamingModularDrm) {
+        drmType = DrmType.WIDEVINE_MODULAR_STREAM;
+        drmHandler = streamingModularDrm;
+        return this;
+    }
+
+    public PlayerBuilder withWidevineModularDownloadDrm(DownloadedModularDrm downloadedModularDrm) {
+        drmType = DrmType.WIDEVINE_MODULAR_DOWNLOAD;
+        drmHandler = downloadedModularDrm;
+        return this;
+    }
+
+    @Deprecated
+    public PlayerBuilder withDrm(DrmType drmType, DrmHandler drmHandler) {
+        this.drmType = drmType;
+        this.drmHandler = drmHandler;
+        return this;
+    }
+
+    public PlayerBuilder withPriority(PlayerType playerType, PlayerType... playerTypes) {
+        List<PlayerType> types = new ArrayList<>();
+        types.add(playerType);
+        types.addAll(Arrays.asList(playerTypes));
+        prioritizedPlayerTypes = new PrioritizedPlayerTypes(types);
+        return this;
+    }
+
+    public PlayerBuilder withDowngradedSecureDecoder() {
+        downgradeSecureDecoder = true;
+        return this;
+    }
+
+    public Player build(Context context) {
+        Handler handler = new Handler(Looper.getMainLooper());
+        DrmSessionCreatorFactory drmSessionCreatorFactory = new DrmSessionCreatorFactory(AndroidDeviceVersion.newInstance(), handler);
+        PlayerFactory playerFactory = new PlayerFactory(
+                context,
+                prioritizedPlayerTypes,
+                NoPlayerExoPlayerCreator.newInstance(handler),
+                NoPlayerMediaPlayerCreator.newInstance(handler),
+                drmSessionCreatorFactory
+        );
+        return playerFactory.create(drmType, drmHandler, downgradeSecureDecoder);
+    }
+}

--- a/core/src/main/java/com/novoda/noplayer/player/PlayerFactory.java
+++ b/core/src/main/java/com/novoda/noplayer/player/PlayerFactory.java
@@ -6,10 +6,10 @@ import android.os.Looper;
 
 import com.novoda.noplayer.Player;
 import com.novoda.noplayer.drm.DrmHandler;
-import com.novoda.noplayer.exoplayer.drm.DrmSessionCreator;
-import com.novoda.noplayer.exoplayer.drm.DrmSessionCreatorFactory;
 import com.novoda.noplayer.drm.DrmType;
 import com.novoda.noplayer.exoplayer.NoPlayerExoPlayerCreator;
+import com.novoda.noplayer.exoplayer.drm.DrmSessionCreator;
+import com.novoda.noplayer.exoplayer.drm.DrmSessionCreatorFactory;
 import com.novoda.noplayer.mediaplayer.NoPlayerMediaPlayerCreator;
 import com.novoda.utils.AndroidDeviceVersion;
 
@@ -73,38 +73,6 @@ public class PlayerFactory {
                 return noPlayerExoPlayerCreator.createExoPlayer(context, drmSessionCreator, downgradeSecureDecoder);
             default:
                 throw UnableToCreatePlayerException.unhandledPlayerType(playerType);
-        }
-    }
-
-    public static class UnableToCreatePlayerException extends RuntimeException {
-
-        static UnableToCreatePlayerException unhandledDrmType(DrmType drmType) {
-            return new UnableToCreatePlayerException("Unhandled DrmType: " + drmType);
-        }
-
-        public static UnableToCreatePlayerException noDrmHandlerFor(DrmType drmType) {
-            return new UnableToCreatePlayerException("No DrmHandler for DrmType: " + drmType);
-        }
-
-        static UnableToCreatePlayerException unhandledPlayerType(PlayerType playerType) {
-            return new UnableToCreatePlayerException("Unhandled player type: " + playerType.name());
-        }
-
-        public static UnableToCreatePlayerException deviceDoesNotMeetTargetApiException(DrmType drmType,
-                                                                                        int targetApiLevel,
-                                                                                        AndroidDeviceVersion actualApiLevel) {
-            return new UnableToCreatePlayerException(
-                    "Device must be target: "
-                            + targetApiLevel
-                            + " but was: "
-                            + actualApiLevel.sdkInt()
-                            + " for DRM type: "
-                            + drmType.name()
-            );
-        }
-
-        UnableToCreatePlayerException(String reason) {
-            super(reason);
         }
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/player/PlayerFactory.java
+++ b/core/src/main/java/com/novoda/noplayer/player/PlayerFactory.java
@@ -1,8 +1,6 @@
 package com.novoda.noplayer.player;
 
 import android.content.Context;
-import android.os.Handler;
-import android.os.Looper;
 
 import com.novoda.noplayer.Player;
 import com.novoda.noplayer.drm.DrmHandler;
@@ -11,29 +9,14 @@ import com.novoda.noplayer.exoplayer.NoPlayerExoPlayerCreator;
 import com.novoda.noplayer.exoplayer.drm.DrmSessionCreator;
 import com.novoda.noplayer.exoplayer.drm.DrmSessionCreatorFactory;
 import com.novoda.noplayer.mediaplayer.NoPlayerMediaPlayerCreator;
-import com.novoda.utils.AndroidDeviceVersion;
 
-public class PlayerFactory {
-
-    private static final boolean DOWNGRADE_SECURE_DECODER = false;
+class PlayerFactory {
 
     private final Context context;
     private final PrioritizedPlayerTypes prioritizedPlayerTypes;
     private final NoPlayerExoPlayerCreator noPlayerExoPlayerCreator;
     private final NoPlayerMediaPlayerCreator noPlayerMediaPlayerCreator;
     private final DrmSessionCreatorFactory drmSessionCreatorFactory;
-
-    public static PlayerFactory newInstance(Context context, PrioritizedPlayerTypes prioritizedPlayerTypes) {
-        Handler handler = new Handler(Looper.getMainLooper());
-        DrmSessionCreatorFactory drmSessionCreatorFactory = new DrmSessionCreatorFactory(AndroidDeviceVersion.newInstance(), handler);
-        return new PlayerFactory(
-                context,
-                prioritizedPlayerTypes,
-                NoPlayerExoPlayerCreator.newInstance(handler),
-                NoPlayerMediaPlayerCreator.newInstance(handler),
-                drmSessionCreatorFactory
-        );
-    }
 
     PlayerFactory(Context context,
                   PrioritizedPlayerTypes prioritizedPlayerTypes,
@@ -47,15 +30,7 @@ public class PlayerFactory {
         this.drmSessionCreatorFactory = drmSessionCreatorFactory;
     }
 
-    public Player create() {
-        return create(DrmType.NONE, DrmHandler.NO_DRM);
-    }
-
-    public Player create(DrmType drmType, DrmHandler drmHandler) {
-        return create(drmType, drmHandler, DOWNGRADE_SECURE_DECODER);
-    }
-
-    public Player create(DrmType drmType, DrmHandler drmHandler, boolean downgradeSecureDecoder) {
+    Player create(DrmType drmType, DrmHandler drmHandler, boolean downgradeSecureDecoder) {
         for (PlayerType player : prioritizedPlayerTypes) {
             if (player.supports(drmType)) {
                 return createPlayerForType(player, drmType, drmHandler, downgradeSecureDecoder);

--- a/core/src/main/java/com/novoda/noplayer/player/UnableToCreatePlayerException.java
+++ b/core/src/main/java/com/novoda/noplayer/player/UnableToCreatePlayerException.java
@@ -1,0 +1,36 @@
+package com.novoda.noplayer.player;
+
+import com.novoda.noplayer.drm.DrmType;
+import com.novoda.utils.AndroidDeviceVersion;
+
+public class UnableToCreatePlayerException extends RuntimeException {
+
+    static UnableToCreatePlayerException unhandledDrmType(DrmType drmType) {
+        return new UnableToCreatePlayerException("Unhandled DrmType: " + drmType);
+    }
+
+    public static UnableToCreatePlayerException noDrmHandlerFor(DrmType drmType) {
+        return new UnableToCreatePlayerException("No DrmHandler for DrmType: " + drmType);
+    }
+
+    static UnableToCreatePlayerException unhandledPlayerType(PlayerType playerType) {
+        return new UnableToCreatePlayerException("Unhandled player type: " + playerType.name());
+    }
+
+    public static UnableToCreatePlayerException deviceDoesNotMeetTargetApiException(DrmType drmType,
+                                                                                    int targetApiLevel,
+                                                                                    AndroidDeviceVersion actualApiLevel) {
+        return new UnableToCreatePlayerException(
+                "Device must be target: "
+                        + targetApiLevel
+                        + " but was: "
+                        + actualApiLevel.sdkInt()
+                        + " for DRM type: "
+                        + drmType.name()
+        );
+    }
+
+    UnableToCreatePlayerException(String reason) {
+        super(reason);
+    }
+}

--- a/core/src/test/java/com/novoda/noplayer/exoplayer/ExoPlayerFacadeTest.java
+++ b/core/src/test/java/com/novoda/noplayer/exoplayer/ExoPlayerFacadeTest.java
@@ -5,17 +5,18 @@ import android.view.SurfaceHolder;
 
 import com.google.android.exoplayer2.SimpleExoPlayer;
 import com.google.android.exoplayer2.drm.DefaultDrmSessionManager;
+import com.google.android.exoplayer2.mediacodec.MediaCodecSelector;
 import com.google.android.exoplayer2.source.MediaSource;
 import com.novoda.noplayer.ContentType;
-import com.novoda.noplayer.model.PlayerAudioTrack;
-import com.novoda.noplayer.model.PlayerSubtitleTrack;
-import com.novoda.noplayer.model.VideoDuration;
-import com.novoda.noplayer.model.VideoPosition;
 import com.novoda.noplayer.exoplayer.drm.DrmSessionCreator;
 import com.novoda.noplayer.exoplayer.forwarder.ExoPlayerForwarder;
 import com.novoda.noplayer.exoplayer.mediasource.ExoPlayerAudioTrackSelector;
 import com.novoda.noplayer.exoplayer.mediasource.ExoPlayerSubtitleTrackSelector;
 import com.novoda.noplayer.exoplayer.mediasource.MediaSourceFactory;
+import com.novoda.noplayer.model.PlayerAudioTrack;
+import com.novoda.noplayer.model.PlayerSubtitleTrack;
+import com.novoda.noplayer.model.VideoDuration;
+import com.novoda.noplayer.model.VideoPosition;
 
 import java.util.Collections;
 import java.util.List;
@@ -45,7 +46,6 @@ import static org.mockito.Mockito.when;
 @RunWith(Enclosed.class)
 public class ExoPlayerFacadeTest {
 
-    private static final boolean USE_SECURE_CODEC = true;
     private static final long TWO_MINUTES_IN_MILLIS = 120000;
     private static final long TEN_MINUTES_IN_MILLIS = 600000;
 
@@ -79,7 +79,7 @@ public class ExoPlayerFacadeTest {
         @Test
         public void whenLoadingVideo_thenAddsPlayerEventListener() {
 
-            facade.loadVideo(drmSessionCreator, uri, ANY_CONTENT_TYPE, exoPlayerForwarder, USE_SECURE_CODEC);
+            facade.loadVideo(drmSessionCreator, uri, ANY_CONTENT_TYPE, exoPlayerForwarder, mediaCodecSelector);
 
             verify(exoPlayer).addListener(exoPlayerForwarder.exoPlayerEventListener());
         }
@@ -87,7 +87,7 @@ public class ExoPlayerFacadeTest {
         @Test
         public void whenLoadingVideo_thenSetsVideoDebugListener() {
 
-            facade.loadVideo(drmSessionCreator, uri, ANY_CONTENT_TYPE, exoPlayerForwarder, USE_SECURE_CODEC);
+            facade.loadVideo(drmSessionCreator, uri, ANY_CONTENT_TYPE, exoPlayerForwarder, mediaCodecSelector);
 
             verify(exoPlayer).setVideoDebugListener(exoPlayerForwarder.videoRendererEventListener());
         }
@@ -96,7 +96,7 @@ public class ExoPlayerFacadeTest {
         public void givenMediaSource_whenLoadingVideo_thenPreparesInternalExoPlayer() {
             MediaSource mediaSource = givenMediaSource();
 
-            facade.loadVideo(drmSessionCreator, uri, ANY_CONTENT_TYPE, exoPlayerForwarder, USE_SECURE_CODEC);
+            facade.loadVideo(drmSessionCreator, uri, ANY_CONTENT_TYPE, exoPlayerForwarder, mediaCodecSelector);
 
             verify(exoPlayer).prepare(mediaSource, RESET_POSITION, DO_NOT_RESET_STATE);
         }
@@ -192,7 +192,7 @@ public class ExoPlayerFacadeTest {
 
         private void givenPlayerIsLoaded() {
             givenMediaSource();
-            facade.loadVideo(drmSessionCreator, uri, ANY_CONTENT_TYPE, exoPlayerForwarder, USE_SECURE_CODEC);
+            facade.loadVideo(drmSessionCreator, uri, ANY_CONTENT_TYPE, exoPlayerForwarder, mediaCodecSelector);
         }
 
         @Test
@@ -392,6 +392,8 @@ public class ExoPlayerFacadeTest {
         DrmSessionCreator drmSessionCreator;
         @Mock
         DefaultDrmSessionManager.EventListener drmSessionEventListener;
+        @Mock
+        MediaCodecSelector mediaCodecSelector;
 
         ExoPlayerFacade facade;
 
@@ -399,7 +401,7 @@ public class ExoPlayerFacadeTest {
         public void setUp() {
             ExoPlayerCreator exoPlayerCreator = mock(ExoPlayerCreator.class);
             given(exoPlayerForwarder.drmSessionEventListener()).willReturn(drmSessionEventListener);
-            given(exoPlayerCreator.create(drmSessionCreator, drmSessionEventListener, USE_SECURE_CODEC)).willReturn(exoPlayer);
+            given(exoPlayerCreator.create(drmSessionCreator, drmSessionEventListener, mediaCodecSelector)).willReturn(exoPlayer);
             when(rendererTypeRequesterCreator.createfrom(exoPlayer)).thenReturn(rendererTypeRequester);
             facade = new ExoPlayerFacade(
                     mediaSourceFactory,

--- a/core/src/test/java/com/novoda/noplayer/exoplayer/ExoPlayerTwoImplTest.java
+++ b/core/src/test/java/com/novoda/noplayer/exoplayer/ExoPlayerTwoImplTest.java
@@ -4,6 +4,7 @@ import android.net.Uri;
 import android.view.SurfaceHolder;
 
 import com.google.android.exoplayer2.ExoPlayerLibraryInfo;
+import com.google.android.exoplayer2.mediacodec.MediaCodecSelector;
 import com.google.android.exoplayer2.text.Cue;
 import com.novoda.noplayer.ContentType;
 import com.novoda.noplayer.Heart;
@@ -60,7 +61,6 @@ import static org.mockito.Mockito.verify;
 @RunWith(Enclosed.class)
 public class ExoPlayerTwoImplTest {
 
-    private static final boolean USE_SECURE_CODEC = true;
     private static final long TWO_MINUTES_IN_MILLIS = 120000;
     private static final long TEN_SECONDS = 10;
 
@@ -181,7 +181,7 @@ public class ExoPlayerTwoImplTest {
 
             player.loadVideo(uri, ANY_CONTENT_TYPE);
 
-            verify(exoPlayerFacade).loadVideo(drmSessionCreator, uri, ANY_CONTENT_TYPE, forwarder, USE_SECURE_CODEC);
+            verify(exoPlayerFacade).loadVideo(drmSessionCreator, uri, ANY_CONTENT_TYPE, forwarder, mediaCodecSelector);
         }
 
         @Test
@@ -189,7 +189,7 @@ public class ExoPlayerTwoImplTest {
 
             player.loadVideoWithTimeout(uri, ANY_CONTENT_TYPE, ANY_TIMEOUT, ANY_LOAD_TIMEOUT_CALLBACK);
 
-            verify(exoPlayerFacade).loadVideo(drmSessionCreator, uri, ANY_CONTENT_TYPE, forwarder, USE_SECURE_CODEC);
+            verify(exoPlayerFacade).loadVideo(drmSessionCreator, uri, ANY_CONTENT_TYPE, forwarder, mediaCodecSelector);
         }
 
         @Test
@@ -542,6 +542,8 @@ public class ExoPlayerTwoImplTest {
         ExoPlayerTrackSelector exoPlayerTrackSelector;
         @Mock
         DrmSessionCreator drmSessionCreator;
+        @Mock
+        MediaCodecSelector mediaCodecSelector;
 
         ExoPlayerTwoImpl player;
 
@@ -575,7 +577,7 @@ public class ExoPlayerTwoImplTest {
                     loadTimeout,
                     heart,
                     drmSessionCreator,
-                    USE_SECURE_CODEC
+                    mediaCodecSelector
             );
         }
     }

--- a/core/src/test/java/com/novoda/noplayer/exoplayer/SecurityDowngradingCodecSelectorTest.java
+++ b/core/src/test/java/com/novoda/noplayer/exoplayer/SecurityDowngradingCodecSelectorTest.java
@@ -15,11 +15,8 @@ import static org.mockito.Mockito.verify;
 
 public class SecurityDowngradingCodecSelectorTest {
 
-    private static final boolean ANY_USE_SECURE_DECODER = false;
     private static final String ANY_MIME_TYPE = "mimeType";
 
-    private static final boolean NOT_DOWNGRADING = false;
-    private static final boolean DOWNGRADING = true;
     private static final boolean CONTENT_SECURE = true;
     private static final boolean CONTENT_INSECURE = false;
 
@@ -30,30 +27,8 @@ public class SecurityDowngradingCodecSelectorTest {
     private SecurityDowngradingCodecSelector.InternalMediaCodecUtil internalMediaCodecUtil;
 
     @Test
-    public void givenContentIsSecure_whenNotDowngrading_thenRequiresSecureDecoderIsTrue() throws MediaCodecUtil.DecoderQueryException {
-        SecurityDowngradingCodecSelector securityDowngradingCodecSelector = new SecurityDowngradingCodecSelector(internalMediaCodecUtil, NOT_DOWNGRADING);
-
-        securityDowngradingCodecSelector.getDecoderInfo(ANY_MIME_TYPE, CONTENT_SECURE);
-
-        ArgumentCaptor<Boolean> argumentCaptor = ArgumentCaptor.forClass(Boolean.class);
-        verify(internalMediaCodecUtil).getDecoderInfo(eq(ANY_MIME_TYPE), argumentCaptor.capture());
-        assertThat(argumentCaptor.getValue()).isTrue();
-    }
-
-    @Test
-    public void givenContentIsInsecure_whenDowngrading_thenRequiresSecureDecoderIsFalse() throws MediaCodecUtil.DecoderQueryException {
-        SecurityDowngradingCodecSelector securityDowngradingCodecSelector = new SecurityDowngradingCodecSelector(internalMediaCodecUtil, DOWNGRADING);
-
-        securityDowngradingCodecSelector.getDecoderInfo(ANY_MIME_TYPE, CONTENT_INSECURE);
-
-        ArgumentCaptor<Boolean> argumentCaptor = ArgumentCaptor.forClass(Boolean.class);
-        verify(internalMediaCodecUtil).getDecoderInfo(eq(ANY_MIME_TYPE), argumentCaptor.capture());
-        assertThat(argumentCaptor.getValue()).isFalse();
-    }
-
-    @Test
-    public void givenContentIsSecure_whenDowngrading_thenRequiresSecureDecoderIsFalse() throws MediaCodecUtil.DecoderQueryException {
-        SecurityDowngradingCodecSelector securityDowngradingCodecSelector = new SecurityDowngradingCodecSelector(internalMediaCodecUtil, DOWNGRADING);
+    public void whenContentIsSecure_thenRequiresSecureDecoderIsFalse() throws MediaCodecUtil.DecoderQueryException {
+        SecurityDowngradingCodecSelector securityDowngradingCodecSelector = new SecurityDowngradingCodecSelector(internalMediaCodecUtil);
 
         securityDowngradingCodecSelector.getDecoderInfo(ANY_MIME_TYPE, CONTENT_SECURE);
 
@@ -63,8 +38,8 @@ public class SecurityDowngradingCodecSelectorTest {
     }
 
     @Test
-    public void givenContentIsInsecure_whenNotDowngrading_thenRequiresSecureDecoderIsFalse() throws MediaCodecUtil.DecoderQueryException {
-        SecurityDowngradingCodecSelector securityDowngradingCodecSelector = new SecurityDowngradingCodecSelector(internalMediaCodecUtil, NOT_DOWNGRADING);
+    public void whenContentIsInsecure_thenRequiresSecureDecoderIsFalse() throws MediaCodecUtil.DecoderQueryException {
+        SecurityDowngradingCodecSelector securityDowngradingCodecSelector = new SecurityDowngradingCodecSelector(internalMediaCodecUtil);
 
         securityDowngradingCodecSelector.getDecoderInfo(ANY_MIME_TYPE, CONTENT_INSECURE);
 
@@ -75,7 +50,7 @@ public class SecurityDowngradingCodecSelectorTest {
 
     @Test
     public void whenGettingPassthroughDecoderInfo_thenDelegates() throws MediaCodecUtil.DecoderQueryException {
-        SecurityDowngradingCodecSelector securityDowngradingCodecSelector = new SecurityDowngradingCodecSelector(internalMediaCodecUtil, ANY_USE_SECURE_DECODER);
+        SecurityDowngradingCodecSelector securityDowngradingCodecSelector = new SecurityDowngradingCodecSelector(internalMediaCodecUtil);
 
         securityDowngradingCodecSelector.getPassthroughDecoderInfo();
 

--- a/core/src/test/java/com/novoda/noplayer/exoplayer/drm/DrmSessionCreatorFactoryTest.java
+++ b/core/src/test/java/com/novoda/noplayer/exoplayer/drm/DrmSessionCreatorFactoryTest.java
@@ -6,7 +6,7 @@ import com.novoda.noplayer.drm.DownloadedModularDrm;
 import com.novoda.noplayer.drm.DrmHandler;
 import com.novoda.noplayer.drm.DrmType;
 import com.novoda.noplayer.drm.StreamingModularDrm;
-import com.novoda.noplayer.player.PlayerFactory;
+import com.novoda.noplayer.player.UnableToCreatePlayerException;
 import com.novoda.utils.AndroidDeviceVersion;
 
 import org.junit.Before;
@@ -72,7 +72,7 @@ public class DrmSessionCreatorFactoryTest {
         drmSessionCreatorFactory = new DrmSessionCreatorFactory(UNSUPPORTED_MEDIA_DRM_DEVICE_VERSION, handler);
 
         String message = "Device must be target: 18 but was: 17 for DRM type: WIDEVINE_MODULAR_STREAM";
-        thrown.expect(ExceptionMatcher.matches(message, PlayerFactory.UnableToCreatePlayerException.class));
+        thrown.expect(ExceptionMatcher.matches(message, UnableToCreatePlayerException.class));
 
         drmSessionCreatorFactory.createFor(DrmType.WIDEVINE_MODULAR_STREAM, IGNORED_DRM_HANDLER);
     }
@@ -89,7 +89,7 @@ public class DrmSessionCreatorFactoryTest {
         drmSessionCreatorFactory = new DrmSessionCreatorFactory(UNSUPPORTED_MEDIA_DRM_DEVICE_VERSION, handler);
 
         String message = "Device must be target: 18 but was: 17 for DRM type: WIDEVINE_MODULAR_DOWNLOAD";
-        thrown.expect(ExceptionMatcher.matches(message, PlayerFactory.UnableToCreatePlayerException.class));
+        thrown.expect(ExceptionMatcher.matches(message, UnableToCreatePlayerException.class));
 
         drmSessionCreatorFactory.createFor(DrmType.WIDEVINE_MODULAR_DOWNLOAD, IGNORED_DRM_HANDLER);
     }

--- a/core/src/test/java/com/novoda/noplayer/player/NoPlayerCreatorTest.java
+++ b/core/src/test/java/com/novoda/noplayer/player/NoPlayerCreatorTest.java
@@ -29,7 +29,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 
 @RunWith(Enclosed.class)
-public class PlayerFactoryTest {
+public class NoPlayerCreatorTest {
 
     public static abstract class Base {
 
@@ -54,14 +54,14 @@ public class PlayerFactoryTest {
         @Mock
         DrmSessionCreatorFactory drmSessionCreatorFactory;
 
-        PlayerFactory playerFactory;
+        NoPlayerCreator noPlayerCreator;
 
         @Before
         public void setUp() {
             given(drmSessionCreatorFactory.createFor(any(DrmType.class), any(DrmHandler.class))).willReturn(drmSessionCreator);
             given(noPlayerExoPlayerCreator.createExoPlayer(context, drmSessionCreator, USE_SECURE_CODEC)).willReturn(EXO_PLAYER);
             given(noPlayerMediaPlayerCreator.createMediaPlayer(context)).willReturn(MEDIA_PLAYER);
-            playerFactory = new PlayerFactory(context, prioritizedPlayerTypes(), noPlayerExoPlayerCreator, noPlayerMediaPlayerCreator, drmSessionCreatorFactory);
+            noPlayerCreator = new NoPlayerCreator(context, prioritizedPlayerTypes(), noPlayerExoPlayerCreator, noPlayerMediaPlayerCreator, drmSessionCreatorFactory);
         }
 
         abstract PrioritizedPlayerTypes prioritizedPlayerTypes();
@@ -76,28 +76,28 @@ public class PlayerFactoryTest {
 
         @Test
         public void whenCreatingPlayerWithDrmTypeNone_thenReturnsMediaPlayer() {
-            Player player = playerFactory.create(DrmType.NONE, DrmHandler.NO_DRM, USE_SECURE_CODEC);
+            Player player = noPlayerCreator.create(DrmType.NONE, DrmHandler.NO_DRM, USE_SECURE_CODEC);
 
             assertThat(player).isEqualTo(MEDIA_PLAYER);
         }
 
         @Test
         public void whenCreatingPlayerWithDrmTypeWidevineClassic_thenReturnsMediaPlayer() {
-            Player player = playerFactory.create(DrmType.WIDEVINE_CLASSIC, DrmHandler.NO_DRM, USE_SECURE_CODEC);
+            Player player = noPlayerCreator.create(DrmType.WIDEVINE_CLASSIC, DrmHandler.NO_DRM, USE_SECURE_CODEC);
 
             assertThat(player).isEqualTo(MEDIA_PLAYER);
         }
 
         @Test
         public void whenCreatingPlayerWithDrmTypeWidevineModularStream_thenReturnsExoPlayer() {
-            Player player = playerFactory.create(DrmType.WIDEVINE_MODULAR_STREAM, STREAMING_MODULAR_DRM, USE_SECURE_CODEC);
+            Player player = noPlayerCreator.create(DrmType.WIDEVINE_MODULAR_STREAM, STREAMING_MODULAR_DRM, USE_SECURE_CODEC);
 
             assertThat(player).isEqualTo(EXO_PLAYER);
         }
 
         @Test
         public void whenCreatingPlayerWithDrmTypeWidevineModularDownload_thenReturnsExoPlayer() {
-            Player player = playerFactory.create(DrmType.WIDEVINE_MODULAR_DOWNLOAD, DOWNLOADED_MODULAR_DRM, USE_SECURE_CODEC);
+            Player player = noPlayerCreator.create(DrmType.WIDEVINE_MODULAR_DOWNLOAD, DOWNLOADED_MODULAR_DRM, USE_SECURE_CODEC);
 
             assertThat(player).isEqualTo(EXO_PLAYER);
         }
@@ -112,28 +112,28 @@ public class PlayerFactoryTest {
 
         @Test
         public void whenCreatingPlayerWithDrmTypeNone_thenReturnsExoPlayer() {
-            Player player = playerFactory.create(DrmType.NONE, DrmHandler.NO_DRM, USE_SECURE_CODEC);
+            Player player = noPlayerCreator.create(DrmType.NONE, DrmHandler.NO_DRM, USE_SECURE_CODEC);
 
             assertThat(player).isEqualTo(EXO_PLAYER);
         }
 
         @Test
         public void whenCreatingPlayerWithDrmTypeWidevineClassic_thenReturnsMediaPlayer() {
-            Player player = playerFactory.create(DrmType.WIDEVINE_CLASSIC, DrmHandler.NO_DRM, USE_SECURE_CODEC);
+            Player player = noPlayerCreator.create(DrmType.WIDEVINE_CLASSIC, DrmHandler.NO_DRM, USE_SECURE_CODEC);
 
             assertThat(player).isEqualTo(MEDIA_PLAYER);
         }
 
         @Test
         public void whenCreatingPlayerWithDrmTypeWidevineModularStream_thenReturnsExoPlayer() {
-            Player player = playerFactory.create(DrmType.WIDEVINE_MODULAR_STREAM, STREAMING_MODULAR_DRM, USE_SECURE_CODEC);
+            Player player = noPlayerCreator.create(DrmType.WIDEVINE_MODULAR_STREAM, STREAMING_MODULAR_DRM, USE_SECURE_CODEC);
 
             assertThat(player).isEqualTo(EXO_PLAYER);
         }
 
         @Test
         public void whenCreatingPlayerWithDrmTypeWidevineModularDownload_thenReturnsExoPlayer() {
-            Player player = playerFactory.create(DrmType.WIDEVINE_MODULAR_DOWNLOAD, DOWNLOADED_MODULAR_DRM, USE_SECURE_CODEC);
+            Player player = noPlayerCreator.create(DrmType.WIDEVINE_MODULAR_DOWNLOAD, DOWNLOADED_MODULAR_DRM, USE_SECURE_CODEC);
 
             assertThat(player).isEqualTo(EXO_PLAYER);
         }

--- a/core/src/test/java/com/novoda/noplayer/player/PlayerFactoryTest.java
+++ b/core/src/test/java/com/novoda/noplayer/player/PlayerFactoryTest.java
@@ -5,11 +5,11 @@ import android.content.Context;
 import com.novoda.noplayer.Player;
 import com.novoda.noplayer.drm.DownloadedModularDrm;
 import com.novoda.noplayer.drm.DrmHandler;
-import com.novoda.noplayer.exoplayer.drm.DrmSessionCreator;
-import com.novoda.noplayer.exoplayer.drm.DrmSessionCreatorFactory;
 import com.novoda.noplayer.drm.DrmType;
 import com.novoda.noplayer.drm.StreamingModularDrm;
 import com.novoda.noplayer.exoplayer.NoPlayerExoPlayerCreator;
+import com.novoda.noplayer.exoplayer.drm.DrmSessionCreator;
+import com.novoda.noplayer.exoplayer.drm.DrmSessionCreatorFactory;
 import com.novoda.noplayer.mediaplayer.NoPlayerMediaPlayerCreator;
 
 import org.junit.Before;
@@ -75,36 +75,29 @@ public class PlayerFactoryTest {
         }
 
         @Test
-        public void whenCreatingPlayer_thenReturnsMediaPlayer() {
-            Player player = playerFactory.create();
-
-            assertThat(player).isEqualTo(MEDIA_PLAYER);
-        }
-
-        @Test
         public void whenCreatingPlayerWithDrmTypeNone_thenReturnsMediaPlayer() {
-            Player player = playerFactory.create(DrmType.NONE, DrmHandler.NO_DRM);
+            Player player = playerFactory.create(DrmType.NONE, DrmHandler.NO_DRM, USE_SECURE_CODEC);
 
             assertThat(player).isEqualTo(MEDIA_PLAYER);
         }
 
         @Test
         public void whenCreatingPlayerWithDrmTypeWidevineClassic_thenReturnsMediaPlayer() {
-            Player player = playerFactory.create(DrmType.WIDEVINE_CLASSIC, DrmHandler.NO_DRM);
+            Player player = playerFactory.create(DrmType.WIDEVINE_CLASSIC, DrmHandler.NO_DRM, USE_SECURE_CODEC);
 
             assertThat(player).isEqualTo(MEDIA_PLAYER);
         }
 
         @Test
         public void whenCreatingPlayerWithDrmTypeWidevineModularStream_thenReturnsExoPlayer() {
-            Player player = playerFactory.create(DrmType.WIDEVINE_MODULAR_STREAM, STREAMING_MODULAR_DRM);
+            Player player = playerFactory.create(DrmType.WIDEVINE_MODULAR_STREAM, STREAMING_MODULAR_DRM, USE_SECURE_CODEC);
 
             assertThat(player).isEqualTo(EXO_PLAYER);
         }
 
         @Test
         public void whenCreatingPlayerWithDrmTypeWidevineModularDownload_thenReturnsExoPlayer() {
-            Player player = playerFactory.create(DrmType.WIDEVINE_MODULAR_DOWNLOAD, DOWNLOADED_MODULAR_DRM);
+            Player player = playerFactory.create(DrmType.WIDEVINE_MODULAR_DOWNLOAD, DOWNLOADED_MODULAR_DRM, USE_SECURE_CODEC);
 
             assertThat(player).isEqualTo(EXO_PLAYER);
         }
@@ -118,36 +111,29 @@ public class PlayerFactoryTest {
         }
 
         @Test
-        public void whenCreatingPlayer_thenReturnsExoPlayer() {
-            Player player = playerFactory.create();
-
-            assertThat(player).isEqualTo(EXO_PLAYER);
-        }
-
-        @Test
         public void whenCreatingPlayerWithDrmTypeNone_thenReturnsExoPlayer() {
-            Player player = playerFactory.create(DrmType.NONE, DrmHandler.NO_DRM);
+            Player player = playerFactory.create(DrmType.NONE, DrmHandler.NO_DRM, USE_SECURE_CODEC);
 
             assertThat(player).isEqualTo(EXO_PLAYER);
         }
 
         @Test
         public void whenCreatingPlayerWithDrmTypeWidevineClassic_thenReturnsMediaPlayer() {
-            Player player = playerFactory.create(DrmType.WIDEVINE_CLASSIC, DrmHandler.NO_DRM);
+            Player player = playerFactory.create(DrmType.WIDEVINE_CLASSIC, DrmHandler.NO_DRM, USE_SECURE_CODEC);
 
             assertThat(player).isEqualTo(MEDIA_PLAYER);
         }
 
         @Test
         public void whenCreatingPlayerWithDrmTypeWidevineModularStream_thenReturnsExoPlayer() {
-            Player player = playerFactory.create(DrmType.WIDEVINE_MODULAR_STREAM, STREAMING_MODULAR_DRM);
+            Player player = playerFactory.create(DrmType.WIDEVINE_MODULAR_STREAM, STREAMING_MODULAR_DRM, USE_SECURE_CODEC);
 
             assertThat(player).isEqualTo(EXO_PLAYER);
         }
 
         @Test
         public void whenCreatingPlayerWithDrmTypeWidevineModularDownload_thenReturnsExoPlayer() {
-            Player player = playerFactory.create(DrmType.WIDEVINE_MODULAR_DOWNLOAD, DOWNLOADED_MODULAR_DRM);
+            Player player = playerFactory.create(DrmType.WIDEVINE_MODULAR_DOWNLOAD, DOWNLOADED_MODULAR_DRM, USE_SECURE_CODEC);
 
             assertThat(player).isEqualTo(EXO_PLAYER);
         }

--- a/demo/src/main/java/com/novoda/demo/MainActivity.java
+++ b/demo/src/main/java/com/novoda/demo/MainActivity.java
@@ -11,13 +11,11 @@ import android.widget.Toast;
 
 import com.novoda.noplayer.ContentType;
 import com.novoda.noplayer.Player;
-import com.novoda.noplayer.model.PlayerAudioTrack;
 import com.novoda.noplayer.PlayerState;
-import com.novoda.noplayer.model.PlayerSubtitleTrack;
 import com.novoda.noplayer.PlayerView;
-import com.novoda.noplayer.drm.DrmType;
-import com.novoda.noplayer.player.PlayerFactory;
-import com.novoda.noplayer.player.PrioritizedPlayerTypes;
+import com.novoda.noplayer.model.PlayerAudioTrack;
+import com.novoda.noplayer.model.PlayerSubtitleTrack;
+import com.novoda.noplayer.player.PlayerBuilder;
 import com.novoda.utils.NoPlayerLog;
 
 import java.util.ArrayList;
@@ -50,10 +48,12 @@ public class MainActivity extends Activity {
     protected void onStart() {
         super.onStart();
         // TODO: Add switch in UI to avoid redeploy.
-        PlayerFactory playerFactory = PlayerFactory.newInstance(this, PrioritizedPlayerTypes.prioritizeExoPlayer());
         DataPostingModularDrm drmHandler = new DataPostingModularDrm(EXAMPLE_MODULAR_LICENSE_SERVER_PROXY);
 
-        player = playerFactory.create(DrmType.WIDEVINE_MODULAR_STREAM, drmHandler);
+        player = new PlayerBuilder()
+                .withWidevineModularStreamingDrm(drmHandler)
+                .build(this);
+
         player.getListeners().addPreparedListener(new Player.PreparedListener() {
             @Override
             public void onPrepared(PlayerState playerState) {


### PR DESCRIPTION
## Problem
As per issue #53 and the conversation that took place in https://github.com/novoda/no-player/pull/52/files/4748c1dd02defdb565cd7174a38deb90ee214d9d#diff-d137d202ec4e30de3f26dfb2c0131896 we want to replace the `PlayerFactory` with a `PlayerBuilder` as the player has a number of customizations that can be exposed to our clients.

## Solution
Create a `PlayerBuilder` and a `PlayerCreator`. We have exposed a `withDowngradedSecureDecoder` to hide the `boolean` we had before. This `boolean` is passed down to the `ExoPlayer` level at which point it is transformed into the necessary `MediaCodecSelector`. The `MediaCodecSelector` is not directly exposed in the `Builder` because it is only necessary for `ExoPlayer`.

### Test(s) added 
Updating tests that we broke as a result of these changes.

### Screenshots
No UI changes.

### Paired with 
@ouchadam 
