### PR TITLE
ALL-3936/Leaking Player through error listeners

### DIFF
--- a/core/src/main/java/com/novoda/noplayer/Player.java
+++ b/core/src/main/java/com/novoda/noplayer/Player.java
@@ -157,7 +157,7 @@ public interface Player extends PlayerState {
 
     interface ErrorListener {
 
-        void onError(Player player, PlayerError error);
+        void onError(PlayerError error);
     }
 
     interface PreparedListener {

--- a/core/src/main/java/com/novoda/noplayer/PlayerState.java
+++ b/core/src/main/java/com/novoda/noplayer/PlayerState.java
@@ -16,5 +16,4 @@ public interface PlayerState {
     VideoDuration getMediaDuration();
 
     int getBufferPercentage();
-
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImpl.java
@@ -62,7 +62,7 @@ class ExoPlayerTwoImpl implements Player {
         heart.bind(new Heart.Heartbeat(listenersHolder.getHeartbeatCallbacks(), this));
         forwarder.bind(listenersHolder.getPreparedListeners(), this);
         forwarder.bind(listenersHolder.getCompletionListeners(), listenersHolder.getStateChangedListeners());
-        forwarder.bind(listenersHolder.getErrorListeners(), this);
+        forwarder.bind(listenersHolder.getErrorListeners());
         forwarder.bind(listenersHolder.getBufferStateListeners());
         forwarder.bind(listenersHolder.getVideoSizeChangedListeners());
         forwarder.bind(listenersHolder.getBitrateChangedListeners());
@@ -75,7 +75,7 @@ class ExoPlayerTwoImpl implements Player {
         });
         listenersHolder.addErrorListener(new ErrorListener() {
             @Override
-            public void onError(Player player, PlayerError error) {
+            public void onError(PlayerError error) {
                 loadTimeout.cancel();
             }
         });

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/DrmSessionErrorForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/DrmSessionErrorForwarder.java
@@ -6,11 +6,9 @@ import com.novoda.noplayer.internal.exoplayer.playererror.DrmInitiatingError;
 
 class DrmSessionErrorForwarder implements DefaultDrmSessionManager.EventListener {
 
-    private final Player player;
     private final Player.ErrorListener errorListener;
 
-    DrmSessionErrorForwarder(Player player, Player.ErrorListener errorListener) {
-        this.player = player;
+    DrmSessionErrorForwarder(Player.ErrorListener errorListener) {
         this.errorListener = errorListener;
     }
 
@@ -22,7 +20,7 @@ class DrmSessionErrorForwarder implements DefaultDrmSessionManager.EventListener
     @Override
     public void onDrmSessionManagerError(Exception e) {
         Player.PlayerError playerError = new DrmInitiatingError(e);
-        errorListener.onError(player, playerError);
+        errorListener.onError(playerError);
     }
 
     @Override

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/ExoPlayerForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/ExoPlayerForwarder.java
@@ -52,10 +52,10 @@ public class ExoPlayerForwarder {
         exoPlayerEventListener.add(new OnCompletionStateChangedForwarder(stateChangedListener));
     }
 
-    public void bind(Player.ErrorListener errorListener, Player player) {
-        exoPlayerEventListener.add(new PlayerOnErrorForwarder(player, errorListener));
-        extractorMediaSourceListener.add(new MediaSourceOnErrorForwarder(player, errorListener));
-        drmSessionEventListener.add(new DrmSessionErrorForwarder(player, errorListener));
+    public void bind(Player.ErrorListener errorListener) {
+        exoPlayerEventListener.add(new PlayerOnErrorForwarder(errorListener));
+        extractorMediaSourceListener.add(new MediaSourceOnErrorForwarder(errorListener));
+        drmSessionEventListener.add(new DrmSessionErrorForwarder(errorListener));
     }
 
     public void bind(Player.BufferStateListener bufferStateListener) {

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/MediaSourceOnErrorForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/MediaSourceOnErrorForwarder.java
@@ -8,17 +8,15 @@ import java.io.IOException;
 
 class MediaSourceOnErrorForwarder implements ExtractorMediaSource.EventListener {
 
-    private final Player player;
     private final Player.ErrorListener errorListener;
 
-    MediaSourceOnErrorForwarder(Player player, Player.ErrorListener errorListener) {
-        this.player = player;
+    MediaSourceOnErrorForwarder(Player.ErrorListener errorListener) {
         this.errorListener = errorListener;
     }
 
     @Override
     public void onLoadError(IOException error) {
         Player.PlayerError playerError = new MediaSourceError(error);
-        errorListener.onError(player, playerError);
+        errorListener.onError(playerError);
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/PlayerOnErrorForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/PlayerOnErrorForwarder.java
@@ -10,18 +10,16 @@ import com.novoda.noplayer.Player;
 
 class PlayerOnErrorForwarder implements ExoPlayer.EventListener {
 
-    private final Player player;
     private final Player.ErrorListener errorListener;
 
-    PlayerOnErrorForwarder(Player player, Player.ErrorListener errorListener) {
-        this.player = player;
+    PlayerOnErrorForwarder(Player.ErrorListener errorListener) {
         this.errorListener = errorListener;
     }
 
     @Override
     public void onPlayerError(ExoPlaybackException error) {
         Player.PlayerError playerError = ExoPlayerErrorMapper.errorFor(error);
-        errorListener.onError(player, playerError);
+        errorListener.onError(playerError);
     }
 
     @Override

--- a/core/src/main/java/com/novoda/noplayer/internal/listeners/ErrorListeners.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/listeners/ErrorListeners.java
@@ -22,9 +22,9 @@ class ErrorListeners implements Player.ErrorListener {
     }
 
     @Override
-    public void onError(Player player, Player.PlayerError error) {
+    public void onError(Player.PlayerError error) {
         for (Player.ErrorListener listener : listeners) {
-            listener.onError(player, error);
+            listener.onError(error);
         }
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImpl.java
@@ -68,7 +68,7 @@ class AndroidMediaPlayerImpl implements Player {
 
     void initialise() {
         forwarder.bind(listenersHolder.getPreparedListeners(), this);
-        forwarder.bind(listenersHolder.getBufferStateListeners(), listenersHolder.getErrorListeners(), this);
+        forwarder.bind(listenersHolder.getBufferStateListeners(), listenersHolder.getErrorListeners());
         forwarder.bind(listenersHolder.getCompletionListeners(), listenersHolder.getStateChangedListeners());
         forwarder.bind(listenersHolder.getVideoSizeChangedListeners());
         forwarder.bind(listenersHolder.getInfoListeners());
@@ -87,7 +87,7 @@ class AndroidMediaPlayerImpl implements Player {
         });
         listenersHolder.addErrorListener(new ErrorListener() {
             @Override
-            public void onError(Player player, PlayerError error) {
+            public void onError(PlayerError error) {
                 loadTimeout.cancel();
             }
         });

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/forwarder/ErrorForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/forwarder/ErrorForwarder.java
@@ -9,19 +9,17 @@ class ErrorForwarder implements MediaPlayer.OnErrorListener {
 
     private final Player.BufferStateListener bufferStateListener;
     private final Player.ErrorListener errorListener;
-    private final Player player;
 
-    ErrorForwarder(Player.BufferStateListener bufferStateListener, Player.ErrorListener errorListener, Player player) {
+    ErrorForwarder(Player.BufferStateListener bufferStateListener, Player.ErrorListener errorListener) {
         this.bufferStateListener = bufferStateListener;
         this.errorListener = errorListener;
-        this.player = player;
     }
 
     @Override
     public boolean onError(MediaPlayer mp, int what, int extra) {
         bufferStateListener.onBufferCompleted();
         Player.PlayerError error = ErrorFactory.createErrorFrom(what, extra);
-        errorListener.onError(player, error);
+        errorListener.onError(error);
         return true;
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/forwarder/MediaPlayerForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/forwarder/MediaPlayerForwarder.java
@@ -26,10 +26,10 @@ public class MediaPlayerForwarder {
         this.preparedListener.add(new OnPreparedForwarder(preparedListener, playerState));
     }
 
-    public void bind(Player.BufferStateListener bufferStateListener, Player.ErrorListener errorListener, Player player) {
+    public void bind(Player.BufferStateListener bufferStateListener, Player.ErrorListener errorListener) {
         preparedListener.add(new BufferOnPreparedListener(bufferStateListener));
         heartBeatListener.add(new BufferHeartbeatListener(bufferStateListener));
-        this.errorListener.add(new ErrorForwarder(bufferStateListener, errorListener, player));
+        this.errorListener.add(new ErrorForwarder(bufferStateListener, errorListener));
     }
 
     public void bind(Player.CompletionListener completionListener, Player.StateChangedListener stateChangedListener) {

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImplTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImplTest.java
@@ -85,7 +85,7 @@ public class ExoPlayerTwoImplTest {
 
             verify(forwarder).bind(preparedListener, player);
             verify(forwarder).bind(completionListener, stateChangedListener);
-            verify(forwarder).bind(errorListener, player);
+            verify(forwarder).bind(errorListener);
             verify(forwarder).bind(bufferStateListener);
             verify(forwarder).bind(videoSizeChangedListener);
             verify(forwarder).bind(bitrateChangedListener);
@@ -121,7 +121,7 @@ public class ExoPlayerTwoImplTest {
 
             verify(listenersHolder).addErrorListener(argumentCaptor.capture());
             Player.ErrorListener errorListener = argumentCaptor.getValue();
-            errorListener.onError(player, mock(Player.PlayerError.class));
+            errorListener.onError(mock(Player.PlayerError.class));
 
             verify(loadTimeout).cancel();
         }

--- a/core/src/test/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImplTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImplTest.java
@@ -2,7 +2,6 @@ package com.novoda.noplayer.internal.mediaplayer;
 
 import android.media.MediaPlayer;
 import android.net.Uri;
-import android.os.Build;
 import android.os.Handler;
 import android.view.SurfaceHolder;
 import android.view.View;
@@ -10,7 +9,6 @@ import android.view.View;
 import com.novoda.noplayer.ContentType;
 import com.novoda.noplayer.Player;
 import com.novoda.noplayer.PlayerInformation;
-import com.novoda.noplayer.PlayerType;
 import com.novoda.noplayer.PlayerView;
 import com.novoda.noplayer.SurfaceHolderRequester;
 import com.novoda.noplayer.internal.Heart;
@@ -72,7 +70,7 @@ public class AndroidMediaPlayerImplTest {
             player.initialise();
 
             verify(forwarder).bind(preparedListener, player);
-            verify(forwarder).bind(bufferStateListener, errorListener, player);
+            verify(forwarder).bind(bufferStateListener, errorListener);
             verify(forwarder).bind(completionListener, stateChangedListener);
             verify(forwarder).bind(videoSizeChangedListener);
             verify(forwarder).bind(infoListener);
@@ -131,7 +129,7 @@ public class AndroidMediaPlayerImplTest {
             verify(listenersHolder).addErrorListener(errorListenerCaptor.capture());
 
             Player.ErrorListener errorListener = errorListenerCaptor.getValue();
-            errorListener.onError(player, mock(Player.PlayerError.class));
+            errorListener.onError(mock(Player.PlayerError.class));
 
             verify(loadTimeout).cancel();
         }


### PR DESCRIPTION
## Problem
We are leaking `Player` through our `ErrorListeners`, this is potentially dangerous.

## Solution
Remove the `Player` from the `ErrorListeners` and `Forwarders`.

### Test(s) added 
No, just removing `Player` from `ErrorListeners` and `Forwarders`.

### Screenshots
No UI changes.

### Paired with 
@Dorvaryn 
