### PR TITLE
NP-85/Make AudioDescribed track obvious

### DIFF
--- a/core/src/main/java/com/novoda/noplayer/Player.java
+++ b/core/src/main/java/com/novoda/noplayer/Player.java
@@ -102,7 +102,7 @@ public interface Player extends PlayerState {
     void detach(PlayerView playerView);
 
     /**
-     * Retrieves all of the available {@link PlayerAudioTrack} of a prepared Player as a first class collection.
+     * Retrieves all of the available {@link PlayerAudioTrack} of a prepared Player.
      *
      * @return {@link AudioTracks} that contains a list of available {@link PlayerAudioTrack}.
      * @throws IllegalStateException - if called before {@link Player#loadVideo(Uri, ContentType)}.

--- a/core/src/main/java/com/novoda/noplayer/Player.java
+++ b/core/src/main/java/com/novoda/noplayer/Player.java
@@ -2,6 +2,7 @@ package com.novoda.noplayer;
 
 import android.net.Uri;
 
+import com.novoda.noplayer.model.AudioTracks;
 import com.novoda.noplayer.model.Bitrate;
 import com.novoda.noplayer.model.PlayerAudioTrack;
 import com.novoda.noplayer.model.PlayerSubtitleTrack;
@@ -101,13 +102,13 @@ public interface Player extends PlayerState {
     void detach(PlayerView playerView);
 
     /**
-     * Retrieves all of the available {@link PlayerAudioTrack} of a prepared Player.
+     * Retrieves all of the available {@link PlayerAudioTrack} of a prepared Player as a first class collection.
      *
-     * @return A list of available {@link PlayerAudioTrack}.
+     * @return {@link AudioTracks} that contains a list of available {@link PlayerAudioTrack}.
      * @throws IllegalStateException - if called before {@link Player#loadVideo(Uri, ContentType)}.
      * @see Player.PreparedListener
      */
-    List<PlayerAudioTrack> getAudioTracks() throws IllegalStateException;
+    AudioTracks getAudioTracks() throws IllegalStateException;
 
     /**
      * Selects a given {@link PlayerAudioTrack}.

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
@@ -13,6 +13,7 @@ import com.novoda.noplayer.internal.exoplayer.forwarder.ExoPlayerForwarder;
 import com.novoda.noplayer.internal.exoplayer.mediasource.ExoPlayerAudioTrackSelector;
 import com.novoda.noplayer.internal.exoplayer.mediasource.ExoPlayerSubtitleTrackSelector;
 import com.novoda.noplayer.internal.exoplayer.mediasource.MediaSourceFactory;
+import com.novoda.noplayer.model.AudioTracks;
 import com.novoda.noplayer.model.PlayerAudioTrack;
 import com.novoda.noplayer.model.PlayerSubtitleTrack;
 import com.novoda.noplayer.model.VideoDuration;
@@ -123,7 +124,7 @@ class ExoPlayerFacade {
         return audioTrackSelector.selectAudioTrack(audioTrack, rendererTypeRequester);
     }
 
-    List<PlayerAudioTrack> getAudioTracks() throws IllegalStateException {
+    AudioTracks getAudioTracks() throws IllegalStateException {
         assertVideoLoaded();
         return audioTrackSelector.getAudioTracks(rendererTypeRequester);
     }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImpl.java
@@ -16,6 +16,7 @@ import com.novoda.noplayer.internal.Heart;
 import com.novoda.noplayer.internal.exoplayer.drm.DrmSessionCreator;
 import com.novoda.noplayer.internal.exoplayer.forwarder.ExoPlayerForwarder;
 import com.novoda.noplayer.internal.listeners.PlayerListenersHolder;
+import com.novoda.noplayer.model.AudioTracks;
 import com.novoda.noplayer.model.LoadTimeout;
 import com.novoda.noplayer.model.PlayerAudioTrack;
 import com.novoda.noplayer.model.PlayerSubtitleTrack;
@@ -256,7 +257,7 @@ class ExoPlayerTwoImpl implements Player {
     }
 
     @Override
-    public List<PlayerAudioTrack> getAudioTracks() throws IllegalStateException {
+    public AudioTracks getAudioTracks() throws IllegalStateException {
         return exoPlayer.getAudioTracks();
     }
 

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/mediasource/AudioTrackType.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/mediasource/AudioTrackType.java
@@ -1,0 +1,22 @@
+package com.novoda.noplayer.internal.exoplayer.mediasource;
+
+public enum AudioTrackType {
+    MAIN(1),
+    AUDIO_DESCRIBED(0),
+    UNKNOWN(-1);
+
+    private final int selectionFlag;
+
+    AudioTrackType(int selectionFlag) {
+        this.selectionFlag = selectionFlag;
+    }
+
+    static AudioTrackType from(int selectionFlag) {
+        for (AudioTrackType audioTrackType : AudioTrackType.values()) {
+            if (audioTrackType.selectionFlag == selectionFlag) {
+                return audioTrackType;
+            }
+        }
+        return UNKNOWN;
+    }
+}

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/mediasource/AudioTrackType.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/mediasource/AudioTrackType.java
@@ -1,8 +1,8 @@
 package com.novoda.noplayer.internal.exoplayer.mediasource;
 
 public enum AudioTrackType {
-    MAIN(1),
-    AUDIO_DESCRIBED(0),
+    MAIN(0),
+    AUDIO_DESCRIBED(1),
     UNKNOWN(-1);
 
     private final int selectionFlag;

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/mediasource/AudioTrackType.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/mediasource/AudioTrackType.java
@@ -2,7 +2,7 @@ package com.novoda.noplayer.internal.exoplayer.mediasource;
 
 public enum AudioTrackType {
     MAIN(0),
-    AUDIO_DESCRIBED(1),
+    ALTERNATIVE(1),
     UNKNOWN(-1);
 
     private final int selectionFlag;

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/mediasource/AudioTrackType.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/mediasource/AudioTrackType.java
@@ -1,6 +1,7 @@
 package com.novoda.noplayer.internal.exoplayer.mediasource;
 
 public enum AudioTrackType {
+
     MAIN(0),
     ALTERNATIVE(1),
     UNKNOWN(-1);

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/mediasource/ExoPlayerAudioTrackSelector.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/mediasource/ExoPlayerAudioTrackSelector.java
@@ -6,6 +6,7 @@ import com.google.android.exoplayer2.source.TrackGroupArray;
 import com.google.android.exoplayer2.trackselection.MappingTrackSelector;
 import com.google.android.exoplayer2.trackselection.TrackSelection;
 import com.novoda.noplayer.internal.exoplayer.RendererTypeRequester;
+import com.novoda.noplayer.model.AudioTracks;
 import com.novoda.noplayer.model.PlayerAudioTrack;
 
 import java.util.ArrayList;
@@ -34,7 +35,7 @@ public class ExoPlayerAudioTrackSelector {
         return trackSelector.setSelectionOverride(AUDIO, rendererTypeRequester, trackGroups, selectionOverride);
     }
 
-    public List<PlayerAudioTrack> getAudioTracks(RendererTypeRequester rendererTypeRequester) {
+    public AudioTracks getAudioTracks(RendererTypeRequester rendererTypeRequester) {
         TrackGroupArray trackGroups = trackSelector.trackGroups(AUDIO, rendererTypeRequester);
 
         List<PlayerAudioTrack> audioTracks = new ArrayList<>();
@@ -61,6 +62,6 @@ public class ExoPlayerAudioTrackSelector {
             }
         }
 
-        return audioTracks;
+        return AudioTracks.from(audioTracks);
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/mediasource/ExoPlayerAudioTrackSelector.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/mediasource/ExoPlayerAudioTrackSelector.java
@@ -5,8 +5,8 @@ import com.google.android.exoplayer2.source.TrackGroup;
 import com.google.android.exoplayer2.source.TrackGroupArray;
 import com.google.android.exoplayer2.trackselection.MappingTrackSelector;
 import com.google.android.exoplayer2.trackselection.TrackSelection;
-import com.novoda.noplayer.model.PlayerAudioTrack;
 import com.novoda.noplayer.internal.exoplayer.RendererTypeRequester;
+import com.novoda.noplayer.model.PlayerAudioTrack;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -45,6 +45,7 @@ public class ExoPlayerAudioTrackSelector {
 
                 for (int formatIndex = 0; formatIndex < trackGroup.length; formatIndex++) {
                     Format format = trackGroup.getFormat(formatIndex);
+
                     PlayerAudioTrack playerAudioTrack = new PlayerAudioTrack(
                             groupIndex,
                             formatIndex,
@@ -52,7 +53,8 @@ public class ExoPlayerAudioTrackSelector {
                             format.language,
                             format.sampleMimeType,
                             format.channelCount,
-                            format.bitrate
+                            format.bitrate,
+                            AudioTrackType.from(format.selectionFlags)
                     );
                     audioTracks.add(playerAudioTrack);
                 }

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerAudioTrackSelector.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerAudioTrackSelector.java
@@ -3,6 +3,7 @@ package com.novoda.noplayer.internal.mediaplayer;
 import android.media.MediaPlayer;
 
 import com.novoda.noplayer.internal.exoplayer.mediasource.AudioTrackType;
+import com.novoda.noplayer.model.AudioTracks;
 import com.novoda.noplayer.model.PlayerAudioTrack;
 
 import java.util.ArrayList;
@@ -21,7 +22,7 @@ class AndroidMediaPlayerAudioTrackSelector {
         this.trackInfosFactory = trackInfosFactory;
     }
 
-    List<PlayerAudioTrack> getAudioTracks(MediaPlayer mediaPlayer) {
+    AudioTracks getAudioTracks(MediaPlayer mediaPlayer) {
         if (mediaPlayer == null) {
             throw new NullPointerException("You can only call getAudioTracks() when video is prepared.");
         }
@@ -46,7 +47,7 @@ class AndroidMediaPlayerAudioTrackSelector {
                 );
             }
         }
-        return audioTracks;
+        return AudioTracks.from(audioTracks);
     }
 
     boolean selectAudioTrack(MediaPlayer mediaPlayer, PlayerAudioTrack playerAudioTrack) {

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerAudioTrackSelector.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerAudioTrackSelector.java
@@ -2,6 +2,7 @@ package com.novoda.noplayer.internal.mediaplayer;
 
 import android.media.MediaPlayer;
 
+import com.novoda.noplayer.internal.exoplayer.mediasource.AudioTrackType;
 import com.novoda.noplayer.model.PlayerAudioTrack;
 
 import java.util.ArrayList;
@@ -39,7 +40,9 @@ class AndroidMediaPlayerAudioTrackSelector {
                                 trackInfo.language(),
                                 NO_MIME_TYPE,
                                 NO_CHANNELS,
-                                NO_FREQUENCY)
+                                NO_FREQUENCY,
+                                AudioTrackType.MAIN
+                        )
                 );
             }
         }

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerFacade.java
@@ -8,6 +8,7 @@ import android.view.SurfaceHolder;
 
 import com.novoda.noplayer.internal.mediaplayer.PlaybackStateChecker.PlaybackState;
 import com.novoda.noplayer.internal.mediaplayer.forwarder.MediaPlayerForwarder;
+import com.novoda.noplayer.model.AudioTracks;
 import com.novoda.noplayer.model.PlayerAudioTrack;
 import com.novoda.noplayer.model.PlayerSubtitleTrack;
 import com.novoda.utils.NoPlayerLog;
@@ -205,7 +206,7 @@ class AndroidMediaPlayerFacade {
         return currentBufferPercentage;
     }
 
-    List<PlayerAudioTrack> getAudioTracks() throws IllegalStateException {
+    AudioTracks getAudioTracks() throws IllegalStateException {
         assertIsInPlaybackState();
         return trackSelector.getAudioTracks(mediaPlayer);
     }

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImpl.java
@@ -16,6 +16,7 @@ import com.novoda.noplayer.SurfaceHolderRequester;
 import com.novoda.noplayer.internal.Heart;
 import com.novoda.noplayer.internal.listeners.PlayerListenersHolder;
 import com.novoda.noplayer.internal.mediaplayer.forwarder.MediaPlayerForwarder;
+import com.novoda.noplayer.model.AudioTracks;
 import com.novoda.noplayer.model.LoadTimeout;
 import com.novoda.noplayer.model.PlayerAudioTrack;
 import com.novoda.noplayer.model.PlayerSubtitleTrack;
@@ -305,7 +306,7 @@ class AndroidMediaPlayerImpl implements Player {
     }
 
     @Override
-    public List<PlayerAudioTrack> getAudioTracks() throws IllegalStateException {
+    public AudioTracks getAudioTracks() throws IllegalStateException {
         return mediaPlayer.getAudioTracks();
     }
 

--- a/core/src/main/java/com/novoda/noplayer/model/AudioTracks.java
+++ b/core/src/main/java/com/novoda/noplayer/model/AudioTracks.java
@@ -1,7 +1,6 @@
 package com.novoda.noplayer.model;
 
 import com.novoda.noplayer.internal.exoplayer.mediasource.AudioTrackType;
-import com.novoda.utils.Optional;
 
 import java.util.Collections;
 import java.util.Iterator;
@@ -26,15 +25,6 @@ public class AudioTracks implements Iterable<PlayerAudioTrack> {
             }
         }
         return false;
-    }
-
-    public Optional<PlayerAudioTrack> firstTrackWith(AudioTrackType audioTrackType) {
-        for (PlayerAudioTrack audioTrack : audioTracks) {
-            if (audioTrack.audioTrackType() == audioTrackType) {
-                return Optional.of(audioTrack);
-            }
-        }
-        return Optional.absent();
     }
 
     public PlayerAudioTrack get(int index) {

--- a/core/src/main/java/com/novoda/noplayer/model/AudioTracks.java
+++ b/core/src/main/java/com/novoda/noplayer/model/AudioTracks.java
@@ -4,9 +4,10 @@ import com.novoda.noplayer.internal.exoplayer.mediasource.AudioTrackType;
 import com.novoda.utils.Optional;
 
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 
-public class AudioTracks {
+public class AudioTracks implements Iterable<PlayerAudioTrack> {
 
     private final List<PlayerAudioTrack> audioTracks;
 
@@ -36,8 +37,13 @@ public class AudioTracks {
         return Optional.absent();
     }
 
-    public PlayerAudioTrack getPlayerAudioTrack(int index) {
-        return audioTracks.get(index);
+    public PlayerAudioTrack getPlayerAudioTrackAt(int position) {
+        return audioTracks.get(position);
+    }
+
+    @Override
+    public Iterator<PlayerAudioTrack> iterator() {
+        return audioTracks.iterator();
     }
 
     @Override
@@ -57,5 +63,12 @@ public class AudioTracks {
     @Override
     public int hashCode() {
         return audioTracks != null ? audioTracks.hashCode() : 0;
+    }
+
+    @Override
+    public String toString() {
+        return "AudioTracks{" +
+                "audioTracks=" + audioTracks +
+                '}';
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/model/AudioTracks.java
+++ b/core/src/main/java/com/novoda/noplayer/model/AudioTracks.java
@@ -41,6 +41,10 @@ public class AudioTracks implements Iterable<PlayerAudioTrack> {
         return audioTracks.get(position);
     }
 
+    public int size() {
+        return audioTracks.size();
+    }
+
     @Override
     public Iterator<PlayerAudioTrack> iterator() {
         return audioTracks.iterator();

--- a/core/src/main/java/com/novoda/noplayer/model/AudioTracks.java
+++ b/core/src/main/java/com/novoda/noplayer/model/AudioTracks.java
@@ -19,7 +19,7 @@ public class AudioTracks implements Iterable<PlayerAudioTrack> {
         this.audioTracks = audioTracks;
     }
 
-    public boolean containsPlayerAudioTrackWith(AudioTrackType trackType) {
+    public boolean containsTrackWith(AudioTrackType trackType) {
         for (PlayerAudioTrack audioTrack : audioTracks) {
             if (audioTrack.audioTrackType() == trackType) {
                 return true;
@@ -28,7 +28,7 @@ public class AudioTracks implements Iterable<PlayerAudioTrack> {
         return false;
     }
 
-    public Optional<PlayerAudioTrack> firstPlayerAudioTrackWith(AudioTrackType audioTrackType) {
+    public Optional<PlayerAudioTrack> firstTrackWith(AudioTrackType audioTrackType) {
         for (PlayerAudioTrack audioTrack : audioTracks) {
             if (audioTrack.audioTrackType() == audioTrackType) {
                 return Optional.of(audioTrack);
@@ -37,8 +37,8 @@ public class AudioTracks implements Iterable<PlayerAudioTrack> {
         return Optional.absent();
     }
 
-    public PlayerAudioTrack getPlayerAudioTrackAt(int position) {
-        return audioTracks.get(position);
+    public PlayerAudioTrack get(int index) {
+        return audioTracks.get(index);
     }
 
     public int size() {

--- a/core/src/main/java/com/novoda/noplayer/model/AudioTracks.java
+++ b/core/src/main/java/com/novoda/noplayer/model/AudioTracks.java
@@ -1,0 +1,61 @@
+package com.novoda.noplayer.model;
+
+import com.novoda.noplayer.internal.exoplayer.mediasource.AudioTrackType;
+import com.novoda.utils.Optional;
+
+import java.util.Collections;
+import java.util.List;
+
+public class AudioTracks {
+
+    private final List<PlayerAudioTrack> audioTracks;
+
+    public static AudioTracks from(List<PlayerAudioTrack> audioTracks) {
+        return new AudioTracks(Collections.unmodifiableList(audioTracks));
+    }
+
+    private AudioTracks(List<PlayerAudioTrack> audioTracks) {
+        this.audioTracks = audioTracks;
+    }
+
+    public boolean containsPlayerAudioTrackWith(AudioTrackType trackType) {
+        for (PlayerAudioTrack audioTrack : audioTracks) {
+            if (audioTrack.audioTrackType() == trackType) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public Optional<PlayerAudioTrack> firstPlayerAudioTrackWith(AudioTrackType audioTrackType) {
+        for (PlayerAudioTrack audioTrack : audioTracks) {
+            if (audioTrack.audioTrackType() == audioTrackType) {
+                return Optional.of(audioTrack);
+            }
+        }
+        return Optional.absent();
+    }
+
+    public PlayerAudioTrack getPlayerAudioTrack(int index) {
+        return audioTracks.get(index);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        AudioTracks that = (AudioTracks) o;
+
+        return audioTracks != null ? audioTracks.equals(that.audioTracks) : that.audioTracks == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return audioTracks != null ? audioTracks.hashCode() : 0;
+    }
+}

--- a/core/src/main/java/com/novoda/noplayer/model/AudioTracks.java
+++ b/core/src/main/java/com/novoda/noplayer/model/AudioTracks.java
@@ -1,7 +1,5 @@
 package com.novoda.noplayer.model;
 
-import com.novoda.noplayer.internal.exoplayer.mediasource.AudioTrackType;
-
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -16,15 +14,6 @@ public class AudioTracks implements Iterable<PlayerAudioTrack> {
 
     private AudioTracks(List<PlayerAudioTrack> audioTracks) {
         this.audioTracks = audioTracks;
-    }
-
-    public boolean containsTrackWith(AudioTrackType trackType) {
-        for (PlayerAudioTrack audioTrack : audioTracks) {
-            if (audioTrack.audioTrackType() == trackType) {
-                return true;
-            }
-        }
-        return false;
     }
 
     public PlayerAudioTrack get(int index) {

--- a/core/src/main/java/com/novoda/noplayer/model/PlayerAudioTrack.java
+++ b/core/src/main/java/com/novoda/noplayer/model/PlayerAudioTrack.java
@@ -1,5 +1,7 @@
 package com.novoda.noplayer.model;
 
+import com.novoda.noplayer.internal.exoplayer.mediasource.AudioTrackType;
+
 public class PlayerAudioTrack {
 
     private final int groupIndex;
@@ -9,8 +11,16 @@ public class PlayerAudioTrack {
     private final String mimeType;
     private final int numberOfChannels;
     private final int frequency;
+    private final AudioTrackType audioTrackType;
 
-    public PlayerAudioTrack(int groupIndex, int formatIndex, String trackId, String language, String mimeType, int numberOfChannels, int frequency) {
+    public PlayerAudioTrack(int groupIndex,
+                            int formatIndex,
+                            String trackId,
+                            String language,
+                            String mimeType,
+                            int numberOfChannels,
+                            int frequency,
+                            AudioTrackType audioTrackType) {
         this.groupIndex = groupIndex;
         this.formatIndex = formatIndex;
         this.trackId = trackId;
@@ -18,6 +28,7 @@ public class PlayerAudioTrack {
         this.mimeType = mimeType;
         this.numberOfChannels = numberOfChannels;
         this.frequency = frequency;
+        this.audioTrackType = audioTrackType;
     }
 
     public int groupIndex() {
@@ -46,6 +57,10 @@ public class PlayerAudioTrack {
 
     public int frequency() {
         return frequency;
+    }
+
+    public AudioTrackType audioTrackType() {
+        return audioTrackType;
     }
 
     @Override
@@ -77,7 +92,10 @@ public class PlayerAudioTrack {
         if (language != null ? !language.equals(that.language) : that.language != null) {
             return false;
         }
-        return mimeType != null ? mimeType.equals(that.mimeType) : that.mimeType == null;
+        if (mimeType != null ? !mimeType.equals(that.mimeType) : that.mimeType != null) {
+            return false;
+        }
+        return audioTrackType == that.audioTrackType;
     }
 
     @Override
@@ -89,6 +107,7 @@ public class PlayerAudioTrack {
         result = 31 * result + (mimeType != null ? mimeType.hashCode() : 0);
         result = 31 * result + numberOfChannels;
         result = 31 * result + frequency;
+        result = 31 * result + (audioTrackType != null ? audioTrackType.hashCode() : 0);
         return result;
     }
 
@@ -102,6 +121,7 @@ public class PlayerAudioTrack {
                 ", mimeType='" + mimeType + '\'' +
                 ", numberOfChannels=" + numberOfChannels +
                 ", frequency=" + frequency +
+                ", audioTrackType=" + audioTrackType +
                 '}';
     }
 }

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacadeTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacadeTest.java
@@ -10,6 +10,7 @@ import com.google.android.exoplayer2.source.MediaSource;
 import com.novoda.noplayer.ContentType;
 import com.novoda.noplayer.internal.exoplayer.drm.DrmSessionCreator;
 import com.novoda.noplayer.internal.exoplayer.forwarder.ExoPlayerForwarder;
+import com.novoda.noplayer.internal.exoplayer.mediasource.AudioTrackType;
 import com.novoda.noplayer.internal.exoplayer.mediasource.ExoPlayerAudioTrackSelector;
 import com.novoda.noplayer.internal.exoplayer.mediasource.ExoPlayerSubtitleTrackSelector;
 import com.novoda.noplayer.internal.exoplayer.mediasource.MediaSourceFactory;
@@ -60,7 +61,7 @@ public class ExoPlayerFacadeTest {
     public static class GivenVideoNotLoaded extends Base {
 
         private static final VideoPosition ANY_POSITION = VideoPosition.fromMillis(1000);
-        private static final PlayerAudioTrack PLAYER_AUDIO_TRACK = new PlayerAudioTrack(0, 0, "id", "english", ".mp4", 1, 120);
+        private static final PlayerAudioTrack PLAYER_AUDIO_TRACK = new PlayerAudioTrack(0, 0, "id", "english", ".mp4", 1, 120, AudioTrackType.MAIN);
         private static final List<PlayerAudioTrack> AUDIO_TRACKS = Collections.singletonList(PLAYER_AUDIO_TRACK);
 
         @Rule
@@ -180,7 +181,7 @@ public class ExoPlayerFacadeTest {
 
     public static class GivenVideoIsLoaded extends Base {
 
-        private static final PlayerAudioTrack PLAYER_AUDIO_TRACK = new PlayerAudioTrack(0, 0, "id", "english", ".mp4", 1, 120);
+        private static final PlayerAudioTrack PLAYER_AUDIO_TRACK = new PlayerAudioTrack(0, 0, "id", "english", ".mp4", 1, 120, AudioTrackType.MAIN);
         private static final List<PlayerAudioTrack> AUDIO_TRACKS = Collections.singletonList(PLAYER_AUDIO_TRACK);
 
         @Override

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacadeTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacadeTest.java
@@ -10,17 +10,17 @@ import com.google.android.exoplayer2.source.MediaSource;
 import com.novoda.noplayer.ContentType;
 import com.novoda.noplayer.internal.exoplayer.drm.DrmSessionCreator;
 import com.novoda.noplayer.internal.exoplayer.forwarder.ExoPlayerForwarder;
-import com.novoda.noplayer.internal.exoplayer.mediasource.AudioTrackType;
 import com.novoda.noplayer.internal.exoplayer.mediasource.ExoPlayerAudioTrackSelector;
 import com.novoda.noplayer.internal.exoplayer.mediasource.ExoPlayerSubtitleTrackSelector;
 import com.novoda.noplayer.internal.exoplayer.mediasource.MediaSourceFactory;
+import com.novoda.noplayer.model.AudioTracks;
 import com.novoda.noplayer.model.PlayerAudioTrack;
+import com.novoda.noplayer.model.PlayerAudioTrackFixture;
 import com.novoda.noplayer.model.PlayerSubtitleTrack;
 import com.novoda.noplayer.model.VideoDuration;
 import com.novoda.noplayer.model.VideoPosition;
 
 import java.util.Collections;
-import java.util.List;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -61,8 +61,8 @@ public class ExoPlayerFacadeTest {
     public static class GivenVideoNotLoaded extends Base {
 
         private static final VideoPosition ANY_POSITION = VideoPosition.fromMillis(1000);
-        private static final PlayerAudioTrack PLAYER_AUDIO_TRACK = new PlayerAudioTrack(0, 0, "id", "english", ".mp4", 1, 120, AudioTrackType.MAIN);
-        private static final List<PlayerAudioTrack> AUDIO_TRACKS = Collections.singletonList(PLAYER_AUDIO_TRACK);
+        private static final PlayerAudioTrack PLAYER_AUDIO_TRACK = PlayerAudioTrackFixture.aPlayerAudioTrack().build();
+        private static final AudioTracks AUDIO_TRACKS = AudioTracks.from(Collections.singletonList(PLAYER_AUDIO_TRACK));
 
         @Rule
         public ExpectedException thrown = ExpectedException.none();
@@ -181,8 +181,8 @@ public class ExoPlayerFacadeTest {
 
     public static class GivenVideoIsLoaded extends Base {
 
-        private static final PlayerAudioTrack PLAYER_AUDIO_TRACK = new PlayerAudioTrack(0, 0, "id", "english", ".mp4", 1, 120, AudioTrackType.MAIN);
-        private static final List<PlayerAudioTrack> AUDIO_TRACKS = Collections.singletonList(PLAYER_AUDIO_TRACK);
+        private static final PlayerAudioTrack PLAYER_AUDIO_TRACK = PlayerAudioTrackFixture.aPlayerAudioTrack().build();
+        private static final AudioTracks AUDIO_TRACKS = AudioTracks.from(Collections.singletonList(PLAYER_AUDIO_TRACK));
 
         @Override
         public void setUp() {
@@ -341,7 +341,7 @@ public class ExoPlayerFacadeTest {
         public void whenGettingAudioTracks_thenDelegatesToTrackSelector() {
             given(audioTrackSelector.getAudioTracks(any(RendererTypeRequester.class))).willReturn(AUDIO_TRACKS);
 
-            List<PlayerAudioTrack> audioTracks = facade.getAudioTracks();
+            AudioTracks audioTracks = facade.getAudioTracks();
 
             assertThat(audioTracks).isEqualTo(AUDIO_TRACKS);
         }

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/mediasource/AudioTrackTypeTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/mediasource/AudioTrackTypeTest.java
@@ -6,8 +6,8 @@ import static org.fest.assertions.api.Assertions.assertThat;
 
 public class AudioTrackTypeTest {
 
-    private static final int AUDIO_DESCRIBED_SELECTION_FLAG = 0;
-    private static final int MAIN_SELECTION_FLAG = 1;
+    private static final int MAIN_SELECTION_FLAG = 0;
+    private static final int AUDIO_DESCRIBED_SELECTION_FLAG = 1;
     private static final int RANDOM_SELECTION_FLAG = 2;
 
     @Test

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/mediasource/AudioTrackTypeTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/mediasource/AudioTrackTypeTest.java
@@ -7,14 +7,14 @@ import static org.fest.assertions.api.Assertions.assertThat;
 public class AudioTrackTypeTest {
 
     private static final int MAIN_SELECTION_FLAG = 0;
-    private static final int AUDIO_DESCRIBED_SELECTION_FLAG = 1;
+    private static final int ALTERNATIVE_SELECTION_FLAG = 1;
     private static final int RANDOM_SELECTION_FLAG = 2;
 
     @Test
-    public void givenSelectionFlagIsZero_whenCreatingAudioTrackType_thenReturnsAudioDescribed() {
-        AudioTrackType audioTrackType = AudioTrackType.from(AUDIO_DESCRIBED_SELECTION_FLAG);
+    public void givenSelectionFlagIsZero_whenCreatingAudioTrackType_thenReturnsAlternative() {
+        AudioTrackType audioTrackType = AudioTrackType.from(ALTERNATIVE_SELECTION_FLAG);
 
-        assertThat(audioTrackType).isEqualTo(AudioTrackType.AUDIO_DESCRIBED);
+        assertThat(audioTrackType).isEqualTo(AudioTrackType.ALTERNATIVE);
     }
 
     @Test

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/mediasource/AudioTrackTypeTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/mediasource/AudioTrackTypeTest.java
@@ -1,0 +1,33 @@
+package com.novoda.noplayer.internal.exoplayer.mediasource;
+
+import org.junit.Test;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+
+public class AudioTrackTypeTest {
+
+    private static final int AUDIO_DESCRIBED_SELECTION_FLAG = 0;
+    private static final int MAIN_SELECTION_FLAG = 1;
+    private static final int RANDOM_SELECTION_FLAG = 2;
+
+    @Test
+    public void givenSelectionFlagIsZero_whenCreatingAudioTrackType_thenReturnsAudioDescribed() {
+        AudioTrackType audioTrackType = AudioTrackType.from(AUDIO_DESCRIBED_SELECTION_FLAG);
+
+        assertThat(audioTrackType).isEqualTo(AudioTrackType.AUDIO_DESCRIBED);
+    }
+
+    @Test
+    public void givenSelectionFlagIsOne_whenCreatingAudioTrackType_thenReturnsMain() {
+        AudioTrackType audioTrackType = AudioTrackType.from(MAIN_SELECTION_FLAG);
+
+        assertThat(audioTrackType).isEqualTo(AudioTrackType.MAIN);
+    }
+
+    @Test
+    public void givenAnyOtherSelectionFlag_whenCreatingAudioTrackType_thenReturnsUnknown() {
+        AudioTrackType audioTrackType = AudioTrackType.from(RANDOM_SELECTION_FLAG);
+
+        assertThat(audioTrackType).isEqualTo(AudioTrackType.UNKNOWN);
+    }
+}

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/mediasource/ExoPlayerAudioTrackSelectorTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/mediasource/ExoPlayerAudioTrackSelectorTest.java
@@ -5,8 +5,8 @@ import com.google.android.exoplayer2.source.TrackGroup;
 import com.google.android.exoplayer2.source.TrackGroupArray;
 import com.google.android.exoplayer2.trackselection.MappingTrackSelector;
 import com.google.android.exoplayer2.trackselection.TrackSelection;
-import com.novoda.noplayer.model.PlayerAudioTrack;
 import com.novoda.noplayer.internal.exoplayer.RendererTypeRequester;
+import com.novoda.noplayer.model.PlayerAudioTrack;
 
 import java.util.Collections;
 import java.util.List;
@@ -38,8 +38,9 @@ public class ExoPlayerAudioTrackSelectorTest {
     private static final int FIRST_TRACK = 0;
     private static final int SECOND_GROUP = 1;
     private static final int THIRD_TRACK = 2;
+    private static final int MAIN_AUDIO_TRACK_TYPE = 1;
 
-    private static final Format AUDIO_FORMAT = AudioFormatFixture.anAudioFormat().withId("id1").build();
+    private static final Format AUDIO_FORMAT = AudioFormatFixture.anAudioFormat().withId("id1").withSelectionFlags(MAIN_AUDIO_TRACK_TYPE).build();
 
     @Rule
     public MockitoRule mockitoRule = MockitoJUnit.rule();
@@ -52,7 +53,7 @@ public class ExoPlayerAudioTrackSelectorTest {
     private RendererTypeRequester rendererTypeRequester;
 
     private ExoPlayerAudioTrackSelector exoPlayerAudioTrackSelector;
-    private static final PlayerAudioTrack AUDIO_TRACK = new PlayerAudioTrack(SECOND_GROUP, THIRD_TRACK, ANY_TRACK_ID, ANY_LANGUAGE, ANY_MIME_TYPE, ANY_NUMBER_OF_CHANNELS, ANY_FREQUENCY);
+    private static final PlayerAudioTrack AUDIO_TRACK = new PlayerAudioTrack(SECOND_GROUP, THIRD_TRACK, ANY_TRACK_ID, ANY_LANGUAGE, ANY_MIME_TYPE, ANY_NUMBER_OF_CHANNELS, ANY_FREQUENCY, AudioTrackType.MAIN);
 
     @Before
     public void setUp() {
@@ -126,8 +127,8 @@ public class ExoPlayerAudioTrackSelectorTest {
                         AUDIO_FORMAT.language,
                         AUDIO_FORMAT.sampleMimeType,
                         AUDIO_FORMAT.channelCount,
-                        AUDIO_FORMAT.bitrate
-                )
+                        AUDIO_FORMAT.bitrate,
+                        AudioTrackType.from(AUDIO_FORMAT.selectionFlags))
         );
     }
 }

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/mediasource/ExoPlayerAudioTrackSelectorTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/mediasource/ExoPlayerAudioTrackSelectorTest.java
@@ -6,10 +6,10 @@ import com.google.android.exoplayer2.source.TrackGroupArray;
 import com.google.android.exoplayer2.trackselection.MappingTrackSelector;
 import com.google.android.exoplayer2.trackselection.TrackSelection;
 import com.novoda.noplayer.internal.exoplayer.RendererTypeRequester;
+import com.novoda.noplayer.model.AudioTracks;
 import com.novoda.noplayer.model.PlayerAudioTrack;
 
 import java.util.Collections;
-import java.util.List;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -76,7 +76,7 @@ public class ExoPlayerAudioTrackSelectorTest {
     public void givenTrackSelectorContainsUnsupportedTracks_whenGettingAudioTracks_thenReturnsOnlySupportedTracks() {
         givenTrackSelectorContainsUnsupportedTracks();
 
-        List<PlayerAudioTrack> actualAudioTracks = exoPlayerAudioTrackSelector.getAudioTracks(rendererTypeRequester);
+        AudioTracks actualAudioTracks = exoPlayerAudioTrackSelector.getAudioTracks(rendererTypeRequester);
 
         assertThat(actualAudioTracks).isEqualTo(expectedSupportedAudioTracks());
     }
@@ -118,17 +118,21 @@ public class ExoPlayerAudioTrackSelectorTest {
                 .willReturn(false);
     }
 
-    private List<PlayerAudioTrack> expectedSupportedAudioTracks() {
-        return Collections.singletonList(
-                new PlayerAudioTrack(
-                        FIRST_GROUP,
-                        FIRST_TRACK,
-                        AUDIO_FORMAT.id,
-                        AUDIO_FORMAT.language,
-                        AUDIO_FORMAT.sampleMimeType,
-                        AUDIO_FORMAT.channelCount,
-                        AUDIO_FORMAT.bitrate,
-                        AudioTrackType.from(AUDIO_FORMAT.selectionFlags))
+    private AudioTracks expectedSupportedAudioTracks() {
+        return AudioTracks.from(
+                Collections.singletonList(
+                        new PlayerAudioTrack(
+                                FIRST_GROUP,
+                                FIRST_TRACK,
+                                AUDIO_FORMAT.id,
+                                AUDIO_FORMAT.language,
+                                AUDIO_FORMAT.sampleMimeType,
+                                AUDIO_FORMAT.channelCount,
+                                AUDIO_FORMAT.bitrate,
+                                AudioTrackType.from(AUDIO_FORMAT.selectionFlags)
+
+                        )
+                )
         );
     }
 }

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/mediasource/PlayerAudioTrackFixture.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/mediasource/PlayerAudioTrackFixture.java
@@ -1,0 +1,72 @@
+package com.novoda.noplayer.internal.exoplayer.mediasource;
+
+import com.novoda.noplayer.model.PlayerAudioTrack;
+
+class PlayerAudioTrackFixture {
+
+    private int groupIndex = 0;
+    private int formatIndex = 0;
+    private String trackId = "id";
+    private String language = "english";
+    private String mimeType = ".mp4";
+    private int numberOfChannels = 1;
+    private int frequency = 60;
+    private AudioTrackType audioTrackType = AudioTrackType.MAIN;
+
+    public static PlayerAudioTrackFixture aPlayerAudioTrack() {
+        return new PlayerAudioTrackFixture();
+    }
+
+    public PlayerAudioTrackFixture withGroupIndex(int groupIndex) {
+        this.groupIndex = groupIndex;
+        return this;
+    }
+
+    public PlayerAudioTrackFixture withFormatIndex(int formatIndex) {
+        this.formatIndex = formatIndex;
+        return this;
+    }
+
+    public PlayerAudioTrackFixture withTrackId(String trackId) {
+        this.trackId = trackId;
+        return this;
+    }
+
+    public PlayerAudioTrackFixture withLanguage(String language) {
+        this.language = language;
+        return this;
+    }
+
+    public PlayerAudioTrackFixture withMimeType(String mimeType) {
+        this.mimeType = mimeType;
+        return this;
+    }
+
+    public PlayerAudioTrackFixture withNumberOfChannels(int numberOfChannels) {
+        this.numberOfChannels = numberOfChannels;
+        return this;
+    }
+
+    public PlayerAudioTrackFixture withFrequency(int frequency) {
+        this.frequency = frequency;
+        return this;
+    }
+
+    public PlayerAudioTrackFixture withAudioTrackType(AudioTrackType audioTrackType) {
+        this.audioTrackType = audioTrackType;
+        return this;
+    }
+
+    PlayerAudioTrack build() {
+        return new PlayerAudioTrack(
+                groupIndex,
+                formatIndex,
+                trackId,
+                language,
+                mimeType,
+                numberOfChannels,
+                frequency,
+                audioTrackType
+        );
+    }
+}

--- a/core/src/test/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerAudioTrackSelectorTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerAudioTrackSelectorTest.java
@@ -3,11 +3,11 @@ package com.novoda.noplayer.internal.mediaplayer;
 import android.media.MediaPlayer;
 
 import com.novoda.noplayer.internal.exoplayer.mediasource.AudioTrackType;
+import com.novoda.noplayer.model.AudioTracks;
 import com.novoda.noplayer.model.PlayerAudioTrack;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -70,7 +70,7 @@ public class AndroidMediaPlayerAudioTrackSelectorTest {
     public void givenTrackSelectorContainsUnsupportedTracks_whenGettingAudioTracks_thenReturnsOnlySupportedTracks() {
         givenTrackSelectorContainsUnsupportedTracks();
 
-        List<PlayerAudioTrack> audioTracks = trackSelector.getAudioTracks(mediaPlayer);
+        AudioTracks audioTracks = trackSelector.getAudioTracks(mediaPlayer);
 
         assertThat(audioTracks).isEqualTo(expectedAudioTrack());
     }
@@ -110,17 +110,19 @@ public class AndroidMediaPlayerAudioTrackSelectorTest {
         given(trackInfosFactory.createFrom(mediaPlayer)).willReturn(noPlayerTrackInfos);
     }
 
-    private List<PlayerAudioTrack> expectedAudioTrack() {
-        return Collections.singletonList(
-                new PlayerAudioTrack(
-                        AUDIO_TRACK_INDEX,
-                        NO_FORMAT,
-                        String.valueOf(AUDIO_TRACK_INFO.hashCode()),
-                        AUDIO_TRACK_INFO.language(),
-                        NO_MIME_TYPE,
-                        NO_CHANNELS,
-                        NO_FREQUENCY,
-                        AudioTrackType.MAIN
+    private AudioTracks expectedAudioTrack() {
+        return AudioTracks.from(
+                Collections.singletonList(
+                        new PlayerAudioTrack(
+                                AUDIO_TRACK_INDEX,
+                                NO_FORMAT,
+                                String.valueOf(AUDIO_TRACK_INFO.hashCode()),
+                                AUDIO_TRACK_INFO.language(),
+                                NO_MIME_TYPE,
+                                NO_CHANNELS,
+                                NO_FREQUENCY,
+                                AudioTrackType.MAIN
+                        )
                 )
         );
     }

--- a/core/src/test/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerAudioTrackSelectorTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerAudioTrackSelectorTest.java
@@ -2,7 +2,7 @@ package com.novoda.noplayer.internal.mediaplayer;
 
 import android.media.MediaPlayer;
 
-import utils.ExceptionMatcher;
+import com.novoda.noplayer.internal.exoplayer.mediasource.AudioTrackType;
 import com.novoda.noplayer.model.PlayerAudioTrack;
 
 import java.util.Arrays;
@@ -17,11 +17,13 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
-import static utils.ExceptionMatcher.matches;
+import utils.ExceptionMatcher;
+
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static utils.ExceptionMatcher.matches;
 
 public class AndroidMediaPlayerAudioTrackSelectorTest {
 
@@ -117,7 +119,8 @@ public class AndroidMediaPlayerAudioTrackSelectorTest {
                         AUDIO_TRACK_INFO.language(),
                         NO_MIME_TYPE,
                         NO_CHANNELS,
-                        NO_FREQUENCY
+                        NO_FREQUENCY,
+                        AudioTrackType.MAIN
                 )
         );
     }

--- a/core/src/test/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerFacadeTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerFacadeTest.java
@@ -7,6 +7,7 @@ import android.net.Uri;
 import android.view.SurfaceHolder;
 
 import com.novoda.noplayer.SurfaceHolderRequester;
+import com.novoda.noplayer.internal.exoplayer.mediasource.AudioTrackType;
 import com.novoda.noplayer.internal.mediaplayer.forwarder.MediaPlayerForwarder;
 import com.novoda.noplayer.model.PlayerAudioTrack;
 import com.novoda.noplayer.model.PlayerSubtitleTrack;
@@ -59,7 +60,7 @@ public class AndroidMediaPlayerFacadeTest {
 
     private static final Map<String, String> NO_HEADERS = null;
     private static final Uri ANY_URI = mock(Uri.class);
-    private static final PlayerAudioTrack PLAYER_AUDIO_TRACK = new PlayerAudioTrack(0, 0, "id", "english", ".mp4", 1, 120);
+    private static final PlayerAudioTrack PLAYER_AUDIO_TRACK = new PlayerAudioTrack(0, 0, "id", "english", ".mp4", 1, 120, AudioTrackType.MAIN);
     private static final List<PlayerAudioTrack> AUDIO_TRACKS = Collections.singletonList(PLAYER_AUDIO_TRACK);
     private static final String ERROR_MESSAGE = "Video must be loaded and not in an error state before trying to interact with the player";
 

--- a/core/src/test/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerFacadeTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerFacadeTest.java
@@ -7,9 +7,10 @@ import android.net.Uri;
 import android.view.SurfaceHolder;
 
 import com.novoda.noplayer.SurfaceHolderRequester;
-import com.novoda.noplayer.internal.exoplayer.mediasource.AudioTrackType;
 import com.novoda.noplayer.internal.mediaplayer.forwarder.MediaPlayerForwarder;
+import com.novoda.noplayer.model.AudioTracks;
 import com.novoda.noplayer.model.PlayerAudioTrack;
+import com.novoda.noplayer.model.PlayerAudioTrackFixture;
 import com.novoda.noplayer.model.PlayerSubtitleTrack;
 import com.novoda.utils.NoPlayerLog;
 
@@ -60,8 +61,8 @@ public class AndroidMediaPlayerFacadeTest {
 
     private static final Map<String, String> NO_HEADERS = null;
     private static final Uri ANY_URI = mock(Uri.class);
-    private static final PlayerAudioTrack PLAYER_AUDIO_TRACK = new PlayerAudioTrack(0, 0, "id", "english", ".mp4", 1, 120, AudioTrackType.MAIN);
-    private static final List<PlayerAudioTrack> AUDIO_TRACKS = Collections.singletonList(PLAYER_AUDIO_TRACK);
+    private static final PlayerAudioTrack PLAYER_AUDIO_TRACK = PlayerAudioTrackFixture.aPlayerAudioTrack().build();
+    private static final AudioTracks AUDIO_TRACKS = AudioTracks.from(Collections.singletonList(PLAYER_AUDIO_TRACK));
     private static final String ERROR_MESSAGE = "Video must be loaded and not in an error state before trying to interact with the player";
 
     @Rule
@@ -446,7 +447,7 @@ public class AndroidMediaPlayerFacadeTest {
         givenMediaPlayerIsPrepared();
         given(trackSelector.getAudioTracks(mediaPlayer)).willReturn(AUDIO_TRACKS);
 
-        List<PlayerAudioTrack> audioTracks = facade.getAudioTracks();
+        AudioTracks audioTracks = facade.getAudioTracks();
 
         assertThat(audioTracks).isEqualTo(AUDIO_TRACKS);
     }

--- a/core/src/test/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImplTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImplTest.java
@@ -12,6 +12,7 @@ import com.novoda.noplayer.PlayerInformation;
 import com.novoda.noplayer.PlayerView;
 import com.novoda.noplayer.SurfaceHolderRequester;
 import com.novoda.noplayer.internal.Heart;
+import com.novoda.noplayer.internal.exoplayer.mediasource.AudioTrackType;
 import com.novoda.noplayer.internal.listeners.PlayerListenersHolder;
 import com.novoda.noplayer.internal.mediaplayer.forwarder.MediaPlayerForwarder;
 import com.novoda.noplayer.model.LoadTimeout;
@@ -62,7 +63,7 @@ public class AndroidMediaPlayerImplTest {
         private static final long TWO_MINUTES_IN_MILLIS = 120000;
         private static final int ONE_SECOND_IN_MILLIS = 1000;
         private static final boolean IS_PLAYING = true;
-        private static final PlayerAudioTrack PLAYER_AUDIO_TRACK = new PlayerAudioTrack(0, 0, "id", "english", ".mp4", 1, 120);
+        private static final PlayerAudioTrack PLAYER_AUDIO_TRACK = new PlayerAudioTrack(0, 0, "id", "english", ".mp4", 1, 120, AudioTrackType.MAIN);
         private static final List<PlayerAudioTrack> AUDIO_TRACKS = Collections.singletonList(PLAYER_AUDIO_TRACK);
 
         @Test

--- a/core/src/test/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImplTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImplTest.java
@@ -12,18 +12,18 @@ import com.novoda.noplayer.PlayerInformation;
 import com.novoda.noplayer.PlayerView;
 import com.novoda.noplayer.SurfaceHolderRequester;
 import com.novoda.noplayer.internal.Heart;
-import com.novoda.noplayer.internal.exoplayer.mediasource.AudioTrackType;
 import com.novoda.noplayer.internal.listeners.PlayerListenersHolder;
 import com.novoda.noplayer.internal.mediaplayer.forwarder.MediaPlayerForwarder;
+import com.novoda.noplayer.model.AudioTracks;
 import com.novoda.noplayer.model.LoadTimeout;
 import com.novoda.noplayer.model.PlayerAudioTrack;
+import com.novoda.noplayer.model.PlayerAudioTrackFixture;
 import com.novoda.noplayer.model.Timeout;
 import com.novoda.noplayer.model.VideoDuration;
 import com.novoda.noplayer.model.VideoPosition;
 import com.novoda.utils.NoPlayerLog;
 
 import java.util.Collections;
-import java.util.List;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -63,8 +63,8 @@ public class AndroidMediaPlayerImplTest {
         private static final long TWO_MINUTES_IN_MILLIS = 120000;
         private static final int ONE_SECOND_IN_MILLIS = 1000;
         private static final boolean IS_PLAYING = true;
-        private static final PlayerAudioTrack PLAYER_AUDIO_TRACK = new PlayerAudioTrack(0, 0, "id", "english", ".mp4", 1, 120, AudioTrackType.MAIN);
-        private static final List<PlayerAudioTrack> AUDIO_TRACKS = Collections.singletonList(PLAYER_AUDIO_TRACK);
+        private static final PlayerAudioTrack PLAYER_AUDIO_TRACK = PlayerAudioTrackFixture.aPlayerAudioTrack().build();
+        private static final AudioTracks AUDIO_TRACKS = AudioTracks.from(Collections.singletonList(PLAYER_AUDIO_TRACK));
 
         @Test
         public void whenInitialising_thenBindsListenersToForwarder() {
@@ -345,7 +345,7 @@ public class AndroidMediaPlayerImplTest {
         @Test
         public void whenGettingAudioTracks_thenDelegatesToMediaPlayer() {
             given(mediaPlayer.getAudioTracks()).willReturn(AUDIO_TRACKS);
-            List<PlayerAudioTrack> audioTracks = player.getAudioTracks();
+            AudioTracks audioTracks = player.getAudioTracks();
 
             assertThat(audioTracks).isEqualTo(AUDIO_TRACKS);
         }

--- a/core/src/test/java/com/novoda/noplayer/model/AudioTracksTest.java
+++ b/core/src/test/java/com/novoda/noplayer/model/AudioTracksTest.java
@@ -13,43 +13,43 @@ import static org.fest.assertions.api.Assertions.assertThat;
 public class AudioTracksTest {
 
     private static final PlayerAudioTrack MAIN_TRACK = PlayerAudioTrackFixture.aPlayerAudioTrack().withAudioTrackType(AudioTrackType.MAIN).build();
-    private static final PlayerAudioTrack AUDIO_DESCRIBED_TRACK = PlayerAudioTrackFixture.aPlayerAudioTrack().withAudioTrackType(AudioTrackType.AUDIO_DESCRIBED).build();
+    private static final PlayerAudioTrack ALTERNATIVE_TRACK = PlayerAudioTrackFixture.aPlayerAudioTrack().withAudioTrackType(AudioTrackType.ALTERNATIVE).build();
     private static final int FIRST_INDEX = 0;
     private static final int EXPECTED_SIZE = 2;
 
     @Test
-    public void givenAudioTracks_withAudioDescribedTrack_whenCheckingContainsAudioDescribedTrack_thenReturnsTrue() {
-        AudioTracks audioTracks = AudioTracks.from(Arrays.asList(MAIN_TRACK, AUDIO_DESCRIBED_TRACK));
+    public void givenAudioTracks_withAlternativeTrack_whenCheckingContainsAlternativeTrack_thenReturnsTrue() {
+        AudioTracks audioTracks = AudioTracks.from(Arrays.asList(MAIN_TRACK, ALTERNATIVE_TRACK));
 
-        boolean containsAudioDescribedTrack = audioTracks.containsTrackWith(AudioTrackType.AUDIO_DESCRIBED);
+        boolean containsAlternativeTrack = audioTracks.containsTrackWith(AudioTrackType.ALTERNATIVE);
 
-        assertThat(containsAudioDescribedTrack).isTrue();
+        assertThat(containsAlternativeTrack).isTrue();
     }
 
     @Test
-    public void givenAudioTracks_withoutAudioDescribedTrack_whenCheckingContainsAudioDescribedTrack_thenReturnsFalse() {
+    public void givenAudioTracks_withoutAlternativeTrack_whenCheckingContainsAlternativeTrack_thenReturnsFalse() {
         AudioTracks audioTracks = AudioTracks.from(Collections.singletonList(MAIN_TRACK));
 
-        boolean containsAudioDescribedTrack = audioTracks.containsTrackWith(AudioTrackType.AUDIO_DESCRIBED);
+        boolean containsAlternativeTrack = audioTracks.containsTrackWith(AudioTrackType.ALTERNATIVE);
 
-        assertThat(containsAudioDescribedTrack).isFalse();
+        assertThat(containsAlternativeTrack).isFalse();
     }
 
     @Test
-    public void givenAudioTracks_withAudioDescribedTrack_whenGettingFirstAudioDescribedTrack_thenReturnsAudioDescribedTrack() {
-        AudioTracks audioTracks = AudioTracks.from(Arrays.asList(MAIN_TRACK, AUDIO_DESCRIBED_TRACK));
+    public void givenAudioTracks_withAlternativeTrack_whenGettingFirstAlternativeTrack_thenReturnsAlternativeTrack() {
+        AudioTracks audioTracks = AudioTracks.from(Arrays.asList(MAIN_TRACK, ALTERNATIVE_TRACK));
 
-        Optional<PlayerAudioTrack> playerAudioTrack = audioTracks.firstTrackWith(AudioTrackType.AUDIO_DESCRIBED);
+        Optional<PlayerAudioTrack> playerAudioTrack = audioTracks.firstTrackWith(AudioTrackType.ALTERNATIVE);
 
         assertThat(playerAudioTrack.isPresent()).isTrue();
-        assertThat(playerAudioTrack.get()).isEqualTo(AUDIO_DESCRIBED_TRACK);
+        assertThat(playerAudioTrack.get()).isEqualTo(ALTERNATIVE_TRACK);
     }
 
     @Test
-    public void givenAudioTracks_withoutAudioDescribedTrack_whenGettingFirstAudioDescribedTrack_thenReturnsAbsent() {
+    public void givenAudioTracks_withoutAlternativeTrack_whenGettingFirstAlternativeTrack_thenReturnsAbsent() {
         AudioTracks audioTracks = AudioTracks.from(Collections.singletonList(MAIN_TRACK));
 
-        Optional<PlayerAudioTrack> playerAudioTrack = audioTracks.firstTrackWith(AudioTrackType.AUDIO_DESCRIBED);
+        Optional<PlayerAudioTrack> playerAudioTrack = audioTracks.firstTrackWith(AudioTrackType.ALTERNATIVE);
 
         assertThat(playerAudioTrack.isPresent()).isFalse();
     }
@@ -65,7 +65,7 @@ public class AudioTracksTest {
 
     @Test
     public void givenAudioTracks_whenGettingSize_thenReturnsSize() {
-        AudioTracks audioTracks = AudioTracks.from(Arrays.asList(MAIN_TRACK, AUDIO_DESCRIBED_TRACK));
+        AudioTracks audioTracks = AudioTracks.from(Arrays.asList(MAIN_TRACK, ALTERNATIVE_TRACK));
 
         int size = audioTracks.size();
 

--- a/core/src/test/java/com/novoda/noplayer/model/AudioTracksTest.java
+++ b/core/src/test/java/com/novoda/noplayer/model/AudioTracksTest.java
@@ -15,6 +15,7 @@ public class AudioTracksTest {
     private static final PlayerAudioTrack MAIN_TRACK = PlayerAudioTrackFixture.aPlayerAudioTrack().withAudioTrackType(AudioTrackType.MAIN).build();
     private static final PlayerAudioTrack AUDIO_DESCRIBED_TRACK = PlayerAudioTrackFixture.aPlayerAudioTrack().withAudioTrackType(AudioTrackType.AUDIO_DESCRIBED).build();
     private static final int FIRST_INDEX = 0;
+    private static final int EXPECTED_SIZE = 2;
 
     @Test
     public void givenAudioTracks_withAudioDescribedTrack_whenCheckingContainsAudioDescribedTrack_thenReturnsTrue() {
@@ -60,5 +61,14 @@ public class AudioTracksTest {
         PlayerAudioTrack playerAudioTrack = audioTracks.getPlayerAudioTrackAt(FIRST_INDEX);
 
         assertThat(playerAudioTrack).isEqualTo(MAIN_TRACK);
+    }
+
+    @Test
+    public void givenAudioTracks_whenGettingSize_thenReturnsSize() {
+        AudioTracks audioTracks = AudioTracks.from(Arrays.asList(MAIN_TRACK, AUDIO_DESCRIBED_TRACK));
+
+        int size = audioTracks.size();
+
+        assertThat(size).isEqualTo(EXPECTED_SIZE);
     }
 }

--- a/core/src/test/java/com/novoda/noplayer/model/AudioTracksTest.java
+++ b/core/src/test/java/com/novoda/noplayer/model/AudioTracksTest.java
@@ -1,0 +1,64 @@
+package com.novoda.noplayer.model;
+
+import com.novoda.noplayer.internal.exoplayer.mediasource.AudioTrackType;
+import com.novoda.utils.Optional;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.Test;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+
+public class AudioTracksTest {
+
+    private static final PlayerAudioTrack MAIN_TRACK = PlayerAudioTrackFixture.aPlayerAudioTrack().withAudioTrackType(AudioTrackType.MAIN).build();
+    private static final PlayerAudioTrack AUDIO_DESCRIBED_TRACK = PlayerAudioTrackFixture.aPlayerAudioTrack().withAudioTrackType(AudioTrackType.AUDIO_DESCRIBED).build();
+    private static final int FIRST_INDEX = 0;
+
+    @Test
+    public void givenAudioTracks_withAudioDescribedTrack_whenCheckingContainsAudioDescribedTrack_thenReturnsTrue() {
+        AudioTracks audioTracks = AudioTracks.from(Arrays.asList(MAIN_TRACK, AUDIO_DESCRIBED_TRACK));
+
+        boolean containsAudioDescribedTrack = audioTracks.containsPlayerAudioTrackWith(AudioTrackType.AUDIO_DESCRIBED);
+
+        assertThat(containsAudioDescribedTrack).isTrue();
+    }
+
+    @Test
+    public void givenAudioTracks_withoutAudioDescribedTrack_whenCheckingContainsAudioDescribedTrack_thenReturnsFalse() {
+        AudioTracks audioTracks = AudioTracks.from(Collections.singletonList(MAIN_TRACK));
+
+        boolean containsAudioDescribedTrack = audioTracks.containsPlayerAudioTrackWith(AudioTrackType.AUDIO_DESCRIBED);
+
+        assertThat(containsAudioDescribedTrack).isFalse();
+    }
+
+    @Test
+    public void givenAudioTracks_withAudioDescribedTrack_whenGettingFirstAudioDescribedTrack_thenReturnsAudioDescribedTrack() {
+        AudioTracks audioTracks = AudioTracks.from(Arrays.asList(MAIN_TRACK, AUDIO_DESCRIBED_TRACK));
+
+        Optional<PlayerAudioTrack> playerAudioTrack = audioTracks.firstPlayerAudioTrackWith(AudioTrackType.AUDIO_DESCRIBED);
+
+        assertThat(playerAudioTrack.isPresent()).isTrue();
+        assertThat(playerAudioTrack.get()).isEqualTo(AUDIO_DESCRIBED_TRACK);
+    }
+
+    @Test
+    public void givenAudioTracks_withoutAudioDescribedTrack_whenGettingFirstAudioDescribedTrack_thenReturnsAbsent() {
+        AudioTracks audioTracks = AudioTracks.from(Collections.singletonList(MAIN_TRACK));
+
+        Optional<PlayerAudioTrack> playerAudioTrack = audioTracks.firstPlayerAudioTrackWith(AudioTrackType.AUDIO_DESCRIBED);
+
+        assertThat(playerAudioTrack.isPresent()).isFalse();
+    }
+
+    @Test
+    public void givenAudioTracks_whenGettingPlayerAudioTrack_thenReturnsPlayerAudioTrack() {
+        AudioTracks audioTracks = AudioTracks.from(Collections.singletonList(MAIN_TRACK));
+
+        PlayerAudioTrack playerAudioTrack = audioTracks.getPlayerAudioTrack(FIRST_INDEX);
+
+        assertThat(playerAudioTrack).isEqualTo(MAIN_TRACK);
+    }
+}

--- a/core/src/test/java/com/novoda/noplayer/model/AudioTracksTest.java
+++ b/core/src/test/java/com/novoda/noplayer/model/AudioTracksTest.java
@@ -1,7 +1,6 @@
 package com.novoda.noplayer.model;
 
 import com.novoda.noplayer.internal.exoplayer.mediasource.AudioTrackType;
-import com.novoda.utils.Optional;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -36,26 +35,7 @@ public class AudioTracksTest {
     }
 
     @Test
-    public void givenAudioTracks_withAlternativeTrack_whenGettingFirstAlternativeTrack_thenReturnsAlternativeTrack() {
-        AudioTracks audioTracks = AudioTracks.from(Arrays.asList(MAIN_TRACK, ALTERNATIVE_TRACK));
-
-        Optional<PlayerAudioTrack> playerAudioTrack = audioTracks.firstTrackWith(AudioTrackType.ALTERNATIVE);
-
-        assertThat(playerAudioTrack.isPresent()).isTrue();
-        assertThat(playerAudioTrack.get()).isEqualTo(ALTERNATIVE_TRACK);
-    }
-
-    @Test
-    public void givenAudioTracks_withoutAlternativeTrack_whenGettingFirstAlternativeTrack_thenReturnsAbsent() {
-        AudioTracks audioTracks = AudioTracks.from(Collections.singletonList(MAIN_TRACK));
-
-        Optional<PlayerAudioTrack> playerAudioTrack = audioTracks.firstTrackWith(AudioTrackType.ALTERNATIVE);
-
-        assertThat(playerAudioTrack.isPresent()).isFalse();
-    }
-
-    @Test
-    public void givenAudioTracks_whenGettingPlayerAudioTrack_thenReturnsPlayerAudioTrack() {
+    public void givenAudioTracks_whenGettingTrack_thenReturnsTrack() {
         AudioTracks audioTracks = AudioTracks.from(Collections.singletonList(MAIN_TRACK));
 
         PlayerAudioTrack playerAudioTrack = audioTracks.get(FIRST_INDEX);

--- a/core/src/test/java/com/novoda/noplayer/model/AudioTracksTest.java
+++ b/core/src/test/java/com/novoda/noplayer/model/AudioTracksTest.java
@@ -57,7 +57,7 @@ public class AudioTracksTest {
     public void givenAudioTracks_whenGettingPlayerAudioTrack_thenReturnsPlayerAudioTrack() {
         AudioTracks audioTracks = AudioTracks.from(Collections.singletonList(MAIN_TRACK));
 
-        PlayerAudioTrack playerAudioTrack = audioTracks.getPlayerAudioTrack(FIRST_INDEX);
+        PlayerAudioTrack playerAudioTrack = audioTracks.getPlayerAudioTrackAt(FIRST_INDEX);
 
         assertThat(playerAudioTrack).isEqualTo(MAIN_TRACK);
     }

--- a/core/src/test/java/com/novoda/noplayer/model/AudioTracksTest.java
+++ b/core/src/test/java/com/novoda/noplayer/model/AudioTracksTest.java
@@ -21,7 +21,7 @@ public class AudioTracksTest {
     public void givenAudioTracks_withAudioDescribedTrack_whenCheckingContainsAudioDescribedTrack_thenReturnsTrue() {
         AudioTracks audioTracks = AudioTracks.from(Arrays.asList(MAIN_TRACK, AUDIO_DESCRIBED_TRACK));
 
-        boolean containsAudioDescribedTrack = audioTracks.containsPlayerAudioTrackWith(AudioTrackType.AUDIO_DESCRIBED);
+        boolean containsAudioDescribedTrack = audioTracks.containsTrackWith(AudioTrackType.AUDIO_DESCRIBED);
 
         assertThat(containsAudioDescribedTrack).isTrue();
     }
@@ -30,7 +30,7 @@ public class AudioTracksTest {
     public void givenAudioTracks_withoutAudioDescribedTrack_whenCheckingContainsAudioDescribedTrack_thenReturnsFalse() {
         AudioTracks audioTracks = AudioTracks.from(Collections.singletonList(MAIN_TRACK));
 
-        boolean containsAudioDescribedTrack = audioTracks.containsPlayerAudioTrackWith(AudioTrackType.AUDIO_DESCRIBED);
+        boolean containsAudioDescribedTrack = audioTracks.containsTrackWith(AudioTrackType.AUDIO_DESCRIBED);
 
         assertThat(containsAudioDescribedTrack).isFalse();
     }
@@ -39,7 +39,7 @@ public class AudioTracksTest {
     public void givenAudioTracks_withAudioDescribedTrack_whenGettingFirstAudioDescribedTrack_thenReturnsAudioDescribedTrack() {
         AudioTracks audioTracks = AudioTracks.from(Arrays.asList(MAIN_TRACK, AUDIO_DESCRIBED_TRACK));
 
-        Optional<PlayerAudioTrack> playerAudioTrack = audioTracks.firstPlayerAudioTrackWith(AudioTrackType.AUDIO_DESCRIBED);
+        Optional<PlayerAudioTrack> playerAudioTrack = audioTracks.firstTrackWith(AudioTrackType.AUDIO_DESCRIBED);
 
         assertThat(playerAudioTrack.isPresent()).isTrue();
         assertThat(playerAudioTrack.get()).isEqualTo(AUDIO_DESCRIBED_TRACK);
@@ -49,7 +49,7 @@ public class AudioTracksTest {
     public void givenAudioTracks_withoutAudioDescribedTrack_whenGettingFirstAudioDescribedTrack_thenReturnsAbsent() {
         AudioTracks audioTracks = AudioTracks.from(Collections.singletonList(MAIN_TRACK));
 
-        Optional<PlayerAudioTrack> playerAudioTrack = audioTracks.firstPlayerAudioTrackWith(AudioTrackType.AUDIO_DESCRIBED);
+        Optional<PlayerAudioTrack> playerAudioTrack = audioTracks.firstTrackWith(AudioTrackType.AUDIO_DESCRIBED);
 
         assertThat(playerAudioTrack.isPresent()).isFalse();
     }
@@ -58,7 +58,7 @@ public class AudioTracksTest {
     public void givenAudioTracks_whenGettingPlayerAudioTrack_thenReturnsPlayerAudioTrack() {
         AudioTracks audioTracks = AudioTracks.from(Collections.singletonList(MAIN_TRACK));
 
-        PlayerAudioTrack playerAudioTrack = audioTracks.getPlayerAudioTrackAt(FIRST_INDEX);
+        PlayerAudioTrack playerAudioTrack = audioTracks.get(FIRST_INDEX);
 
         assertThat(playerAudioTrack).isEqualTo(MAIN_TRACK);
     }

--- a/core/src/test/java/com/novoda/noplayer/model/AudioTracksTest.java
+++ b/core/src/test/java/com/novoda/noplayer/model/AudioTracksTest.java
@@ -17,24 +17,6 @@ public class AudioTracksTest {
     private static final int EXPECTED_SIZE = 2;
 
     @Test
-    public void givenAudioTracks_withAlternativeTrack_whenCheckingContainsAlternativeTrack_thenReturnsTrue() {
-        AudioTracks audioTracks = AudioTracks.from(Arrays.asList(MAIN_TRACK, ALTERNATIVE_TRACK));
-
-        boolean containsAlternativeTrack = audioTracks.containsTrackWith(AudioTrackType.ALTERNATIVE);
-
-        assertThat(containsAlternativeTrack).isTrue();
-    }
-
-    @Test
-    public void givenAudioTracks_withoutAlternativeTrack_whenCheckingContainsAlternativeTrack_thenReturnsFalse() {
-        AudioTracks audioTracks = AudioTracks.from(Collections.singletonList(MAIN_TRACK));
-
-        boolean containsAlternativeTrack = audioTracks.containsTrackWith(AudioTrackType.ALTERNATIVE);
-
-        assertThat(containsAlternativeTrack).isFalse();
-    }
-
-    @Test
     public void givenAudioTracks_whenGettingTrack_thenReturnsTrack() {
         AudioTracks audioTracks = AudioTracks.from(Collections.singletonList(MAIN_TRACK));
 

--- a/core/src/test/java/com/novoda/noplayer/model/PlayerAudioTrackFixture.java
+++ b/core/src/test/java/com/novoda/noplayer/model/PlayerAudioTrackFixture.java
@@ -2,7 +2,7 @@ package com.novoda.noplayer.model;
 
 import com.novoda.noplayer.internal.exoplayer.mediasource.AudioTrackType;
 
-class PlayerAudioTrackFixture {
+public class PlayerAudioTrackFixture {
 
     private int groupIndex = 0;
     private int formatIndex = 0;
@@ -57,7 +57,7 @@ class PlayerAudioTrackFixture {
         return this;
     }
 
-    PlayerAudioTrack build() {
+    public PlayerAudioTrack build() {
         return new PlayerAudioTrack(
                 groupIndex,
                 formatIndex,

--- a/core/src/test/java/com/novoda/noplayer/model/PlayerAudioTrackFixture.java
+++ b/core/src/test/java/com/novoda/noplayer/model/PlayerAudioTrackFixture.java
@@ -1,6 +1,6 @@
-package com.novoda.noplayer.internal.exoplayer.mediasource;
+package com.novoda.noplayer.model;
 
-import com.novoda.noplayer.model.PlayerAudioTrack;
+import com.novoda.noplayer.internal.exoplayer.mediasource.AudioTrackType;
 
 class PlayerAudioTrackFixture {
 

--- a/demo/src/main/java/com/novoda/demo/MainActivity.java
+++ b/demo/src/main/java/com/novoda/demo/MainActivity.java
@@ -14,6 +14,7 @@ import com.novoda.noplayer.Player;
 import com.novoda.noplayer.PlayerBuilder;
 import com.novoda.noplayer.PlayerState;
 import com.novoda.noplayer.PlayerView;
+import com.novoda.noplayer.model.AudioTracks;
 import com.novoda.noplayer.model.PlayerAudioTrack;
 import com.novoda.noplayer.model.PlayerSubtitleTrack;
 import com.novoda.utils.NoPlayerLog;
@@ -76,7 +77,7 @@ public class MainActivity extends Activity {
         }
 
         private void showAudioSelectionDialog() {
-            final List<PlayerAudioTrack> audioTracks = player.getAudioTracks();
+            final AudioTracks audioTracks = player.getAudioTracks();
             ArrayAdapter<String> adapter = new ArrayAdapter<>(MainActivity.this, R.layout.list_item);
             adapter.addAll(mapAudioTrackToLabel(audioTracks));
             AlertDialog audioSelectionDialog = new AlertDialog.Builder(MainActivity.this)
@@ -84,14 +85,14 @@ public class MainActivity extends Activity {
                     .setAdapter(adapter, new DialogInterface.OnClickListener() {
                         @Override
                         public void onClick(DialogInterface dialog, int position) {
-                            PlayerAudioTrack audioTrack = audioTracks.get(position);
+                            PlayerAudioTrack audioTrack = audioTracks.getPlayerAudioTrackAt(position);
                             player.selectAudioTrack(audioTrack);
                         }
                     }).create();
             audioSelectionDialog.show();
         }
 
-        private List<String> mapAudioTrackToLabel(List<PlayerAudioTrack> audioTracks) {
+        private List<String> mapAudioTrackToLabel(AudioTracks audioTracks) {
             List<String> labels = new ArrayList<>();
             for (PlayerAudioTrack audioTrack : audioTracks) {
                 labels.add("Group: " + audioTrack.groupIndex() + " Format: " + audioTrack.formatIndex());

--- a/demo/src/main/java/com/novoda/demo/MainActivity.java
+++ b/demo/src/main/java/com/novoda/demo/MainActivity.java
@@ -86,7 +86,7 @@ public class MainActivity extends Activity {
                     .setAdapter(adapter, new DialogInterface.OnClickListener() {
                         @Override
                         public void onClick(DialogInterface dialog, int position) {
-                            PlayerAudioTrack audioTrack = audioTracks.getPlayerAudioTrackAt(position);
+                            PlayerAudioTrack audioTrack = audioTracks.get(position);
                             player.selectAudioTrack(audioTrack);
                         }
                     }).create();

--- a/demo/src/main/java/com/novoda/demo/MainActivity.java
+++ b/demo/src/main/java/com/novoda/demo/MainActivity.java
@@ -21,6 +21,7 @@ import com.novoda.utils.NoPlayerLog;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 public class MainActivity extends Activity {
 
@@ -95,7 +96,14 @@ public class MainActivity extends Activity {
         private List<String> mapAudioTrackToLabel(AudioTracks audioTracks) {
             List<String> labels = new ArrayList<>();
             for (PlayerAudioTrack audioTrack : audioTracks) {
-                labels.add("Group: " + audioTrack.groupIndex() + " Format: " + audioTrack.formatIndex());
+                String label = String.format(
+                        Locale.UK,
+                        "Group: %s Format: %s Type: %s",
+                        audioTrack.groupIndex(),
+                        audioTrack.formatIndex(),
+                        audioTrack.audioTrackType()
+                );
+                labels.add(label);
             }
             return labels;
         }


### PR DESCRIPTION
## Problem
As per issue #85, we need to provide a mechanism that will allow client applications to switch between **main** and **audio described** audio tracks, without needing to know the position from the manifest.

## Solution
Added an `AudioTrackType` to represent the different audio track types, **main** and **audio described**, a **unknown** type has been added to take into account other types that might present themselves in the future. `AudioTrackType` is created passing in a given `format.selectionFlags` which is created based on the role.

The `AudioTrackType` is publically accessible through `PlayerAudioTrack.audioTrackType`.

A first class collection representing a `List<PlayerAudioTrack>` has been added. This includes several support methods:

`containsPlayerAudioTrackWith(AudioTrackType)` returns a boolean representing whether the underlying `List<PlayerAudioTrack>` contains a `PlayerAudioTrack` with the given `AudioTrackType`.

`firstPlayerAudioTrackWith(AudioTrackType)` returns either the first `PlayerAudioTrack` that contains the given `AudioTrackType`, wrapped in an `Optional` or `Optional.absent`.

### Test(s) added 
Yes, tested all of the newly added classes. Added a `Fixture` for the `PlayerAudioTrack` because it was being created in quite a few tests.

### Screenshots
We now have the type shown in the audio selection.

![audio_type](https://user-images.githubusercontent.com/3380092/29568771-4f003d0a-8749-11e7-9ac2-7b3f83cb5e07.png)


### Paired with 
Nobody.
