### PR TITLE
Subtitles crash and demo flow

### DIFF
--- a/core/src/main/java/com/novoda/noplayer/SubtitleView.java
+++ b/core/src/main/java/com/novoda/noplayer/SubtitleView.java
@@ -19,7 +19,6 @@ public final class SubtitleView extends View {
     private static final boolean APPLY_EMBEDDED_FONT_STYLES = true;
 
     private static final int ZERO_PIXELS = 0;
-    private static final int NO_CUES = 0;
 
     private final List<SubtitlePainter> painters;
 
@@ -31,12 +30,12 @@ public final class SubtitleView extends View {
     }
 
     public void setCues(TextCues textCues) {
-        if (this.textCues.equals(textCues)) {
+        if (textCues.equals(this.textCues)) {
             return;
         }
 
         this.textCues = textCues;
-        int cueCount = (textCues == null) ? NO_CUES : textCues.size();
+        int cueCount = textCues.size();
 
         while (painters.size() < cueCount) {
             painters.add(new SubtitlePainter(getContext()));

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerCueMapper.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerCueMapper.java
@@ -5,6 +5,7 @@ import com.novoda.noplayer.model.NoPlayerCue;
 import com.novoda.noplayer.model.TextCues;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 final class ExoPlayerCueMapper {
@@ -14,6 +15,10 @@ final class ExoPlayerCueMapper {
     }
 
     static TextCues map(List<Cue> cues) {
+        if (cues == null) {
+            return TextCues.of(Collections.<NoPlayerCue>emptyList());
+        }
+
         List<NoPlayerCue> noPlayerCues = new ArrayList<>(cues.size());
 
         for (Cue cue : cues) {

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImpl.java
@@ -163,6 +163,7 @@ class ExoPlayerTwoImpl implements Player {
     }
 
     private void reset() {
+        listenersHolder.resetPreparedState();
         listenersHolder.getStateChangedListeners().onVideoStopped();
         loadTimeout.cancel();
         heart.stopBeatingHeart();

--- a/core/src/main/java/com/novoda/noplayer/internal/listeners/PlayerListenersHolder.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/listeners/PlayerListenersHolder.java
@@ -155,6 +155,10 @@ public class PlayerListenersHolder implements Listeners {
         return bitrateChangedListeners;
     }
 
+    public void resetPreparedState() {
+        preparedListeners.resetPreparedState();
+    }
+
     public void clear() {
         errorListeners.clear();
         preparedListeners.clear();

--- a/core/src/main/java/com/novoda/noplayer/internal/listeners/PreparedListeners.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/listeners/PreparedListeners.java
@@ -34,6 +34,10 @@ class PreparedListeners implements Player.PreparedListener {
         }
     }
 
+    void resetPreparedState() {
+        hasPrepared = false;
+    }
+
     private boolean hasNotPreviouslyPrepared() {
         return !hasPrepared;
     }


### PR DESCRIPTION
## Problem
Crash when trying to check equality of equals on a object that was null 😬 

`NoPlayer` Demo doesn't exactly follow the flow we expect clients to implement...

## Solution
Swap the equality check to prevent crashes.

Make `NoPlayer` demo follow the flow we expect when creating and interacting with a `Player`.

### Test(s) added 
No, just changing flow in Activities.

### Screenshots
No UI changes.

### Paired with 
@Dorvaryn 
