### PR TITLE
Jelly bean crash

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ task wrapper(type: Wrapper) {
 }
 
 allprojects {
-    version = "2.0.4"
+    version = "2.0.5"
 }
 
 buildscript {

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/drm/LocalDrmSessionManager.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/drm/LocalDrmSessionManager.java
@@ -1,9 +1,6 @@
 package com.novoda.noplayer.internal.exoplayer.drm;
 
 import android.annotation.TargetApi;
-import android.media.MediaCryptoException;
-import android.media.NotProvisionedException;
-import android.media.ResourceBusyException;
 import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
@@ -38,7 +35,7 @@ class LocalDrmSessionManager implements DrmSessionManager<FrameworkMediaCrypto> 
         this.handler = handler;
     }
 
-    @TargetApi(Build.VERSION_CODES.KITKAT)
+    @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR2)
     @Override
     public DrmSession<FrameworkMediaCrypto> acquireSession(Looper playbackLooper, DrmInitData drmInitData) {
         DrmSession<FrameworkMediaCrypto> drmSession;
@@ -50,11 +47,10 @@ class LocalDrmSessionManager implements DrmSessionManager<FrameworkMediaCrypto> 
             mediaDrm.restoreKeys(sessionId.asBytes(), keySetIdToRestore.asBytes());
 
             drmSession = new LocalDrmSession(mediaCrypto, keySetIdToRestore, sessionId);
-        } catch (NotProvisionedException | MediaCryptoException | ResourceBusyException exception) {
+        } catch (Exception exception) { // We are forced to catch Exception as ResourceBusyException is api level 19.
             drmSession = new InvalidDrmSession(new DrmSession.DrmSessionException(exception));
             notifyErrorListener(drmSession);
         }
-
         return drmSession;
     }
 


### PR DESCRIPTION
## Problem
When trying to play DRM protected content on API level 18 we would see a crash. This occurred because `LocalDrmSessionManager` was targeting API level 19 when we should have been targeting API 18. We wrongly thought that we should be targeting 19 because `ResourceBusyException` is an API 19 exception... but apparently, if you just use `Exception` in your catch it doesn't matter 🤷‍♂️ and yes ExoPlayer does this too in the Demo...

## Solution
Target API level 18 and catch a generic `Exception` rather than the unsupported `Exception`...

### Test(s) added 
No, just changed the target and edited the exception.

### Screenshots
No UI changes.

### Paired with 
@ouchadam and @zegnus, debugging TEAM!
