### PR TITLE
Exoplayer SurfaceHolder lifecycle

### DIFF
--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
@@ -67,11 +67,6 @@ class ExoPlayerFacade {
         return exoPlayer.getBufferedPercentage();
     }
 
-    void attachToSurface(SurfaceHolder surfaceHolder) {
-        assertVideoLoaded();
-        exoPlayer.setVideoSurfaceHolder(surfaceHolder);
-    }
-
     void play(VideoPosition position) throws IllegalStateException {
         seekTo(position);
         play();
@@ -99,7 +94,12 @@ class ExoPlayerFacade {
         }
     }
 
-    void loadVideo(DrmSessionCreator drmSessionCreator, Uri uri, ContentType contentType, ExoPlayerForwarder forwarder, MediaCodecSelector mediaCodecSelector) {
+    void loadVideo(SurfaceHolder surfaceHolder,
+                   DrmSessionCreator drmSessionCreator,
+                   Uri uri,
+                   ContentType contentType,
+                   ExoPlayerForwarder forwarder,
+                   MediaCodecSelector mediaCodecSelector) {
         exoPlayer = exoPlayerCreator.create(drmSessionCreator, forwarder.drmSessionEventListener(), mediaCodecSelector);
         rendererTypeRequester = rendererTypeRequesterCreator.createfrom(exoPlayer);
         exoPlayer.addListener(forwarder.exoPlayerEventListener());
@@ -110,7 +110,12 @@ class ExoPlayerFacade {
                 forwarder.extractorMediaSourceListener(),
                 forwarder.mediaSourceEventListener()
         );
+        attachToSurface(surfaceHolder);
         exoPlayer.prepare(mediaSource, RESET_POSITION, DO_NOT_RESET_STATE);
+    }
+
+    private void attachToSurface(SurfaceHolder surfaceHolder) {
+        exoPlayer.setVideoSurfaceHolder(surfaceHolder);
     }
 
     boolean selectAudioTrack(PlayerAudioTrack audioTrack) throws IllegalStateException {

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImpl.java
@@ -166,11 +166,16 @@ class ExoPlayerTwoImpl implements Player {
     }
 
     @Override
-    public void loadVideo(Uri uri, ContentType contentType) {
+    public void loadVideo(final Uri uri, final ContentType contentType) {
         if (exoPlayer.hasPlayedContent()) {
             reset();
         }
-        exoPlayer.loadVideo(drmSessionCreator, uri, contentType, forwarder, mediaCodecSelector);
+        surfaceHolderRequester.requestSurfaceHolder(new SurfaceHolderRequester.Callback() {
+            @Override
+            public void onSurfaceHolderReady(SurfaceHolder surfaceHolder) {
+                exoPlayer.loadVideo(surfaceHolder, drmSessionCreator, uri, contentType, forwarder, mediaCodecSelector);
+            }
+        });
     }
 
     @Override
@@ -190,22 +195,14 @@ class ExoPlayerTwoImpl implements Player {
         surfaceHolderRequester = playerView.getSurfaceHolderRequester();
         listenersHolder.addStateChangedListener(playerView.getStateChangedListener());
         listenersHolder.addVideoSizeChangedListener(playerView.getVideoSizeChangedListener());
-        surfaceHolderRequester.requestSurfaceHolder(onSurfaceReady);
     }
-
-    private final SurfaceHolderRequester.Callback onSurfaceReady = new SurfaceHolderRequester.Callback() {
-        @Override
-        public void onSurfaceHolderReady(SurfaceHolder surfaceHolder) {
-            exoPlayer.attachToSurface(surfaceHolder);
-        }
-    };
 
     @Override
     public void detach(PlayerView playerView) {
         listenersHolder.removeStateChangedListener(playerView.getStateChangedListener());
         listenersHolder.removeVideoSizeChangedListener(playerView.getVideoSizeChangedListener());
         exoPlayer.removeSubtitleRendererOutput();
-        surfaceHolderRequester.removeCallback(onSurfaceReady);
+//        surfaceHolderRequester.removeCallback(onSurfaceReady);
         surfaceHolderRequester = null;
         this.playerView = null;
     }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImpl.java
@@ -41,6 +41,7 @@ class ExoPlayerTwoImpl implements Player {
 
     private int videoWidth;
     private int videoHeight;
+    private SurfaceHolderRequester.Callback onSurfaceReadyCallback;
 
     ExoPlayerTwoImpl(ExoPlayerFacade exoPlayer,
                      PlayerListenersHolder listenersHolder,
@@ -170,12 +171,14 @@ class ExoPlayerTwoImpl implements Player {
         if (exoPlayer.hasPlayedContent()) {
             reset();
         }
-        surfaceHolderRequester.requestSurfaceHolder(new SurfaceHolderRequester.Callback() {
+        surfaceHolderRequester.removeCallback(onSurfaceReadyCallback);
+        onSurfaceReadyCallback = new SurfaceHolderRequester.Callback() {
             @Override
             public void onSurfaceHolderReady(SurfaceHolder surfaceHolder) {
                 exoPlayer.loadVideo(surfaceHolder, drmSessionCreator, uri, contentType, forwarder, mediaCodecSelector);
             }
-        });
+        };
+        surfaceHolderRequester.requestSurfaceHolder(onSurfaceReadyCallback);
     }
 
     @Override
@@ -202,7 +205,7 @@ class ExoPlayerTwoImpl implements Player {
         listenersHolder.removeStateChangedListener(playerView.getStateChangedListener());
         listenersHolder.removeVideoSizeChangedListener(playerView.getVideoSizeChangedListener());
         exoPlayer.removeSubtitleRendererOutput();
-//        surfaceHolderRequester.removeCallback(onSurfaceReady);
+        surfaceHolderRequester.removeCallback(onSurfaceReadyCallback);
         surfaceHolderRequester = null;
         this.playerView = null;
     }

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacadeTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacadeTest.java
@@ -77,7 +77,7 @@ public class ExoPlayerFacadeTest {
         @Test
         public void whenLoadingVideo_thenAddsPlayerEventListener() {
 
-            facade.loadVideo(drmSessionCreator, uri, ANY_CONTENT_TYPE, exoPlayerForwarder, mediaCodecSelector);
+            facade.loadVideo(surfaceHolder, drmSessionCreator, uri, ANY_CONTENT_TYPE, exoPlayerForwarder, mediaCodecSelector);
 
             verify(exoPlayer).addListener(exoPlayerForwarder.exoPlayerEventListener());
         }
@@ -85,16 +85,24 @@ public class ExoPlayerFacadeTest {
         @Test
         public void whenLoadingVideo_thenSetsVideoDebugListener() {
 
-            facade.loadVideo(drmSessionCreator, uri, ANY_CONTENT_TYPE, exoPlayerForwarder, mediaCodecSelector);
+            facade.loadVideo(surfaceHolder, drmSessionCreator, uri, ANY_CONTENT_TYPE, exoPlayerForwarder, mediaCodecSelector);
 
             verify(exoPlayer).setVideoDebugListener(exoPlayerForwarder.videoRendererEventListener());
+        }
+
+        @Test
+        public void whenLoadingVideo_thenSetsSurfaceHolderOnExoPlayer() {
+
+            facade.loadVideo(surfaceHolder, drmSessionCreator, uri, ANY_CONTENT_TYPE, exoPlayerForwarder, mediaCodecSelector);
+
+            verify(exoPlayer).setVideoSurfaceHolder(surfaceHolder);
         }
 
         @Test
         public void givenMediaSource_whenLoadingVideo_thenPreparesInternalExoPlayer() {
             MediaSource mediaSource = givenMediaSource();
 
-            facade.loadVideo(drmSessionCreator, uri, ANY_CONTENT_TYPE, exoPlayerForwarder, mediaCodecSelector);
+            facade.loadVideo(surfaceHolder, drmSessionCreator, uri, ANY_CONTENT_TYPE, exoPlayerForwarder, mediaCodecSelector);
 
             verify(exoPlayer).prepare(mediaSource, RESET_POSITION, DO_NOT_RESET_STATE);
         }
@@ -168,15 +176,6 @@ public class ExoPlayerFacadeTest {
 
             facade.selectSubtitleTrack(subtitleTrack);
         }
-
-        @Test
-        public void whenAttachingToSurface_thenThrowsIllegalStateException() {
-            thrown.expect(ExceptionMatcher.matches("Video must be loaded before trying to interact with the player", IllegalStateException.class));
-
-            facade.attachToSurface(surfaceHolder);
-
-            verify(exoPlayer).setVideoSurfaceHolder(surfaceHolder);
-        }
     }
 
     public static class GivenVideoIsLoaded extends Base {
@@ -192,7 +191,7 @@ public class ExoPlayerFacadeTest {
 
         private void givenPlayerIsLoaded() {
             givenMediaSource();
-            facade.loadVideo(drmSessionCreator, uri, ANY_CONTENT_TYPE, exoPlayerForwarder, mediaCodecSelector);
+            facade.loadVideo(surfaceHolder, drmSessionCreator, uri, ANY_CONTENT_TYPE, exoPlayerForwarder, mediaCodecSelector);
         }
 
         @Test
@@ -344,14 +343,6 @@ public class ExoPlayerFacadeTest {
             List<PlayerAudioTrack> audioTracks = facade.getAudioTracks();
 
             assertThat(audioTracks).isEqualTo(AUDIO_TRACKS);
-        }
-
-        @Test
-        public void whenAttachingToSurface_thenDelegatesToExoPlayer() {
-
-            facade.attachToSurface(surfaceHolder);
-
-            verify(exoPlayer).setVideoSurfaceHolder(surfaceHolder);
         }
     }
 

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImplTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImplTest.java
@@ -170,22 +170,25 @@ public class ExoPlayerTwoImplTest {
 
         @Test
         public void whenLoadingVideo_thenDelegatesLoadingToFacade() {
+            player.attach(playerView);
 
             player.loadVideo(uri, ANY_CONTENT_TYPE);
 
-            verify(exoPlayerFacade).loadVideo(drmSessionCreator, uri, ANY_CONTENT_TYPE, forwarder, mediaCodecSelector);
+            verify(exoPlayerFacade).loadVideo(surfaceHolder, drmSessionCreator, uri, ANY_CONTENT_TYPE, forwarder, mediaCodecSelector);
         }
 
         @Test
         public void whenLoadingVideoWithTimeout_thenDelegatesLoadingToFacade() {
+            player.attach(playerView);
 
             player.loadVideoWithTimeout(uri, ANY_CONTENT_TYPE, ANY_TIMEOUT, ANY_LOAD_TIMEOUT_CALLBACK);
 
-            verify(exoPlayerFacade).loadVideo(drmSessionCreator, uri, ANY_CONTENT_TYPE, forwarder, mediaCodecSelector);
+            verify(exoPlayerFacade).loadVideo(surfaceHolder, drmSessionCreator, uri, ANY_CONTENT_TYPE, forwarder, mediaCodecSelector);
         }
 
         @Test
         public void whenLoadingVideoWithTimeout_thenStartsLoadTimeout() {
+            player.attach(playerView);
 
             player.loadVideoWithTimeout(uri, ANY_CONTENT_TYPE, ANY_TIMEOUT, ANY_LOAD_TIMEOUT_CALLBACK);
 
@@ -225,14 +228,6 @@ public class ExoPlayerTwoImplTest {
         }
 
         @Test
-        public void whenAttachingPlayerView_thenExoPlayerIsAttachedToSurfaceHolder() {
-
-            player.attach(playerView);
-
-            verify(exoPlayerFacade).attachToSurface(surfaceHolder);
-        }
-
-        @Test
         public void givenAttachedPlayerView_whenDetachingPlayerView_thenRemovesVideoSizeChangedListener() {
             player.attach(playerView);
 
@@ -253,6 +248,7 @@ public class ExoPlayerTwoImplTest {
         @Test
         public void givenPlayerHasPlayedVideo_whenLoadingVideo_thenPlayerIsReleased_andNotListeners() {
             given(exoPlayerFacade.hasPlayedContent()).willReturn(true);
+            player.attach(playerView);
 
             player.loadVideo(URI, ContentType.HLS);
 
@@ -266,6 +262,7 @@ public class ExoPlayerTwoImplTest {
         @Test
         public void givenPlayerHasPlayedVideo_whenLoadingVideoWithTimeout_thenPlayerResourcesAreReleased_andNotListeners() {
             given(exoPlayerFacade.hasPlayedContent()).willReturn(true);
+            player.attach(playerView);
 
             player.loadVideoWithTimeout(URI, ContentType.HLS, ANY_TIMEOUT, ANY_LOAD_TIMEOUT_CALLBACK);
 
@@ -279,6 +276,7 @@ public class ExoPlayerTwoImplTest {
         @Test
         public void givenPlayerHasNotPlayedVideo_whenLoadingVideo_thenPlayerResourcesAreNotReleased() {
             given(exoPlayerFacade.hasPlayedContent()).willReturn(false);
+            player.attach(playerView);
 
             player.loadVideo(URI, ContentType.HLS);
 
@@ -291,6 +289,7 @@ public class ExoPlayerTwoImplTest {
         @Test
         public void givenPlayerHasNotPlayedVideo_whenLoadingVideoWithTimeout_thenPlayerResourcesAreNotReleased() {
             given(exoPlayerFacade.hasPlayedContent()).willReturn(false);
+            player.attach(playerView);
 
             player.loadVideoWithTimeout(URI, ContentType.HLS, ANY_TIMEOUT, ANY_LOAD_TIMEOUT_CALLBACK);
 


### PR DESCRIPTION
## Problem

There was a race condition introduced in #65 which allowed the demo to attach a `PlayerView` before `Player.loadVideo` and not crash. 

## Solution

To request the surfaceholder when loading the video and set the holder after creating  `ExoPlayer` instance.

### Test(s) added 

Tests updated to reflect changes

### Screenshots

no ui changes

### Paired with 

nobody