### PR TITLE
Reset state on error

### DIFF
--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImpl.java
@@ -77,7 +77,7 @@ class ExoPlayerTwoImpl implements Player {
         listenersHolder.addErrorListener(new ErrorListener() {
             @Override
             public void onError(PlayerError error) {
-                loadTimeout.cancel();
+                reset();
             }
         });
         listenersHolder.addVideoSizeChangedListener(new VideoSizeChangedListener() {
@@ -150,17 +150,17 @@ class ExoPlayerTwoImpl implements Player {
     @Override
     public void stop() {
         reset();
+        listenersHolder.getStateChangedListeners().onVideoStopped();
     }
 
     @Override
     public void release() {
-        reset();
+        stop();
         listenersHolder.clear();
     }
 
     private void reset() {
         listenersHolder.resetPreparedState();
-        listenersHolder.getStateChangedListeners().onVideoStopped();
         loadTimeout.cancel();
         heart.stopBeatingHeart();
         exoPlayer.release();
@@ -169,7 +169,7 @@ class ExoPlayerTwoImpl implements Player {
     @Override
     public void loadVideo(final Uri uri, final ContentType contentType) {
         if (exoPlayer.hasPlayedContent()) {
-            reset();
+            stop();
         }
         surfaceHolderRequester.removeCallback(onSurfaceReadyCallback);
         onSurfaceReadyCallback = new SurfaceHolderRequester.Callback() {

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImpl.java
@@ -54,7 +54,7 @@ class AndroidMediaPlayerImpl implements Player {
                            MediaPlayerForwarder forwarder,
                            PlayerListenersHolder listenersHolder,
                            CheckBufferHeartbeatCallback bufferHeartbeatCallback,
-                           LoadTimeout loadTimeoutParam,
+                           LoadTimeout loadTimeout,
                            Heart heart,
                            Handler handler,
                            BuggyVideoDriverPreventer buggyVideoDriverPreventer) {
@@ -63,7 +63,7 @@ class AndroidMediaPlayerImpl implements Player {
         this.forwarder = forwarder;
         this.listenersHolder = listenersHolder;
         this.bufferHeartbeatCallback = bufferHeartbeatCallback;
-        this.loadTimeout = loadTimeoutParam;
+        this.loadTimeout = loadTimeout;
         this.heart = heart;
         this.handler = handler;
         this.buggyVideoDriverPreventer = buggyVideoDriverPreventer;
@@ -91,7 +91,7 @@ class AndroidMediaPlayerImpl implements Player {
         listenersHolder.addErrorListener(new ErrorListener() {
             @Override
             public void onError(PlayerError error) {
-                loadTimeout.cancel();
+                reset();
             }
         });
         listenersHolder.addVideoSizeChangedListener(new VideoSizeChangedListener() {
@@ -201,7 +201,7 @@ class AndroidMediaPlayerImpl implements Player {
     @Override
     public void loadVideo(final Uri uri, ContentType contentType) {
         if (mediaPlayer.hasPlayedContent()) {
-            reset();
+            stop();
         }
         listenersHolder.getBufferStateListeners().onBufferStarted();
         requestSurface(new SurfaceHolderRequester.Callback() {
@@ -309,11 +309,12 @@ class AndroidMediaPlayerImpl implements Player {
     @Override
     public void stop() {
         reset();
+        listenersHolder.getStateChangedListeners().onVideoStopped();
     }
 
     @Override
     public void release() {
-        reset();
+        stop();
         listenersHolder.clear();
     }
 
@@ -322,6 +323,5 @@ class AndroidMediaPlayerImpl implements Player {
         loadTimeout.cancel();
         heart.stopBeatingHeart();
         mediaPlayer.release();
-        listenersHolder.getStateChangedListeners().onVideoStopped();
     }
 }

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImplTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImplTest.java
@@ -128,6 +128,7 @@ public class ExoPlayerTwoImplTest {
             verify(heart).stopBeatingHeart();
             verify(exoPlayerFacade).release();
             verify(listenersHolder, never()).clear();
+            verify(stateChangedListener, never()).onVideoStopped();
         }
 
         @Test

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImplTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImplTest.java
@@ -114,7 +114,7 @@ public class ExoPlayerTwoImplTest {
         }
 
         @Test
-        public void givenPlayerIsInitialised_whenVideoHasError_thenCancelsTimeout() {
+        public void givenPlayerIsInitialised_whenVideoHasError_thenPlayerResourcesAreReleased_andNotListeners() {
             player.initialise();
 
             ArgumentCaptor<Player.ErrorListener> argumentCaptor = ArgumentCaptor.forClass(Player.ErrorListener.class);
@@ -123,7 +123,11 @@ public class ExoPlayerTwoImplTest {
             Player.ErrorListener errorListener = argumentCaptor.getValue();
             errorListener.onError(mock(Player.PlayerError.class));
 
+            verify(listenersHolder).resetPreparedState();
             verify(loadTimeout).cancel();
+            verify(heart).stopBeatingHeart();
+            verify(exoPlayerFacade).release();
+            verify(listenersHolder, never()).clear();
         }
 
         @Test

--- a/core/src/test/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImplTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImplTest.java
@@ -149,6 +149,7 @@ public class AndroidMediaPlayerImplTest {
             verify(heart).stopBeatingHeart();
             verify(mediaPlayer).release();
             verify(listenersHolder, never()).clear();
+            verify(stateChangedListener, never()).onVideoStopped();
         }
 
         @Test

--- a/core/src/test/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImplTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImplTest.java
@@ -136,6 +136,22 @@ public class AndroidMediaPlayerImplTest {
         }
 
         @Test
+        public void givenInitialised_whenCallingOnError_thenPlayerResourcesAreReleased_andNotListeners() {
+            player.initialise();
+            ArgumentCaptor<Player.ErrorListener> errorListenerCaptor = ArgumentCaptor.forClass(Player.ErrorListener.class);
+            verify(listenersHolder).addErrorListener(errorListenerCaptor.capture());
+
+            Player.ErrorListener errorListener = errorListenerCaptor.getValue();
+            errorListener.onError(mock(Player.PlayerError.class));
+
+            verify(listenersHolder).resetPreparedState();
+            verify(loadTimeout).cancel();
+            verify(heart).stopBeatingHeart();
+            verify(mediaPlayer).release();
+            verify(listenersHolder, never()).clear();
+        }
+
+        @Test
         public void givenInitialised_whenCallingOnVideoSizeChanged_thenVideoWidthAndHeightMatches() {
             player.initialise();
             ArgumentCaptor<Player.VideoSizeChangedListener> videoSizeChangedListenerCaptor = ArgumentCaptor.forClass(Player.VideoSizeChangedListener.class);


### PR DESCRIPTION
## Problem
When receiving an error we never change state. If retrying, it is possible to become stuck in a loop because we are saying that the player is still able to play when it is not.

## Solution
Reset `Player` state when an error occurs. 

### Test(s) added 
Yes, verifying that we reset the state in the event of an error.

### Screenshots
No UI changes.

### Paired with 
@Dorvaryn and @ouchadam
