### PR TITLE
Reset prepared state

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ task wrapper(type: Wrapper) {
 }
 
 allprojects {
-    version = "2.0.0"
+    version = "2.0.1"
 }
 
 buildscript {

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImpl.java
@@ -315,6 +315,7 @@ class AndroidMediaPlayerImpl implements Player {
     }
 
     private void reset() {
+        listenersHolder.resetPreparedState();
         loadTimeout.cancel();
         heart.stopBeatingHeart();
         mediaPlayer.release();

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImplTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImplTest.java
@@ -157,10 +157,23 @@ public class ExoPlayerTwoImplTest {
         }
 
         @Test
+        public void whenStopping_thenPlayerResourcesAreReleased() {
+
+            player.stop();
+
+            verify(listenersHolder).resetPreparedState();
+            verify(stateChangedListener).onVideoStopped();
+            verify(loadTimeout).cancel();
+            verify(heart).stopBeatingHeart();
+            verify(exoPlayerFacade).release();
+        }
+
+        @Test
         public void whenReleasing_thenPlayerResourcesAreReleased() {
 
             player.release();
 
+            verify(listenersHolder).resetPreparedState();
             verify(stateChangedListener).onVideoStopped();
             verify(loadTimeout).cancel();
             verify(heart).stopBeatingHeart();

--- a/core/src/test/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImplTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImplTest.java
@@ -340,6 +340,7 @@ public class AndroidMediaPlayerImplTest {
 
             player.stop();
 
+            verify(listenersHolder).resetPreparedState();
             verify(stateChangedListener).onVideoStopped();
             verify(loadTimeout).cancel();
             verify(heart).stopBeatingHeart();
@@ -352,6 +353,7 @@ public class AndroidMediaPlayerImplTest {
 
             player.release();
 
+            verify(listenersHolder).resetPreparedState();
             verify(stateChangedListener).onVideoStopped();
             verify(loadTimeout).cancel();
             verify(heart).stopBeatingHeart();


### PR DESCRIPTION
## Problem
`PreparedListeners` have a flag checking to see if the prepared state has already been called and swallowing additional calls. For `ExoPlayer` when calling `stop` or `release` we reset this flag so that when a new asset is loaded we will receive a new `prepared` event. For `MediaPlayer` we were never resetting this flag so we never received `prepared` calls when changing the video asset.

## Solution
Reset the flag when calling `reset`. 

### Test(s) added 
Yes, both the `ExoPlayer` and `MediaPlayer` were not checking for this call! 😱 

### Screenshots
No UI changes.

### Paired with 
@ouchadam 
