### PR TITLE
Delegate SurfaceHolder lifecycle to ExoPlayer  

### DIFF
--- a/core/src/main/java/com/novoda/noplayer/PlayerViewSurfaceHolder.java
+++ b/core/src/main/java/com/novoda/noplayer/PlayerViewSurfaceHolder.java
@@ -50,4 +50,9 @@ class PlayerViewSurfaceHolder implements SurfaceHolder.Callback, SurfaceHolderRe
     private boolean isSurfaceHolderReady() {
         return surfaceHolder != null;
     }
+
+    @Override
+    public void removeCallback(Callback callback) {
+        callbacks.remove(callback);
+    }
 }

--- a/core/src/main/java/com/novoda/noplayer/SurfaceHolderRequester.java
+++ b/core/src/main/java/com/novoda/noplayer/SurfaceHolderRequester.java
@@ -6,6 +6,8 @@ public interface SurfaceHolderRequester {
 
     void requestSurfaceHolder(Callback callback);
 
+    void removeCallback(Callback callback);
+
     interface Callback {
 
         void onSurfaceHolderReady(SurfaceHolder surfaceHolder);

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
@@ -67,15 +67,18 @@ class ExoPlayerFacade {
         return exoPlayer.getBufferedPercentage();
     }
 
-    void play(SurfaceHolder surfaceHolder, VideoPosition position) throws IllegalStateException {
-        seekTo(position);
-        play(surfaceHolder);
+    void attachToSurface(SurfaceHolder surfaceHolder) {
+        assertVideoLoaded();
+        exoPlayer.setVideoSurfaceHolder(surfaceHolder);
     }
 
-    void play(SurfaceHolder surfaceHolder) throws IllegalStateException {
+    void play(VideoPosition position) throws IllegalStateException {
+        seekTo(position);
+        play();
+    }
+
+    void play() throws IllegalStateException {
         assertVideoLoaded();
-        exoPlayer.clearVideoSurfaceHolder(surfaceHolder);
-        exoPlayer.setVideoSurfaceHolder(surfaceHolder);
         exoPlayer.setPlayWhenReady(true);
     }
 

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImpl.java
@@ -34,8 +34,6 @@ class ExoPlayerTwoImpl implements Player {
     private final MediaCodecSelector mediaCodecSelector;
     private final LoadTimeout loadTimeout;
 
-    private SurfaceHolderRequester surfaceHolderRequester;
-
     @Nullable
     private PlayerView playerView;
 
@@ -121,13 +119,8 @@ class ExoPlayerTwoImpl implements Player {
     @Override
     public void play() throws IllegalStateException {
         heart.startBeatingHeart();
-        surfaceHolderRequester.requestSurfaceHolder(new SurfaceHolderRequester.Callback() {
-            @Override
-            public void onSurfaceHolderReady(SurfaceHolder surfaceHolder) {
-                exoPlayer.play(surfaceHolder);
-                listenersHolder.getStateChangedListeners().onVideoPlaying();
-            }
-        });
+        exoPlayer.play();
+        listenersHolder.getStateChangedListeners().onVideoPlaying();
     }
 
     @Override
@@ -192,14 +185,19 @@ class ExoPlayerTwoImpl implements Player {
     @Override
     public void attach(PlayerView playerView) {
         this.playerView = playerView;
-        surfaceHolderRequester = playerView.getSurfaceHolderRequester();
+        SurfaceHolderRequester surfaceHolderRequester = playerView.getSurfaceHolderRequester();
         listenersHolder.addStateChangedListener(playerView.getStateChangedListener());
         listenersHolder.addVideoSizeChangedListener(playerView.getVideoSizeChangedListener());
+        surfaceHolderRequester.requestSurfaceHolder(new SurfaceHolderRequester.Callback() {
+            @Override
+            public void onSurfaceHolderReady(SurfaceHolder surfaceHolder) {
+                exoPlayer.attachToSurface(surfaceHolder);
+            }
+        });
     }
 
     @Override
     public void detach(PlayerView playerView) {
-        surfaceHolderRequester = null;
         listenersHolder.removeStateChangedListener(playerView.getStateChangedListener());
         listenersHolder.removeVideoSizeChangedListener(playerView.getVideoSizeChangedListener());
         exoPlayer.removeSubtitleRendererOutput();

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImpl.java
@@ -36,6 +36,8 @@ class ExoPlayerTwoImpl implements Player {
 
     @Nullable
     private PlayerView playerView;
+    @Nullable
+    private SurfaceHolderRequester surfaceHolderRequester;
 
     private int videoWidth;
     private int videoHeight;
@@ -185,22 +187,26 @@ class ExoPlayerTwoImpl implements Player {
     @Override
     public void attach(PlayerView playerView) {
         this.playerView = playerView;
-        SurfaceHolderRequester surfaceHolderRequester = playerView.getSurfaceHolderRequester();
+        surfaceHolderRequester = playerView.getSurfaceHolderRequester();
         listenersHolder.addStateChangedListener(playerView.getStateChangedListener());
         listenersHolder.addVideoSizeChangedListener(playerView.getVideoSizeChangedListener());
-        surfaceHolderRequester.requestSurfaceHolder(new SurfaceHolderRequester.Callback() {
-            @Override
-            public void onSurfaceHolderReady(SurfaceHolder surfaceHolder) {
-                exoPlayer.attachToSurface(surfaceHolder);
-            }
-        });
+        surfaceHolderRequester.requestSurfaceHolder(onSurfaceReady);
     }
+
+    private final SurfaceHolderRequester.Callback onSurfaceReady = new SurfaceHolderRequester.Callback() {
+        @Override
+        public void onSurfaceHolderReady(SurfaceHolder surfaceHolder) {
+            exoPlayer.attachToSurface(surfaceHolder);
+        }
+    };
 
     @Override
     public void detach(PlayerView playerView) {
         listenersHolder.removeStateChangedListener(playerView.getStateChangedListener());
         listenersHolder.removeVideoSizeChangedListener(playerView.getVideoSizeChangedListener());
         exoPlayer.removeSubtitleRendererOutput();
+        surfaceHolderRequester.removeCallback(onSurfaceReady);
+        surfaceHolderRequester = null;
         this.playerView = null;
     }
 

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImpl.java
@@ -22,12 +22,15 @@ import com.novoda.noplayer.model.Timeout;
 import com.novoda.noplayer.model.VideoDuration;
 import com.novoda.noplayer.model.VideoPosition;
 
+import java.util.ArrayList;
 import java.util.List;
 
 class AndroidMediaPlayerImpl implements Player {
 
     private static final VideoPosition NO_SEEK_TO_POSITION = VideoPosition.INVALID;
     private static final int INITIAL_PLAY_SEEK_DELAY_IN_MILLIS = 500;
+
+    private final List<SurfaceHolderRequester.Callback> surfaceHolderRequesterCallbacks = new ArrayList<>();
 
     private final MediaPlayerInformation mediaPlayerInformation;
     private final AndroidMediaPlayerFacade mediaPlayer;
@@ -162,6 +165,7 @@ class AndroidMediaPlayerImpl implements Player {
         if (surfaceHolderRequester == null) {
             throw new IllegalStateException("Must attach a PlayerView before interacting with Player");
         }
+        surfaceHolderRequesterCallbacks.add(callback);
         surfaceHolderRequester.requestSurfaceHolder(callback);
     }
 
@@ -255,10 +259,18 @@ class AndroidMediaPlayerImpl implements Player {
 
     @Override
     public void detach(PlayerView playerView) {
+        clearSurfaceHolderCallbacks();
         surfaceHolderRequester = null;
         listenersHolder.removeStateChangedListener(playerView.getStateChangedListener());
         listenersHolder.removeVideoSizeChangedListener(playerView.getVideoSizeChangedListener());
         buggyVideoDriverPreventer.clear(playerView.getContainerView());
+    }
+
+    private void clearSurfaceHolderCallbacks() {
+        for (SurfaceHolderRequester.Callback callback : surfaceHolderRequesterCallbacks) {
+            surfaceHolderRequester.removeCallback(callback);
+        }
+        surfaceHolderRequesterCallbacks.clear();
     }
 
     @Override

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacadeTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacadeTest.java
@@ -1,6 +1,7 @@
 package com.novoda.noplayer.internal.exoplayer;
 
 import android.net.Uri;
+import android.view.SurfaceHolder;
 
 import com.google.android.exoplayer2.SimpleExoPlayer;
 import com.google.android.exoplayer2.drm.DefaultDrmSessionManager;
@@ -166,6 +167,15 @@ public class ExoPlayerFacadeTest {
             PlayerSubtitleTrack subtitleTrack = mock(PlayerSubtitleTrack.class);
 
             facade.selectSubtitleTrack(subtitleTrack);
+        }
+
+        @Test
+        public void whenAttachingToSurface_thenThrowsIllegalStateException() {
+            thrown.expect(ExceptionMatcher.matches("Video must be loaded before trying to interact with the player", IllegalStateException.class));
+
+            facade.attachToSurface(surfaceHolder);
+
+            verify(exoPlayer).setVideoSurfaceHolder(surfaceHolder);
         }
     }
 
@@ -335,6 +345,14 @@ public class ExoPlayerFacadeTest {
 
             assertThat(audioTracks).isEqualTo(AUDIO_TRACKS);
         }
+
+        @Test
+        public void whenAttachingToSurface_thenDelegatesToExoPlayer() {
+
+            facade.attachToSurface(surfaceHolder);
+
+            verify(exoPlayer).setVideoSurfaceHolder(surfaceHolder);
+        }
     }
 
     public abstract static class Base {
@@ -364,6 +382,8 @@ public class ExoPlayerFacadeTest {
         DefaultDrmSessionManager.EventListener drmSessionEventListener;
         @Mock
         MediaCodecSelector mediaCodecSelector;
+        @Mock
+        SurfaceHolder surfaceHolder;
 
         ExoPlayerFacade facade;
 

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacadeTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacadeTest.java
@@ -1,7 +1,6 @@
 package com.novoda.noplayer.internal.exoplayer;
 
 import android.net.Uri;
-import android.view.SurfaceHolder;
 
 import com.google.android.exoplayer2.SimpleExoPlayer;
 import com.google.android.exoplayer2.drm.DefaultDrmSessionManager;
@@ -27,7 +26,6 @@ import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
-import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
@@ -37,7 +35,6 @@ import utils.ExceptionMatcher;
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -213,19 +210,9 @@ public class ExoPlayerFacadeTest {
         }
 
         @Test
-        public void whenStartingPlayback_thenClearsAndSetsVideoSurfaceHolder() {
-
-            facade.play(surfaceHolder);
-
-            InOrder inOrder = inOrder(exoPlayer);
-            inOrder.verify(exoPlayer).clearVideoSurfaceHolder(surfaceHolder);
-            inOrder.verify(exoPlayer).setVideoSurfaceHolder(surfaceHolder);
-        }
-
-        @Test
         public void whenStartingPlay_thenSetsPlayWhenReadyToTrue() {
 
-            facade.play(surfaceHolder);
+            facade.play();
 
             verify(exoPlayer).setPlayWhenReady(PLAY_WHEN_READY);
         }
@@ -233,7 +220,7 @@ public class ExoPlayerFacadeTest {
         @Test
         public void whenStartingPlayAtVideoPosition_thenSeeksToPosition() {
 
-            facade.play(surfaceHolder, VideoPosition.fromMillis(TWO_MINUTES_IN_MILLIS));
+            facade.play(VideoPosition.fromMillis(TWO_MINUTES_IN_MILLIS));
 
             verify(exoPlayer).seekTo(VideoPosition.fromMillis(TWO_MINUTES_IN_MILLIS).inMillis());
         }
@@ -241,7 +228,7 @@ public class ExoPlayerFacadeTest {
         @Test
         public void whenStartingPlayAtVideoPosition_thenSetsPlayWhenReadyToTrue() {
 
-            facade.play(surfaceHolder, VideoPosition.fromMillis(TWO_MINUTES_IN_MILLIS));
+            facade.play(VideoPosition.fromMillis(TWO_MINUTES_IN_MILLIS));
 
             verify(exoPlayer).setPlayWhenReady(PLAY_WHEN_READY);
         }
@@ -367,8 +354,6 @@ public class ExoPlayerFacadeTest {
         ExoPlayerSubtitleTrackSelector subtitleTrackSelector;
         @Mock
         Uri uri;
-        @Mock
-        SurfaceHolder surfaceHolder;
         @Mock
         RendererTypeRequester rendererTypeRequester;
         @Mock

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImplTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImplTest.java
@@ -201,24 +201,6 @@ public class ExoPlayerTwoImplTest {
         }
 
         @Test
-        public void whenLoadingVideo_thenAddsStateChangedListenerToListenersHolder() {
-            player.attach(playerView);
-
-            player.loadVideo(uri, ANY_CONTENT_TYPE);
-
-            verify(listenersHolder).addStateChangedListener(playerView.getStateChangedListener());
-        }
-
-        @Test
-        public void whenLoadingVideo_thenAddsVideoSizeChangedListenerToListenersHolder() {
-            player.attach(playerView);
-
-            player.loadVideo(uri, ANY_CONTENT_TYPE);
-
-            verify(listenersHolder).addVideoSizeChangedListener(playerView.getVideoSizeChangedListener());
-        }
-
-        @Test
         public void whenQueryingIsPlaying_thenReturnsFalse() {
 
             boolean isPlaying = player.isPlaying();
@@ -318,6 +300,22 @@ public class ExoPlayerTwoImplTest {
             super.setUp();
             player.attach(playerView);
             player.loadVideo(uri, ANY_CONTENT_TYPE);
+        }
+
+        @Test
+        public void whenLoadingVideo_thenAddsStateChangedListenerToListenersHolder() {
+
+            player.loadVideo(uri, ANY_CONTENT_TYPE);
+
+            verify(listenersHolder).addStateChangedListener(playerView.getStateChangedListener());
+        }
+
+        @Test
+        public void whenLoadingVideo_thenAddsVideoSizeChangedListenerToListenersHolder() {
+
+            player.loadVideo(uri, ANY_CONTENT_TYPE);
+
+            verify(listenersHolder).addVideoSizeChangedListener(playerView.getVideoSizeChangedListener());
         }
 
         @Test

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImplTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImplTest.java
@@ -225,6 +225,14 @@ public class ExoPlayerTwoImplTest {
         }
 
         @Test
+        public void whenAttachingPlayerView_thenExoPlayerIsAttachedToSurfaceHolder() {
+
+            player.attach(playerView);
+
+            verify(exoPlayerFacade).attachToSurface(surfaceHolder);
+        }
+
+        @Test
         public void givenAttachedPlayerView_whenDetachingPlayerView_thenRemovesVideoSizeChangedListener() {
             player.attach(playerView);
 

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImplTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImplTest.java
@@ -243,7 +243,8 @@ public class ExoPlayerTwoImplTest {
         }
 
         @Test
-        public void whenDetachingPlayerView_thenRemovesVideoSizeChangedListener() {
+        public void givenAttachedPlayerView_whenDetachingPlayerView_thenRemovesVideoSizeChangedListener() {
+            player.attach(playerView);
 
             player.detach(playerView);
 
@@ -251,7 +252,8 @@ public class ExoPlayerTwoImplTest {
         }
 
         @Test
-        public void whenDetachingPlayerView_thenRemovesStateChangedListener() {
+        public void givenAttachedPlayerView_whenDetachingPlayerView_thenRemovesStateChangedListener() {
+            player.attach(playerView);
 
             player.detach(playerView);
 

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImplTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImplTest.java
@@ -7,11 +7,13 @@ import com.google.android.exoplayer2.ExoPlayerLibraryInfo;
 import com.google.android.exoplayer2.mediacodec.MediaCodecSelector;
 import com.google.android.exoplayer2.text.Cue;
 import com.novoda.noplayer.ContentType;
-import com.novoda.noplayer.internal.Heart;
 import com.novoda.noplayer.Player;
 import com.novoda.noplayer.Player.StateChangedListener;
+import com.novoda.noplayer.PlayerInformation;
+import com.novoda.noplayer.PlayerType;
 import com.novoda.noplayer.PlayerView;
 import com.novoda.noplayer.SurfaceHolderRequester;
+import com.novoda.noplayer.internal.Heart;
 import com.novoda.noplayer.internal.exoplayer.drm.DrmSessionCreator;
 import com.novoda.noplayer.internal.exoplayer.forwarder.ExoPlayerForwarder;
 import com.novoda.noplayer.internal.exoplayer.mediasource.ExoPlayerTrackSelector;
@@ -21,8 +23,6 @@ import com.novoda.noplayer.model.PlayerSubtitleTrack;
 import com.novoda.noplayer.model.TextCues;
 import com.novoda.noplayer.model.Timeout;
 import com.novoda.noplayer.model.VideoPosition;
-import com.novoda.noplayer.PlayerInformation;
-import com.novoda.noplayer.PlayerType;
 
 import java.util.Arrays;
 import java.util.List;
@@ -391,7 +391,7 @@ public class ExoPlayerTwoImplTest {
 
             player.play();
 
-            verify(exoPlayerFacade).play(surfaceHolder);
+            verify(exoPlayerFacade).play();
         }
 
         @Test


### PR DESCRIPTION
## Problem

Spamming play/pause causes the player to freeze and eventually get stuck. This is due to us clearing and resetting the player `SurfaceHolder` each time `Player.play` is called 

## Solution

`SimpleExoPlayer` internally handles the lifecycle of the `SurfaceHolder` so we can simply attach to `SurfaceHolder` to it as part of `Player.attach`.

- Also added a `remove` to the `SurfaceHolderRequest` to avoid leaking any callbacks

### Test(s) added 

Yep around the attach of the `SurfaceHolder` to the `ExoPlayer` via the `Facade` and `Impl`

### Screenshots

no changes in the demo

### Paired with 

nobody