### PR TITLE
Only Play when transitioning 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ task wrapper(type: Wrapper) {
 }
 
 allprojects {
-    version = "2.0.1"
+    version = "2.0.2"
 }
 
 buildscript {

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImpl.java
@@ -121,8 +121,11 @@ class AndroidMediaPlayerImpl implements Player {
         requestSurface(new SurfaceHolderRequester.Callback() {
             @Override
             public void onSurfaceHolderReady(SurfaceHolder surfaceHolder) {
+                boolean videoWasNotPlaying = !isPlaying();
                 mediaPlayer.start(surfaceHolder);
-                listenersHolder.getStateChangedListeners().onVideoPlaying();
+                if (videoWasNotPlaying) {
+                    listenersHolder.getStateChangedListeners().onVideoPlaying();
+                }
             }
         });
     }

--- a/core/src/test/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImplTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImplTest.java
@@ -47,6 +47,7 @@ import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
 
 @RunWith(Enclosed.class)
 public class AndroidMediaPlayerImplTest {
@@ -365,6 +366,8 @@ public class AndroidMediaPlayerImplTest {
     public static class GivenPlayerIsAttached extends Base {
 
         private static final long DELAY_MILLIS = 500;
+        private static final boolean IS_PLAYING = true;
+        private static final boolean IS_NOT_PLAYING = false;
 
         @Override
         public void setUp() {
@@ -536,6 +539,24 @@ public class AndroidMediaPlayerImplTest {
             runnableCaptor.getValue().run();
 
             verify(mediaPlayer).seekTo(differentPosition.inImpreciseMillis());
+        }
+
+        @Test
+        public void givenPlayerIsAlreadyPlaying_whenPlaying_thenDoesNotNotifyOnVideoPlaying() {
+            given(mediaPlayer.isPlaying()).willReturn(IS_PLAYING);
+
+            player.play();
+
+            verifyZeroInteractions(stateChangedListener);
+        }
+
+        @Test
+        public void givenPlayerIsAlreadyPlaying_whenPlaying_thenNotifiesnVideoPlaying() {
+            given(mediaPlayer.isPlaying()).willReturn(IS_NOT_PLAYING);
+
+            player.play();
+
+            verify(stateChangedListener).onVideoPlaying();
         }
 
         private VideoPosition givenPositionThatDiffersFromPlayheadPosition() {


### PR DESCRIPTION
## Problem
We had a crash in a client app that occurred because we were double calling `onVideoPlaying` this occurs only on `MediaPlayer` which calls `play` when performing a seek.

## Solution
Store the `isPlaying` state before calling `mediaPlayer.start` and if the state is already `PLAYING` then do not call `onVideoPlaying`.

### Test(s) added 
Added a test to ensure that we do not call `onVideoPlaying` when the `Player` is already playing.

### Screenshots
No UI changes.

### Paired with 
Nobody but @ouchadam found the problem 😂 
