### PR TITLE
Update ExoPlayer to v2.5.1 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,5 +19,8 @@ buildscript {
 subprojects {
     repositories {
         jcenter()
+        maven {
+            url "https://maven.google.com"
+        }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ task wrapper(type: Wrapper) {
 }
 
 allprojects {
-    version = "2.0.6"
+    version = "2.0.7"
 }
 
 buildscript {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -22,9 +22,8 @@ android {
 }
 
 dependencies {
-    compile 'com.google.android.exoplayer:exoplayer:r2.4.4'
+    compile 'com.google.android.exoplayer:exoplayer:r2.5.1'
     compile 'com.novoda:notils-java:3.0.2'
-
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:2.7.22'
     testCompile 'org.easytesting:fest-assert-core:2.0M10'

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/drm/InvalidDrmSession.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/drm/InvalidDrmSession.java
@@ -28,11 +28,6 @@ class InvalidDrmSession implements FrameworkDrmSession {
     }
 
     @Override
-    public boolean requiresSecureDecoderComponent(String mimeType) {
-        throw new IllegalStateException();
-    }
-
-    @Override
     public DrmSessionException getError() {
         return drmSessionException;
     }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/drm/InvalidDrmSession.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/drm/InvalidDrmSession.java
@@ -47,4 +47,23 @@ class InvalidDrmSession implements FrameworkDrmSession {
     public SessionId getSessionId() {
         return SessionId.absent();
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        InvalidDrmSession that = (InvalidDrmSession) o;
+
+        return drmSessionException != null ? drmSessionException.equals(that.drmSessionException) : that.drmSessionException == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return drmSessionException != null ? drmSessionException.hashCode() : 0;
+    }
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/drm/LocalDrmSession.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/drm/LocalDrmSession.java
@@ -53,4 +53,32 @@ class LocalDrmSession implements FrameworkDrmSession {
     public SessionId getSessionId() {
         return sessionId;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        LocalDrmSession that = (LocalDrmSession) o;
+
+        if (mediaCrypto != null ? !mediaCrypto.equals(that.mediaCrypto) : that.mediaCrypto != null) {
+            return false;
+        }
+        if (keySetIdToRestore != null ? !keySetIdToRestore.equals(that.keySetIdToRestore) : that.keySetIdToRestore != null) {
+            return false;
+        }
+        return sessionId != null ? sessionId.equals(that.sessionId) : that.sessionId == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = mediaCrypto != null ? mediaCrypto.hashCode() : 0;
+        result = 31 * result + (keySetIdToRestore != null ? keySetIdToRestore.hashCode() : 0);
+        result = 31 * result + (sessionId != null ? sessionId.hashCode() : 0);
+        return result;
+    }
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/drm/LocalDrmSession.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/drm/LocalDrmSession.java
@@ -33,11 +33,6 @@ class LocalDrmSession implements FrameworkDrmSession {
         return mediaCrypto;
     }
 
-    @Override
-    public boolean requiresSecureDecoderComponent(String mimeType) {
-        return mediaCrypto.requiresSecureDecoderComponent(mimeType);
-    }
-
     @Nullable
     @Override
     public DrmSessionException getError() {

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/drm/LocalDrmSessionManager.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/drm/LocalDrmSessionManager.java
@@ -37,8 +37,8 @@ class LocalDrmSessionManager implements DrmSessionManager<FrameworkMediaCrypto> 
 
     @Override
     public boolean canAcquireSession(DrmInitData drmInitData) {
-        // TODO: How do we know a local session is valid?
-        return true;
+        DrmInitData.SchemeData schemeData = drmInitData.get(drmScheme);
+        return schemeData != null;
     }
 
     @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR2)

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/drm/LocalDrmSessionManager.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/drm/LocalDrmSessionManager.java
@@ -35,6 +35,12 @@ class LocalDrmSessionManager implements DrmSessionManager<FrameworkMediaCrypto> 
         this.handler = handler;
     }
 
+    @Override
+    public boolean canAcquireSession(DrmInitData drmInitData) {
+        // TODO: How do we know a local session is valid?
+        return true;
+    }
+
     @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR2)
     @Override
     public DrmSession<FrameworkMediaCrypto> acquireSession(Looper playbackLooper, DrmInitData drmInitData) {

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/BitrateForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/BitrateForwarder.java
@@ -33,26 +33,26 @@ class BitrateForwarder implements AdaptiveMediaSourceEventListener {
 
     @Override
     public void onLoadStarted(DataSpec dataSpec, int dataType, int trackType, Format trackFormat, int trackSelectionReason, Object trackSelectionData, long mediaStartTimeMs, long mediaEndTimeMs, long elapsedRealtimeMs) {
-        //TODO should we send ?
+        // TODO: should we send?
     }
 
     @Override
     public void onLoadCompleted(DataSpec dataSpec, int dataType, int trackType, Format trackFormat, int trackSelectionReason, Object trackSelectionData, long mediaStartTimeMs, long mediaEndTimeMs, long elapsedRealtimeMs, long loadDurationMs, long bytesLoaded) {
-        //TODO should we send ?
+        // TODO: should we send?
     }
 
     @Override
     public void onLoadCanceled(DataSpec dataSpec, int dataType, int trackType, Format trackFormat, int trackSelectionReason, Object trackSelectionData, long mediaStartTimeMs, long mediaEndTimeMs, long elapsedRealtimeMs, long loadDurationMs, long bytesLoaded) {
-        //TODO should we send ?
+        // TODO: should we send?
     }
 
     @Override
     public void onLoadError(DataSpec dataSpec, int dataType, int trackType, Format trackFormat, int trackSelectionReason, Object trackSelectionData, long mediaStartTimeMs, long mediaEndTimeMs, long elapsedRealtimeMs, long loadDurationMs, long bytesLoaded, IOException error, boolean wasCanceled) {
-        //TODO should we send ?
+        // TODO: should we send?
     }
 
     @Override
     public void onUpstreamDiscarded(int trackType, long mediaStartTimeMs, long mediaEndTimeMs) {
-        //TODO should we send ?
+        // TODO: should we send?
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/BufferStateForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/BufferStateForwarder.java
@@ -8,7 +8,7 @@ import com.google.android.exoplayer2.source.TrackGroupArray;
 import com.google.android.exoplayer2.trackselection.TrackSelectionArray;
 import com.novoda.noplayer.Player;
 
-class BufferStateForwarder implements ExoPlayer.EventListener {
+class BufferStateForwarder implements com.google.android.exoplayer2.Player.EventListener {
 
     private final Player.BufferStateListener bufferStateListener;
 
@@ -26,32 +26,37 @@ class BufferStateForwarder implements ExoPlayer.EventListener {
     }
 
     @Override
+    public void onRepeatModeChanged(@com.google.android.exoplayer2.Player.RepeatMode int repeatMode) {
+        // TODO: should we send?
+    }
+
+    @Override
     public void onTimelineChanged(Timeline timeline, Object manifest) {
-        //TODO should we send ?
+        // TODO: should we send?
     }
 
     @Override
     public void onTracksChanged(TrackGroupArray trackGroups, TrackSelectionArray trackSelections) {
-        //TODO should we send ?
+        // TODO: should we send?
     }
 
     @Override
     public void onLoadingChanged(boolean isLoading) {
-        //TODO should we send ?
+        // TODO: should we send?
     }
 
     @Override
     public void onPlayerError(ExoPlaybackException error) {
-        //Sent by ErrorForwarder
+        // Sent by ErrorForwarder.
     }
 
     @Override
     public void onPositionDiscontinuity() {
-        //TODO should we send ?
+        // TODO: should we send?
     }
 
     @Override
     public void onPlaybackParametersChanged(PlaybackParameters playbackParameters) {
-        //TODO should we send ?
+        // TODO: should we send?
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/BufferStateForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/BufferStateForwarder.java
@@ -1,7 +1,6 @@
 package com.novoda.noplayer.internal.exoplayer.forwarder;
 
 import com.google.android.exoplayer2.ExoPlaybackException;
-import com.google.android.exoplayer2.ExoPlayer;
 import com.google.android.exoplayer2.PlaybackParameters;
 import com.google.android.exoplayer2.Timeline;
 import com.google.android.exoplayer2.source.TrackGroupArray;
@@ -18,9 +17,9 @@ class BufferStateForwarder implements com.google.android.exoplayer2.Player.Event
 
     @Override
     public void onPlayerStateChanged(boolean playWhenReady, int playbackState) {
-        if (playbackState == ExoPlayer.STATE_BUFFERING) {
+        if (playbackState == com.google.android.exoplayer2.Player.STATE_BUFFERING) {
             bufferStateListener.onBufferStarted();
-        } else if (playbackState == ExoPlayer.STATE_READY) {
+        } else if (playbackState == com.google.android.exoplayer2.Player.STATE_READY) {
             bufferStateListener.onBufferCompleted();
         }
     }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/DrmSessionErrorForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/DrmSessionErrorForwarder.java
@@ -17,7 +17,7 @@ class DrmSessionErrorForwarder implements DefaultDrmSessionManager.EventListener
 
     @Override
     public void onDrmKeysLoaded() {
-        // TODO: Are we interested?
+        // TODO: should we send?
     }
 
     @Override
@@ -28,11 +28,11 @@ class DrmSessionErrorForwarder implements DefaultDrmSessionManager.EventListener
 
     @Override
     public void onDrmKeysRestored() {
-        // TODO: Are we interested?
+        // TODO: should we send?
     }
 
     @Override
     public void onDrmKeysRemoved() {
-        // TODO: Are we interested?
+        // TODO: should we send?
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/ErrorFormatter.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/ErrorFormatter.java
@@ -3,6 +3,7 @@ package com.novoda.noplayer.internal.exoplayer.forwarder;
 final class ErrorFormatter {
 
     private ErrorFormatter() {
+        // Static class.
     }
 
     static String formatMessage(Throwable throwable) {

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/EventInfoForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/EventInfoForwarder.java
@@ -1,7 +1,6 @@
 package com.novoda.noplayer.internal.exoplayer.forwarder;
 
 import com.google.android.exoplayer2.ExoPlaybackException;
-import com.google.android.exoplayer2.ExoPlayer;
 import com.google.android.exoplayer2.PlaybackParameters;
 import com.google.android.exoplayer2.Timeline;
 import com.google.android.exoplayer2.source.TrackGroupArray;
@@ -10,7 +9,7 @@ import com.novoda.noplayer.Player;
 
 import java.util.HashMap;
 
-class EventInfoForwarder implements ExoPlayer.EventListener {
+class EventInfoForwarder implements com.google.android.exoplayer2.Player.EventListener {
 
     private final Player.InfoListener infoListener;
 
@@ -55,6 +54,15 @@ class EventInfoForwarder implements ExoPlayer.EventListener {
         callingMethodParameters.put("playbackState", String.valueOf(playbackState));
 
         infoListener.onNewInfo("onPlayerStateChanged", callingMethodParameters);
+    }
+
+    @Override
+    public void onRepeatModeChanged(@com.google.android.exoplayer2.Player.RepeatMode int repeatMode) {
+        HashMap<String, String> callingMethodParameters = new HashMap<>();
+
+        callingMethodParameters.put("repeatMode", String.valueOf(repeatMode));
+
+        infoListener.onNewInfo("onRepeatModeChanged", callingMethodParameters);
     }
 
     @Override

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/EventListener.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/EventListener.java
@@ -1,8 +1,8 @@
 package com.novoda.noplayer.internal.exoplayer.forwarder;
 
 import com.google.android.exoplayer2.ExoPlaybackException;
-import com.google.android.exoplayer2.ExoPlayer;
 import com.google.android.exoplayer2.PlaybackParameters;
+import com.google.android.exoplayer2.Player;
 import com.google.android.exoplayer2.Timeline;
 import com.google.android.exoplayer2.source.TrackGroupArray;
 import com.google.android.exoplayer2.trackselection.TrackSelectionArray;
@@ -10,59 +10,66 @@ import com.google.android.exoplayer2.trackselection.TrackSelectionArray;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
-class EventListener implements ExoPlayer.EventListener {
+class EventListener implements Player.EventListener {
 
-    private final List<ExoPlayer.EventListener> listeners = new CopyOnWriteArrayList<>();
+    private final List<Player.EventListener> listeners = new CopyOnWriteArrayList<>();
 
-    public void add(ExoPlayer.EventListener listener) {
+    public void add(Player.EventListener listener) {
         listeners.add(listener);
     }
 
     @Override
     public void onTimelineChanged(Timeline timeline, Object manifest) {
-        for (ExoPlayer.EventListener listener : listeners) {
+        for (Player.EventListener listener : listeners) {
             listener.onTimelineChanged(timeline, manifest);
         }
     }
 
     @Override
     public void onTracksChanged(TrackGroupArray trackGroups, TrackSelectionArray trackSelections) {
-        for (ExoPlayer.EventListener listener : listeners) {
+        for (Player.EventListener listener : listeners) {
             listener.onTracksChanged(trackGroups, trackSelections);
         }
     }
 
     @Override
     public void onLoadingChanged(boolean isLoading) {
-        for (ExoPlayer.EventListener listener : listeners) {
+        for (Player.EventListener listener : listeners) {
             listener.onLoadingChanged(isLoading);
         }
     }
 
     @Override
     public void onPlayerStateChanged(boolean playWhenReady, int playbackState) {
-        for (ExoPlayer.EventListener listener : listeners) {
+        for (Player.EventListener listener : listeners) {
             listener.onPlayerStateChanged(playWhenReady, playbackState);
         }
     }
 
     @Override
+    public void onRepeatModeChanged(@Player.RepeatMode int repeatMode) {
+        for (Player.EventListener listener : listeners) {
+            listener.onRepeatModeChanged(repeatMode);
+        }
+    }
+
+    @Override
     public void onPlayerError(ExoPlaybackException error) {
-        for (ExoPlayer.EventListener listener : listeners) {
+        for (Player.EventListener listener : listeners) {
             listener.onPlayerError(error);
         }
     }
 
     @Override
     public void onPositionDiscontinuity() {
-        for (ExoPlayer.EventListener listener : listeners) {
+        for (Player.EventListener listener : listeners) {
             listener.onPositionDiscontinuity();
         }
     }
 
     @Override
     public void onPlaybackParametersChanged(PlaybackParameters playbackParameters) {
-        for (ExoPlayer.EventListener listener : listeners) {
+        for (Player.EventListener listener : listeners) {
             listener.onPlaybackParametersChanged(playbackParameters);
         }
     }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/ExoPlayerErrorMapper.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/ExoPlayerErrorMapper.java
@@ -16,7 +16,7 @@ import static com.novoda.noplayer.internal.exoplayer.forwarder.ErrorFormatter.fo
 final class ExoPlayerErrorMapper {
 
     private ExoPlayerErrorMapper() {
-        // static class.
+        // Static class.
     }
 
     static Player.PlayerError errorFor(Exception e) {

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/OnCompletionForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/OnCompletionForwarder.java
@@ -1,7 +1,6 @@
 package com.novoda.noplayer.internal.exoplayer.forwarder;
 
 import com.google.android.exoplayer2.ExoPlaybackException;
-import com.google.android.exoplayer2.ExoPlayer;
 import com.google.android.exoplayer2.PlaybackParameters;
 import com.google.android.exoplayer2.Timeline;
 import com.google.android.exoplayer2.source.TrackGroupArray;
@@ -18,7 +17,7 @@ class OnCompletionForwarder implements com.google.android.exoplayer2.Player.Even
 
     @Override
     public void onPlayerStateChanged(boolean playWhenReady, int playbackState) {
-        if (playbackState == ExoPlayer.STATE_ENDED) {
+        if (playbackState == com.google.android.exoplayer2.Player.STATE_ENDED) {
             completionListener.onCompletion();
         }
     }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/OnCompletionForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/OnCompletionForwarder.java
@@ -8,7 +8,7 @@ import com.google.android.exoplayer2.source.TrackGroupArray;
 import com.google.android.exoplayer2.trackselection.TrackSelectionArray;
 import com.novoda.noplayer.Player;
 
-class OnCompletionForwarder implements ExoPlayer.EventListener {
+class OnCompletionForwarder implements com.google.android.exoplayer2.Player.EventListener {
 
     private final Player.CompletionListener completionListener;
 
@@ -24,32 +24,37 @@ class OnCompletionForwarder implements ExoPlayer.EventListener {
     }
 
     @Override
+    public void onRepeatModeChanged(@com.google.android.exoplayer2.Player.RepeatMode int repeatMode) {
+        // TODO: should we send?
+    }
+
+    @Override
     public void onTimelineChanged(Timeline timeline, Object manifest) {
-        //TODO should we send ?
+        // TODO: should we send?
     }
 
     @Override
     public void onTracksChanged(TrackGroupArray trackGroups, TrackSelectionArray trackSelections) {
-        //TODO should we send ?
+        // TODO: should we send?
     }
 
     @Override
     public void onLoadingChanged(boolean isLoading) {
-        //TODO should we send ?
+        // TODO: should we send?
     }
 
     @Override
     public void onPlayerError(ExoPlaybackException error) {
-        //Sent by ErrorForwarder
+        // Sent by ErrorForwarder.
     }
 
     @Override
     public void onPositionDiscontinuity() {
-        //TODO should we send ?
+        // TODO: should we send?
     }
 
     @Override
     public void onPlaybackParametersChanged(PlaybackParameters playbackParameters) {
-        //TODO should we send ?
+        // TODO: should we send?
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/OnCompletionStateChangedForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/OnCompletionStateChangedForwarder.java
@@ -1,14 +1,13 @@
 package com.novoda.noplayer.internal.exoplayer.forwarder;
 
 import com.google.android.exoplayer2.ExoPlaybackException;
-import com.google.android.exoplayer2.ExoPlayer;
 import com.google.android.exoplayer2.PlaybackParameters;
 import com.google.android.exoplayer2.Timeline;
 import com.google.android.exoplayer2.source.TrackGroupArray;
 import com.google.android.exoplayer2.trackselection.TrackSelectionArray;
 import com.novoda.noplayer.Player;
 
-class OnCompletionStateChangedForwarder implements ExoPlayer.EventListener {
+class OnCompletionStateChangedForwarder implements com.google.android.exoplayer2.Player.EventListener {
 
     private final Player.StateChangedListener stateChangedListener;
 
@@ -18,38 +17,43 @@ class OnCompletionStateChangedForwarder implements ExoPlayer.EventListener {
 
     @Override
     public void onPlayerStateChanged(boolean playWhenReady, int playbackState) {
-        if (playbackState == ExoPlayer.STATE_ENDED) {
+        if (playbackState == com.google.android.exoplayer2.Player.STATE_ENDED) {
             stateChangedListener.onVideoStopped();
         }
     }
 
     @Override
+    public void onRepeatModeChanged(int i) {
+        // TODO: should we send?
+    }
+
+    @Override
     public void onTimelineChanged(Timeline timeline, Object manifest) {
-        //TODO should we send ?
+        // TODO: should we send?
     }
 
     @Override
     public void onTracksChanged(TrackGroupArray trackGroups, TrackSelectionArray trackSelections) {
-        //TODO should we send ?
+        // TODO: should we send?
     }
 
     @Override
     public void onLoadingChanged(boolean isLoading) {
-        //TODO should we send ?
+        // TODO: should we send?
     }
 
     @Override
     public void onPlayerError(ExoPlaybackException error) {
-        //Sent by ErrorForwarder
+        // Sent by ErrorForwarder.
     }
 
     @Override
     public void onPositionDiscontinuity() {
-        //TODO should we send ?
+        // TODO: should we send?
     }
 
     @Override
     public void onPlaybackParametersChanged(PlaybackParameters playbackParameters) {
-        //TODO should we send ?
+        // TODO: should we send?
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/OnPrepareForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/OnPrepareForwarder.java
@@ -1,7 +1,6 @@
 package com.novoda.noplayer.internal.exoplayer.forwarder;
 
 import com.google.android.exoplayer2.ExoPlaybackException;
-import com.google.android.exoplayer2.ExoPlayer;
 import com.google.android.exoplayer2.PlaybackParameters;
 import com.google.android.exoplayer2.Timeline;
 import com.google.android.exoplayer2.source.TrackGroupArray;
@@ -32,7 +31,7 @@ class OnPrepareForwarder implements com.google.android.exoplayer2.Player.EventLi
     }
 
     private boolean isReady(int playbackState) {
-        return playbackState == ExoPlayer.STATE_READY;
+        return playbackState == com.google.android.exoplayer2.Player.STATE_READY;
     }
 
     @Override

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/OnPrepareForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/OnPrepareForwarder.java
@@ -9,7 +9,7 @@ import com.google.android.exoplayer2.trackselection.TrackSelectionArray;
 import com.novoda.noplayer.Player;
 import com.novoda.noplayer.PlayerState;
 
-class OnPrepareForwarder implements ExoPlayer.EventListener {
+class OnPrepareForwarder implements com.google.android.exoplayer2.Player.EventListener {
 
     private final Player.PreparedListener preparedListener;
     private final PlayerState playerState;
@@ -26,37 +26,42 @@ class OnPrepareForwarder implements ExoPlayer.EventListener {
         }
     }
 
+    @Override
+    public void onRepeatModeChanged(@com.google.android.exoplayer2.Player.RepeatMode int repeatMode) {
+        // TODO: should we send?
+    }
+
     private boolean isReady(int playbackState) {
         return playbackState == ExoPlayer.STATE_READY;
     }
 
     @Override
     public void onTimelineChanged(Timeline timeline, Object manifest) {
-        //TODO should we send ?
+        // TODO: should we send?
     }
 
     @Override
     public void onTracksChanged(TrackGroupArray trackGroups, TrackSelectionArray trackSelections) {
-        //TODO should we send ?
+        // TODO: should we send?
     }
 
     @Override
     public void onLoadingChanged(boolean isLoading) {
-        //TODO should we send ?
+        // TODO: should we send?
     }
 
     @Override
     public void onPlayerError(ExoPlaybackException error) {
-        //Sent by ErrorForwarder
+        // Sent by ErrorForwarder.
     }
 
     @Override
     public void onPositionDiscontinuity() {
-        //TODO should we send ?
+        // TODO: should we send?
     }
 
     @Override
     public void onPlaybackParametersChanged(PlaybackParameters playbackParameters) {
-        //TODO should we send ?
+        // TODO: should we send?
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/PlayerOnErrorForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/PlayerOnErrorForwarder.java
@@ -1,14 +1,13 @@
 package com.novoda.noplayer.internal.exoplayer.forwarder;
 
 import com.google.android.exoplayer2.ExoPlaybackException;
-import com.google.android.exoplayer2.ExoPlayer;
 import com.google.android.exoplayer2.PlaybackParameters;
 import com.google.android.exoplayer2.Timeline;
 import com.google.android.exoplayer2.source.TrackGroupArray;
 import com.google.android.exoplayer2.trackselection.TrackSelectionArray;
 import com.novoda.noplayer.Player;
 
-class PlayerOnErrorForwarder implements ExoPlayer.EventListener {
+class PlayerOnErrorForwarder implements com.google.android.exoplayer2.Player.EventListener {
 
     private final Player.ErrorListener errorListener;
 
@@ -24,31 +23,36 @@ class PlayerOnErrorForwarder implements ExoPlayer.EventListener {
 
     @Override
     public void onTimelineChanged(Timeline timeline, Object manifest) {
-        //TODO should we send ?
+        // TODO: should we send?
     }
 
     @Override
     public void onTracksChanged(TrackGroupArray trackGroups, TrackSelectionArray trackSelections) {
-        //TODO should we send ?
+        // TODO: should we send?
     }
 
     @Override
     public void onLoadingChanged(boolean isLoading) {
-        //TODO should we send ?
+        // TODO: should we send?
     }
 
     @Override
     public void onPlayerStateChanged(boolean playWhenReady, int playbackState) {
-        //Handled by OnPrepared and OnCompletion forwarders
+        // Handled by OnPrepared and OnCompletion forwarders.
+    }
+
+    @Override
+    public void onRepeatModeChanged(@com.google.android.exoplayer2.Player.RepeatMode int repeatMode) {
+        // TODO: should we send?
     }
 
     @Override
     public void onPositionDiscontinuity() {
-        //TODO should we send ?
+        // TODO: should we send?
     }
 
     @Override
     public void onPlaybackParametersChanged(PlaybackParameters playbackParameters) {
-        //TODO should we send ?
+        // TODO: should we send?
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/VideoSizeChangedForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/VideoSizeChangedForwarder.java
@@ -22,31 +22,31 @@ class VideoSizeChangedForwarder implements VideoRendererEventListener {
 
     @Override
     public void onVideoEnabled(DecoderCounters counters) {
-        //TODO should we send ?
+        // TODO: should we send?
     }
 
     @Override
     public void onVideoDecoderInitialized(String decoderName, long initializedTimestampMs, long initializationDurationMs) {
-        //TODO should we send ?
+        // TODO: should we send?
     }
 
     @Override
     public void onVideoInputFormatChanged(Format format) {
-        //TODO should we send ?
+        // TODO: should we send?
     }
 
     @Override
     public void onDroppedFrames(int count, long elapsedMs) {
-        //TODO should we send ?
+        // TODO: should we send?
     }
 
     @Override
     public void onRenderedFirstFrame(Surface surface) {
-        //TODO should we send ?
+        // TODO: should we send?
     }
 
     @Override
     public void onVideoDisabled(DecoderCounters counters) {
-        //TODO should we send ?
+        // TODO: should we send?
     }
 }

--- a/core/src/test/java/com/google/android/exoplayer2/drm/FrameworkMediaCryptoFixture.java
+++ b/core/src/test/java/com/google/android/exoplayer2/drm/FrameworkMediaCryptoFixture.java
@@ -1,0 +1,34 @@
+package com.google.android.exoplayer2.drm;
+
+import android.media.MediaCrypto;
+import android.media.MediaCryptoException;
+
+import java.util.UUID;
+
+public final class FrameworkMediaCryptoFixture {
+
+    private MediaCrypto mediaCrypto = new MediaCrypto(UUID.randomUUID(), new byte[0]);
+    private boolean forceAllowInsecureDecoderComponents = true;
+
+    private FrameworkMediaCryptoFixture() throws MediaCryptoException {
+        // Static factory method.
+    }
+
+    public static FrameworkMediaCryptoFixture aFrameworkMediaCrypto() throws MediaCryptoException {
+        return new FrameworkMediaCryptoFixture();
+    }
+
+    public FrameworkMediaCryptoFixture withMediaCrypto(MediaCrypto mediaCrypto) {
+        this.mediaCrypto = mediaCrypto;
+        return this;
+    }
+
+    public FrameworkMediaCryptoFixture withForceAllowInsecureDecoderComponents(boolean forceAllowInsecureDecoderComponents) {
+        this.forceAllowInsecureDecoderComponents = forceAllowInsecureDecoderComponents;
+        return this;
+    }
+
+    public FrameworkMediaCrypto build() {
+        return new FrameworkMediaCrypto(mediaCrypto, forceAllowInsecureDecoderComponents);
+    }
+}

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/drm/LocalDrmSessionManagerTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/drm/LocalDrmSessionManagerTest.java
@@ -1,11 +1,20 @@
 package com.novoda.noplayer.internal.exoplayer.drm;
 
+import android.media.MediaCryptoException;
+import android.media.NotProvisionedException;
+import android.media.ResourceBusyException;
+import android.os.Build;
 import android.os.Handler;
+import android.os.Looper;
+import android.support.annotation.RequiresApi;
 
 import com.google.android.exoplayer2.drm.DefaultDrmSessionManager;
 import com.google.android.exoplayer2.drm.DrmInitData;
+import com.google.android.exoplayer2.drm.DrmSession;
+import com.google.android.exoplayer2.drm.ExoMediaCrypto;
 import com.google.android.exoplayer2.drm.ExoMediaDrm;
 import com.google.android.exoplayer2.drm.FrameworkMediaCrypto;
+import com.google.android.exoplayer2.drm.FrameworkMediaCryptoFixture;
 import com.novoda.noplayer.model.KeySetId;
 
 import java.util.Collections;
@@ -15,23 +24,24 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
 import static org.fest.assertions.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 
 public class LocalDrmSessionManagerTest {
 
+    private static final Looper IGNORED_LOOPER = null;
+    private static final DrmInitData IGNORED_DRM_DATA = null;
+
+    private static final KeySetId KEY_SET_ID_TO_RESTORE = KeySetId.of(new byte[12]);
+    private static final SessionId SESSION_ID = SessionId.of(new byte[10]);
     private static final UUID DRM_SCHEME = UUID.randomUUID();
-
-    private static final DrmInitData.SchemeData UNRECOGNISED_SCHEME_DATA = new DrmInitData.SchemeData(
-            UUID.randomUUID(), "ANY_TYPE", "ANY_MIME_TYPE", new byte[]{}
-    );
-
-    private static final DrmInitData.SchemeData RECOGNISED_SCHEME_DATA = new DrmInitData.SchemeData(
-            DRM_SCHEME, "ANY_TYPE", "ANY_MIME_TYPE", new byte[]{}
-    );
 
     @Rule
     public MockitoRule mockitoRule = MockitoJUnit.rule();
@@ -39,20 +49,24 @@ public class LocalDrmSessionManagerTest {
     public ExpectedException thrown = ExpectedException.none();
 
     @Mock
-    private KeySetId keySetIdToRestore;
-    @Mock
     private ExoMediaDrm<FrameworkMediaCrypto> mediaDrm;
     @Mock
     private Handler handler;
     @Mock
     private DefaultDrmSessionManager.EventListener eventListener;
+    @Mock
+    private ExoMediaCrypto exoMediaCrypto;
 
     private LocalDrmSessionManager localDrmSessionManager;
+    private FrameworkMediaCrypto frameworkMediaCrypto;
 
     @Before
-    public void setUp() {
+    public void setUp() throws ResourceBusyException, NotProvisionedException, MediaCryptoException {
+        frameworkMediaCrypto = FrameworkMediaCryptoFixture.aFrameworkMediaCrypto().build();
+        given(mediaDrm.openSession()).willReturn(SESSION_ID.asBytes());
+
         localDrmSessionManager = new LocalDrmSessionManager(
-                keySetIdToRestore,
+                KEY_SET_ID_TO_RESTORE,
                 mediaDrm,
                 DRM_SCHEME,
                 handler,
@@ -62,7 +76,10 @@ public class LocalDrmSessionManagerTest {
 
     @Test
     public void givenDrmDataContainsDrmScheme_whenCheckingCanAcquireSession_thenReturnsTrue() {
-        DrmInitData drmInitData = new DrmInitData(Collections.singletonList(RECOGNISED_SCHEME_DATA));
+        DrmInitData.SchemeData recognisedSchemeData = new DrmInitData.SchemeData(
+                DRM_SCHEME, "ANY_TYPE", "ANY_MIME_TYPE", new byte[]{}
+        );
+        DrmInitData drmInitData = new DrmInitData(Collections.singletonList(recognisedSchemeData));
 
         boolean canAcquireSession = localDrmSessionManager.canAcquireSession(drmInitData);
 
@@ -71,10 +88,66 @@ public class LocalDrmSessionManagerTest {
 
     @Test
     public void givenDrmDataDoesNotContainDrmScheme_whenCheckingCanAcquireSession_thenReturnsFalse() {
-        DrmInitData drmInitData = new DrmInitData(Collections.singletonList(UNRECOGNISED_SCHEME_DATA));
+        DrmInitData.SchemeData unrecognisedSchemeData = new DrmInitData.SchemeData(
+                UUID.randomUUID(), "ANY_TYPE", "ANY_MIME_TYPE", new byte[]{}
+        );
+        DrmInitData drmInitData = new DrmInitData(Collections.singletonList(unrecognisedSchemeData));
 
         boolean canAcquireSession = localDrmSessionManager.canAcquireSession(drmInitData);
 
         assertThat(canAcquireSession).isFalse();
+    }
+
+    @Test
+    public void givenValidMediaDrm_whenAcquiringSession_thenRestoresKeys() throws MediaCryptoException {
+        given(mediaDrm.createMediaCrypto(DRM_SCHEME, SESSION_ID.asBytes())).willReturn(frameworkMediaCrypto);
+
+        localDrmSessionManager.acquireSession(IGNORED_LOOPER, IGNORED_DRM_DATA);
+
+        verify(mediaDrm).restoreKeys(SESSION_ID.asBytes(), KEY_SET_ID_TO_RESTORE.asBytes());
+    }
+
+    @Test
+    public void givenValidMediaDrm_whenAcquiringSession_thenReturnsLocalDrmSession() throws MediaCryptoException {
+        given(mediaDrm.createMediaCrypto(DRM_SCHEME, SESSION_ID.asBytes())).willReturn(frameworkMediaCrypto);
+
+        DrmSession<FrameworkMediaCrypto> drmSession = localDrmSessionManager.acquireSession(IGNORED_LOOPER, IGNORED_DRM_DATA);
+
+        LocalDrmSession localDrmSession = new LocalDrmSession(frameworkMediaCrypto, KEY_SET_ID_TO_RESTORE, SESSION_ID);
+        assertThat(drmSession).isEqualTo(localDrmSession);
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.KITKAT)
+    @Test
+    public void givenOpeningSessionError_whenAcquiringSession_thenNotifiesErrorEventListenerOnHandler() throws ResourceBusyException, NotProvisionedException {
+        given(mediaDrm.openSession()).willThrow(new ResourceBusyException("resource is busy"));
+
+        localDrmSessionManager.acquireSession(IGNORED_LOOPER, IGNORED_DRM_DATA);
+
+        ArgumentCaptor<Runnable> argumentCaptor = ArgumentCaptor.forClass(Runnable.class);
+        verify(handler).post(argumentCaptor.capture());
+        argumentCaptor.getValue().run();
+        verify(eventListener).onDrmSessionManagerError(any(DrmSession.DrmSessionException.class));
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.KITKAT)
+    @Test
+    public void givenOpeningSessionError_whenAcquiringSession_thenReturnsInvalidDrmSession() throws ResourceBusyException, NotProvisionedException {
+        ResourceBusyException resourceBusyException = new ResourceBusyException("resource is busy");
+        given(mediaDrm.openSession()).willThrow(resourceBusyException);
+
+        DrmSession<FrameworkMediaCrypto> drmSession = localDrmSessionManager.acquireSession(IGNORED_LOOPER, IGNORED_DRM_DATA);
+
+        assertThat(drmSession).isInstanceOf(InvalidDrmSession.class);
+        assertThat(drmSession.getError().getCause()).isEqualTo(resourceBusyException);
+    }
+
+    @Test
+    public void givenAcquiredSession_whenReleasingSession_thenClosesCurrentSession() {
+        DrmSession<FrameworkMediaCrypto> drmSession = new LocalDrmSession(frameworkMediaCrypto, KEY_SET_ID_TO_RESTORE, SESSION_ID);
+
+        localDrmSessionManager.releaseSession(drmSession);
+
+        verify(mediaDrm).closeSession(SESSION_ID.asBytes());
     }
 }

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/drm/LocalDrmSessionManagerTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/drm/LocalDrmSessionManagerTest.java
@@ -1,0 +1,80 @@
+package com.novoda.noplayer.internal.exoplayer.drm;
+
+import android.os.Handler;
+
+import com.google.android.exoplayer2.drm.DefaultDrmSessionManager;
+import com.google.android.exoplayer2.drm.DrmInitData;
+import com.google.android.exoplayer2.drm.ExoMediaDrm;
+import com.google.android.exoplayer2.drm.FrameworkMediaCrypto;
+import com.novoda.noplayer.model.KeySetId;
+
+import java.util.Collections;
+import java.util.UUID;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+
+public class LocalDrmSessionManagerTest {
+
+    private static final UUID DRM_SCHEME = UUID.randomUUID();
+
+    private static final DrmInitData.SchemeData UNRECOGNISED_SCHEME_DATA = new DrmInitData.SchemeData(
+            UUID.randomUUID(), "ANY_TYPE", "ANY_MIME_TYPE", new byte[]{}
+    );
+
+    private static final DrmInitData.SchemeData RECOGNISED_SCHEME_DATA = new DrmInitData.SchemeData(
+            DRM_SCHEME, "ANY_TYPE", "ANY_MIME_TYPE", new byte[]{}
+    );
+
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Mock
+    private KeySetId keySetIdToRestore;
+    @Mock
+    private ExoMediaDrm<FrameworkMediaCrypto> mediaDrm;
+    @Mock
+    private Handler handler;
+    @Mock
+    private DefaultDrmSessionManager.EventListener eventListener;
+
+    private LocalDrmSessionManager localDrmSessionManager;
+
+    @Before
+    public void setUp() {
+        localDrmSessionManager = new LocalDrmSessionManager(
+                keySetIdToRestore,
+                mediaDrm,
+                DRM_SCHEME,
+                handler,
+                eventListener
+        );
+    }
+
+    @Test
+    public void givenDrmDataContainsDrmScheme_whenCheckingCanAcquireSession_thenReturnsTrue() {
+        DrmInitData drmInitData = new DrmInitData(Collections.singletonList(RECOGNISED_SCHEME_DATA));
+
+        boolean canAcquireSession = localDrmSessionManager.canAcquireSession(drmInitData);
+
+        assertThat(canAcquireSession).isTrue();
+    }
+
+    @Test
+    public void givenDrmDataDoesNotContainDrmScheme_whenCheckingCanAcquireSession_thenReturnsFalse() {
+        DrmInitData drmInitData = new DrmInitData(Collections.singletonList(UNRECOGNISED_SCHEME_DATA));
+
+        boolean canAcquireSession = localDrmSessionManager.canAcquireSession(drmInitData);
+
+        assertThat(canAcquireSession).isFalse();
+    }
+}

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    buildToolsVersion "25.0.3"
 
     defaultConfig {
         applicationId "com.novoda.demo"


### PR DESCRIPTION
## Problem
As per issue #82, we are using an outdated version of `ExoPlayer`.

NoPlayer Version: 2.4.4
Current Version: 2.5.1

## Solution
Use the latest version of `ExoPlayer`.

`ExoPlayer.EventListener` has been deprecated and now exists in `Player.EventListener` with an additional method for `onRepeatModeChanged`.

`DrmSessionManager` has an additional method that checks whether we can acquire a DRM session before attempting to. In the case of `LocalDrmSessionManager` this is a simple assertion that the `DrmInitData` contains a given `DrmScheme`.

### Test(s) added 
Yes, added tests to the previously untested `LocalDrmSessionManager`. Annoyingly, `FrameworkMediaCrypto` is a final class with a package constructor so I have created a `FrameworkMediaCryptoFixture` in order to be able to test the `LocalDrmSessionManager`.

### Screenshots
No UI changes.

### Paired with 
Nobody.
