### PR TITLE
NO-72/Stop double calling state changes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ task wrapper(type: Wrapper) {
 }
 
 allprojects {
-    version = "2.0.5"
+    version = "2.0.6"
 }
 
 buildscript {

--- a/core/src/main/java/com/novoda/noplayer/internal/listeners/StateChangedListeners.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/listeners/StateChangedListeners.java
@@ -1,6 +1,7 @@
 package com.novoda.noplayer.internal.listeners;
 
 import com.novoda.noplayer.Player;
+import com.novoda.utils.NoPlayerLog;
 
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
@@ -32,6 +33,7 @@ class StateChangedListeners implements Player.StateChangedListener {
     @Override
     public void onVideoPlaying() {
         if (currentState == State.PLAYING) {
+            NoPlayerLog.e("Tried calling onVideoPlaying() but video is already playing.");
             return;
         }
 
@@ -45,6 +47,7 @@ class StateChangedListeners implements Player.StateChangedListener {
     @Override
     public void onVideoPaused() {
         if (currentState == State.PAUSED) {
+            NoPlayerLog.e("Tried calling onVideoPaused() but video is already paused.");
             return;
         }
 
@@ -58,6 +61,7 @@ class StateChangedListeners implements Player.StateChangedListener {
     @Override
     public void onVideoStopped() {
         if (currentState == State.STOPPED) {
+            NoPlayerLog.e("Tried calling onVideoStopped() but video has already stopped.");
             return;
         }
 

--- a/core/src/main/java/com/novoda/noplayer/internal/listeners/StateChangedListeners.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/listeners/StateChangedListeners.java
@@ -7,6 +7,14 @@ import java.util.concurrent.CopyOnWriteArraySet;
 
 class StateChangedListeners implements Player.StateChangedListener {
 
+    private enum State {
+        PLAYING,
+        PAUSED,
+        STOPPED
+    }
+
+    private State currentState;
+
     private final Set<Player.StateChangedListener> listeners = new CopyOnWriteArraySet<>();
 
     void add(Player.StateChangedListener listener) {
@@ -23,22 +31,40 @@ class StateChangedListeners implements Player.StateChangedListener {
 
     @Override
     public void onVideoPlaying() {
+        if (currentState == State.PLAYING) {
+            return;
+        }
+
         for (Player.StateChangedListener listener : listeners) {
             listener.onVideoPlaying();
         }
+
+        currentState = State.PLAYING;
     }
 
     @Override
     public void onVideoPaused() {
+        if (currentState == State.PAUSED) {
+            return;
+        }
+
         for (Player.StateChangedListener listener : listeners) {
             listener.onVideoPaused();
         }
+
+        currentState = State.PAUSED;
     }
 
     @Override
     public void onVideoStopped() {
+        if (currentState == State.STOPPED) {
+            return;
+        }
+
         for (Player.StateChangedListener listener : listeners) {
             listener.onVideoStopped();
         }
+
+        currentState = State.STOPPED;
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImpl.java
@@ -123,11 +123,8 @@ class AndroidMediaPlayerImpl implements Player {
         requestSurface(new SurfaceHolderRequester.Callback() {
             @Override
             public void onSurfaceHolderReady(SurfaceHolder surfaceHolder) {
-                boolean videoWasNotPlaying = !isPlaying();
                 mediaPlayer.start(surfaceHolder);
-                if (videoWasNotPlaying) {
-                    listenersHolder.getStateChangedListeners().onVideoPlaying();
-                }
+                listenersHolder.getStateChangedListeners().onVideoPlaying();
             }
         });
     }

--- a/core/src/test/java/com/novoda/noplayer/internal/listeners/StateChangedListenersTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/listeners/StateChangedListenersTest.java
@@ -1,0 +1,53 @@
+package com.novoda.noplayer.internal.listeners;
+
+import com.novoda.noplayer.Player;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import static org.mockito.Mockito.verify;
+
+public class StateChangedListenersTest {
+
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Mock
+    private Player.StateChangedListener stateChangedListener;
+
+    private StateChangedListeners stateChangedListeners;
+
+    @Before
+    public void setUp() {
+        stateChangedListeners = new StateChangedListeners();
+        stateChangedListeners.add(stateChangedListener);
+    }
+
+    @Test
+    public void whenDoubleCallingOnVideoPlaying_thenEmitsOnlyFirstOnVideoPlayingEvent() {
+        stateChangedListeners.onVideoPlaying();
+        stateChangedListeners.onVideoPlaying();
+
+        verify(stateChangedListener).onVideoPlaying();
+    }
+
+    @Test
+    public void whenDoubleCallingOnVideoPaused_thenEmitsOnlyFirstOnVideoPausedEvent() {
+        stateChangedListeners.onVideoPaused();
+        stateChangedListeners.onVideoPaused();
+
+        verify(stateChangedListener).onVideoPaused();
+    }
+
+    @Test
+    public void whenDoubleCallingOnVideoStopped_thenEmitsOnlyFirstOnVideoStoppedEvent() {
+        stateChangedListeners.onVideoStopped();
+        stateChangedListeners.onVideoStopped();
+
+        verify(stateChangedListener).onVideoStopped();
+    }
+}

--- a/core/src/test/java/com/novoda/noplayer/internal/listeners/StateChangedListenersTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/listeners/StateChangedListenersTest.java
@@ -1,6 +1,7 @@
 package com.novoda.noplayer.internal.listeners;
 
 import com.novoda.noplayer.Player;
+import com.novoda.utils.NoPlayerLog;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -23,6 +24,7 @@ public class StateChangedListenersTest {
 
     @Before
     public void setUp() {
+        NoPlayerLog.setLoggingEnabled(false);
         stateChangedListeners = new StateChangedListeners();
         stateChangedListeners.add(stateChangedListener);
     }

--- a/core/src/test/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImplTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImplTest.java
@@ -47,7 +47,6 @@ import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
 
 @RunWith(Enclosed.class)
 public class AndroidMediaPlayerImplTest {
@@ -593,16 +592,7 @@ public class AndroidMediaPlayerImplTest {
         }
 
         @Test
-        public void givenPlayerIsAlreadyPlaying_whenPlaying_thenDoesNotNotifyOnVideoPlaying() {
-            given(mediaPlayer.isPlaying()).willReturn(IS_PLAYING);
-
-            player.play();
-
-            verifyZeroInteractions(stateChangedListener);
-        }
-
-        @Test
-        public void givenPlayerIsAlreadyPlaying_whenPlaying_thenNotifiesnVideoPlaying() {
+        public void givenPlayerIsAlreadyPlaying_whenPlaying_thenNotifiesVideoPlaying() {
             given(mediaPlayer.isPlaying()).willReturn(IS_NOT_PLAYING);
 
             player.play();


### PR DESCRIPTION
## Problem
As per #72, state changes are being double called. An example of this can be seen [here](https://github.com/novoda/no-player/blob/master/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImpl.java#L150-L162). Clients do not need to call `stop` as long as they call `release`, `release` calls `stop` internally` which notifies of the `onVideoStopped` event.

## Solution
Swallow double calls of state through the `StateChangedListeners`.

### Test(s) added 
Yes, tested that double calling swallows the most recent event.

### Screenshots
No UI changes.

### Paired with 
Nobody, but I did have a chat with @ouchadam about this :smile:
