### PR TITLE
NP-87/NoPlayer interface

### DIFF
--- a/core/src/main/java/com/novoda/noplayer/Listeners.java
+++ b/core/src/main/java/com/novoda/noplayer/Listeners.java
@@ -2,39 +2,39 @@ package com.novoda.noplayer;
 
 public interface Listeners {
 
-    void addErrorListener(Player.ErrorListener errorListener);
+    void addErrorListener(NoPlayer.ErrorListener errorListener);
 
-    void removeErrorListener(Player.ErrorListener errorListener);
+    void removeErrorListener(NoPlayer.ErrorListener errorListener);
 
-    void addPreparedListener(Player.PreparedListener preparedListener);
+    void addPreparedListener(NoPlayer.PreparedListener preparedListener);
 
-    void removePreparedListener(Player.PreparedListener preparedListener);
+    void removePreparedListener(NoPlayer.PreparedListener preparedListener);
 
-    void addBufferStateListener(Player.BufferStateListener bufferStateListener);
+    void addBufferStateListener(NoPlayer.BufferStateListener bufferStateListener);
 
-    void removeBufferStateListener(Player.BufferStateListener bufferStateListener);
+    void removeBufferStateListener(NoPlayer.BufferStateListener bufferStateListener);
 
-    void addCompletionListener(Player.CompletionListener completionListener);
+    void addCompletionListener(NoPlayer.CompletionListener completionListener);
 
-    void removeCompletionListener(Player.CompletionListener completionListener);
+    void removeCompletionListener(NoPlayer.CompletionListener completionListener);
 
-    void addStateChangedListener(Player.StateChangedListener stateChangedListener);
+    void addStateChangedListener(NoPlayer.StateChangedListener stateChangedListener);
 
-    void removeStateChangedListener(Player.StateChangedListener stateChangedListener);
+    void removeStateChangedListener(NoPlayer.StateChangedListener stateChangedListener);
 
-    void addInfoListener(Player.InfoListener infoListener);
+    void addInfoListener(NoPlayer.InfoListener infoListener);
 
-    void removeInfoListener(Player.InfoListener infoListener);
+    void removeInfoListener(NoPlayer.InfoListener infoListener);
 
-    void addBitrateChangedListener(Player.BitrateChangedListener bitrateChangedListener);
+    void addBitrateChangedListener(NoPlayer.BitrateChangedListener bitrateChangedListener);
 
-    void removeBitrateChangedListener(Player.BitrateChangedListener bitrateChangedListener);
+    void removeBitrateChangedListener(NoPlayer.BitrateChangedListener bitrateChangedListener);
 
-    void addHeartbeatCallback(Player.HeartbeatCallback heartbeatCallback);
+    void addHeartbeatCallback(NoPlayer.HeartbeatCallback heartbeatCallback);
 
-    void removeHeartbeatCallback(Player.HeartbeatCallback heartbeatCallback);
+    void removeHeartbeatCallback(NoPlayer.HeartbeatCallback heartbeatCallback);
 
-    void addVideoSizeChangedListener(Player.VideoSizeChangedListener videoSizeChangedListener);
+    void addVideoSizeChangedListener(NoPlayer.VideoSizeChangedListener videoSizeChangedListener);
 
-    void removeVideoSizeChangedListener(Player.VideoSizeChangedListener videoSizeChangedListener);
+    void removeVideoSizeChangedListener(NoPlayer.VideoSizeChangedListener videoSizeChangedListener);
 }

--- a/core/src/main/java/com/novoda/noplayer/NoPlayer.java
+++ b/core/src/main/java/com/novoda/noplayer/NoPlayer.java
@@ -12,13 +12,13 @@ import com.novoda.noplayer.model.VideoPosition;
 import java.util.List;
 import java.util.Map;
 
-public interface Player extends PlayerState {
+public interface NoPlayer extends PlayerState {
 
     /**
      * Plays content of a prepared Player.
      *
-     * @throws IllegalStateException - if called before {@link Player#loadVideo(Uri, ContentType)}.
-     * @see Player.PreparedListener
+     * @throws IllegalStateException - if called before {@link NoPlayer#loadVideo(Uri, ContentType)}.
+     * @see NoPlayer.PreparedListener
      */
     void play() throws IllegalStateException;
 
@@ -26,16 +26,16 @@ public interface Player extends PlayerState {
      * Plays content of a prepared Player at a position.
      *
      * @param position to start playing content from.
-     * @throws IllegalStateException - if called before {@link Player#loadVideo(Uri, ContentType)}.
-     * @see Player.PreparedListener
+     * @throws IllegalStateException - if called before {@link NoPlayer#loadVideo(Uri, ContentType)}.
+     * @see NoPlayer.PreparedListener
      */
     void play(VideoPosition position) throws IllegalStateException;
 
     /**
      * Pauses content of a prepared Player.
      *
-     * @throws IllegalStateException - if called before {@link Player#loadVideo(Uri, ContentType)}.
-     * @see Player.PreparedListener
+     * @throws IllegalStateException - if called before {@link NoPlayer#loadVideo(Uri, ContentType)}.
+     * @see NoPlayer.PreparedListener
      */
     void pause() throws IllegalStateException;
 
@@ -44,13 +44,13 @@ public interface Player extends PlayerState {
      * Will not cause content to play if not already playing.
      *
      * @param position to seek content to.
-     * @throws IllegalStateException - if called before {@link Player#loadVideo(Uri, ContentType)}.
-     * @see Player.PreparedListener
+     * @throws IllegalStateException - if called before {@link NoPlayer#loadVideo(Uri, ContentType)}.
+     * @see NoPlayer.PreparedListener
      */
     void seekTo(VideoPosition position) throws IllegalStateException;
 
     /**
-     * Stops playback of content and then requires call to {@link Player#loadVideo(Uri, ContentType)} to continue playback.
+     * Stops playback of content and then requires call to {@link NoPlayer#loadVideo(Uri, ContentType)} to continue playback.
      */
     void stop();
 
@@ -61,22 +61,22 @@ public interface Player extends PlayerState {
     void release();
 
     /**
-     * Loads the video content and triggers the {@link Player.PreparedListener}.
+     * Loads the video content and triggers the {@link NoPlayer.PreparedListener}.
      *
      * @param uri         link to the content.
      * @param contentType format of the content.
-     * @throws IllegalStateException - if called before {@link Player#attach(PlayerView)}.
+     * @throws IllegalStateException - if called before {@link NoPlayer#attach(PlayerView)}.
      */
     void loadVideo(Uri uri, ContentType contentType) throws IllegalStateException;
 
     /**
-     * Loads the video content and triggers the {@link Player.PreparedListener}.
+     * Loads the video content and triggers the {@link NoPlayer.PreparedListener}.
      *
      * @param uri                 link to the content.
      * @param contentType         format of the content.
      * @param timeout             amount of time to wait before triggering {@link LoadTimeoutCallback}.
      * @param loadTimeoutCallback callback when loading has hit the timeout.
-     * @throws IllegalStateException - if called before {@link Player#attach(PlayerView)}.
+     * @throws IllegalStateException - if called before {@link NoPlayer#attach(PlayerView)}.
      */
     void loadVideoWithTimeout(Uri uri, ContentType contentType, Timeout timeout, LoadTimeoutCallback loadTimeoutCallback);
 
@@ -105,8 +105,8 @@ public interface Player extends PlayerState {
      * Retrieves all of the available {@link PlayerAudioTrack} of a prepared Player as a first class collection.
      *
      * @return {@link AudioTracks} that contains a list of available {@link PlayerAudioTrack}.
-     * @throws IllegalStateException - if called before {@link Player#loadVideo(Uri, ContentType)}.
-     * @see Player.PreparedListener
+     * @throws IllegalStateException - if called before {@link NoPlayer#loadVideo(Uri, ContentType)}.
+     * @see NoPlayer.PreparedListener
      */
     AudioTracks getAudioTracks() throws IllegalStateException;
 
@@ -115,7 +115,7 @@ public interface Player extends PlayerState {
      *
      * @param audioTrack the audio track to select.
      * @return whether the selection was successful.
-     * @throws IllegalStateException - if called before {@link Player#loadVideo(Uri, ContentType)}.
+     * @throws IllegalStateException - if called before {@link NoPlayer#loadVideo(Uri, ContentType)}.
      */
     boolean selectAudioTrack(PlayerAudioTrack audioTrack) throws IllegalStateException;
 
@@ -123,8 +123,8 @@ public interface Player extends PlayerState {
      * Retrieves all of the available {@link PlayerSubtitleTrack} of a prepared Player.
      *
      * @return A list of available {@link PlayerSubtitleTrack}.
-     * @throws IllegalStateException - if called before {@link Player#loadVideo(Uri, ContentType)}.
-     * @see Player.PreparedListener
+     * @throws IllegalStateException - if called before {@link NoPlayer#loadVideo(Uri, ContentType)}.
+     * @see NoPlayer.PreparedListener
      */
     List<PlayerSubtitleTrack> getSubtitleTracks() throws IllegalStateException;
 
@@ -133,14 +133,14 @@ public interface Player extends PlayerState {
      *
      * @param subtitleTrack the subtitle track to select.
      * @return whether the selection was successful.
-     * @throws IllegalStateException - if called before {@link Player#loadVideo(Uri, ContentType)}.
+     * @throws IllegalStateException - if called before {@link NoPlayer#loadVideo(Uri, ContentType)}.
      */
     boolean showSubtitleTrack(PlayerSubtitleTrack subtitleTrack) throws IllegalStateException;
 
     /**
      * Clear and hide the subtitles on an attached PlayerView.
      *
-     * @throws IllegalStateException - if called before {@link Player#loadVideo(Uri, ContentType)}.
+     * @throws IllegalStateException - if called before {@link NoPlayer#loadVideo(Uri, ContentType)}.
      */
     void hideSubtitleTrack() throws IllegalStateException;
 
@@ -205,7 +205,7 @@ public interface Player extends PlayerState {
     interface InfoListener {
 
         /**
-         * All event listeners attached to implementations of Player will
+         * All event listeners attached to implementations of {@link NoPlayer} will
          * forward information through this to provide debugging
          * information to client applications.
          *
@@ -230,6 +230,6 @@ public interface Player extends PlayerState {
 
     interface HeartbeatCallback {
 
-        void onBeat(Player player);
+        void onBeat(NoPlayer player);
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/NoPlayerCreator.java
+++ b/core/src/main/java/com/novoda/noplayer/NoPlayerCreator.java
@@ -32,7 +32,7 @@ class NoPlayerCreator {
         this.drmSessionCreatorFactory = drmSessionCreatorFactory;
     }
 
-    Player create(DrmType drmType, DrmHandler drmHandler, boolean downgradeSecureDecoder) {
+    NoPlayer create(DrmType drmType, DrmHandler drmHandler, boolean downgradeSecureDecoder) {
         for (PlayerType player : prioritizedPlayerTypes) {
             if (player.supports(drmType)) {
                 return createPlayerForType(player, drmType, drmHandler, downgradeSecureDecoder);
@@ -41,7 +41,7 @@ class NoPlayerCreator {
         throw UnableToCreatePlayerException.unhandledDrmType(drmType);
     }
 
-    private Player createPlayerForType(PlayerType playerType, DrmType drmType, DrmHandler drmHandler, boolean downgradeSecureDecoder) {
+    private NoPlayer createPlayerForType(PlayerType playerType, DrmType drmType, DrmHandler drmHandler, boolean downgradeSecureDecoder) {
         switch (playerType) {
             case MEDIA_PLAYER:
                 return noPlayerMediaPlayerCreator.createMediaPlayer(context);

--- a/core/src/main/java/com/novoda/noplayer/NoPlayerError.java
+++ b/core/src/main/java/com/novoda/noplayer/NoPlayerError.java
@@ -1,6 +1,6 @@
 package com.novoda.noplayer;
 
-public class NoPlayerError implements Player.PlayerError {
+public class NoPlayerError implements NoPlayer.PlayerError {
 
     private final PlayerErrorType playerErrorType;
     private final String message;

--- a/core/src/main/java/com/novoda/noplayer/NoPlayerView.java
+++ b/core/src/main/java/com/novoda/noplayer/NoPlayerView.java
@@ -56,12 +56,12 @@ public class NoPlayerView extends FrameLayout implements AspectRatioChangeCalcul
     }
 
     @Override
-    public Player.VideoSizeChangedListener getVideoSizeChangedListener() {
+    public NoPlayer.VideoSizeChangedListener getVideoSizeChangedListener() {
         return videoSizeChangedListener;
     }
 
     @Override
-    public Player.StateChangedListener getStateChangedListener() {
+    public NoPlayer.StateChangedListener getStateChangedListener() {
         return stateChangedListener;
     }
 
@@ -80,14 +80,14 @@ public class NoPlayerView extends FrameLayout implements AspectRatioChangeCalcul
         subtitleView.setCues(textCues);
     }
 
-    private final Player.VideoSizeChangedListener videoSizeChangedListener = new Player.VideoSizeChangedListener() {
+    private final NoPlayer.VideoSizeChangedListener videoSizeChangedListener = new NoPlayer.VideoSizeChangedListener() {
         @Override
         public void onVideoSizeChanged(int width, int height, int unappliedRotationDegrees, float pixelWidthHeightRatio) {
             aspectRatioChangeCalculator.onVideoSizeChanged(width, height, pixelWidthHeightRatio);
         }
     };
 
-    private final Player.StateChangedListener stateChangedListener = new Player.StateChangedListener() {
+    private final NoPlayer.StateChangedListener stateChangedListener = new NoPlayer.StateChangedListener() {
         @Override
         public void onVideoPlaying() {
             shutterView.setVisibility(INVISIBLE);

--- a/core/src/main/java/com/novoda/noplayer/PlayerBuilder.java
+++ b/core/src/main/java/com/novoda/noplayer/PlayerBuilder.java
@@ -19,7 +19,7 @@ import java.util.Arrays;
 import java.util.List;
 
 /**
- * Builds instances of {@link Player} for given configurations.
+ * Builds instances of {@link NoPlayer} for given configurations.
  */
 public class PlayerBuilder {
 
@@ -32,7 +32,7 @@ public class PlayerBuilder {
      * Sets {@link PlayerBuilder} to build a Player which supports Widevine classic DRM.
      *
      * @return {@link PlayerBuilder}
-     * @see Player
+     * @see NoPlayer
      */
     public PlayerBuilder withWidevineClassicDrm() {
         return withDrm(DrmType.WIDEVINE_CLASSIC, DrmHandler.NO_DRM);
@@ -43,7 +43,7 @@ public class PlayerBuilder {
      *
      * @param streamingModularDrm Implementation of {@link StreamingModularDrm}.
      * @return {@link PlayerBuilder}
-     * @see Player
+     * @see NoPlayer
      */
     public PlayerBuilder withWidevineModularStreamingDrm(StreamingModularDrm streamingModularDrm) {
         return withDrm(DrmType.WIDEVINE_MODULAR_STREAM, streamingModularDrm);
@@ -54,7 +54,7 @@ public class PlayerBuilder {
      *
      * @param downloadedModularDrm Implementation of {@link DownloadedModularDrm}.
      * @return {@link PlayerBuilder}
-     * @see Player
+     * @see NoPlayer
      */
     public PlayerBuilder withWidevineModularDownloadDrm(DownloadedModularDrm downloadedModularDrm) {
         return withDrm(DrmType.WIDEVINE_MODULAR_DOWNLOAD, downloadedModularDrm);
@@ -66,7 +66,7 @@ public class PlayerBuilder {
      * @param drmType    {@link DrmType}
      * @param drmHandler {@link DrmHandler}
      * @return {@link PlayerBuilder}
-     * @see Player
+     * @see NoPlayer
      */
     public PlayerBuilder withDrm(DrmType drmType, DrmHandler drmHandler) {
         this.drmType = drmType;
@@ -80,7 +80,7 @@ public class PlayerBuilder {
      *
      * @param playerTypes Priority order of {@link PlayerType} with the first being the highest.
      * @return {@link PlayerBuilder}
-     * @see Player
+     * @see NoPlayer
      */
     public PlayerBuilder withPriority(PlayerType playerType, PlayerType... playerTypes) {
         List<PlayerType> types = new ArrayList<>();
@@ -107,9 +107,9 @@ public class PlayerBuilder {
      * @param context
      * @return a Player instance.
      * @throws UnableToCreatePlayerException thrown when the configuration is not supported and there is no way to recover.
-     * @see Player
+     * @see NoPlayer
      */
-    public Player build(Context context) throws UnableToCreatePlayerException {
+    public NoPlayer build(Context context) throws UnableToCreatePlayerException {
         Handler handler = new Handler(Looper.getMainLooper());
         ProvisionExecutorCreator provisionExecutorCreator = new ProvisionExecutorCreator();
         DrmSessionCreatorFactory drmSessionCreatorFactory = new DrmSessionCreatorFactory(

--- a/core/src/main/java/com/novoda/noplayer/PlayerBuilder.java
+++ b/core/src/main/java/com/novoda/noplayer/PlayerBuilder.java
@@ -29,7 +29,7 @@ public class PlayerBuilder {
     private boolean downgradeSecureDecoder = false;
 
     /**
-     * Sets {@link PlayerBuilder} to build a Player which supports Widevine classic DRM.
+     * Sets {@link PlayerBuilder} to build a {@link NoPlayer} which supports Widevine classic DRM.
      *
      * @return {@link PlayerBuilder}
      * @see NoPlayer
@@ -39,7 +39,7 @@ public class PlayerBuilder {
     }
 
     /**
-     * Sets {@link PlayerBuilder} to build a Player which supports Widevine modular streaming DRM.
+     * Sets {@link PlayerBuilder} to build a {@link NoPlayer} which supports Widevine modular streaming DRM.
      *
      * @param streamingModularDrm Implementation of {@link StreamingModularDrm}.
      * @return {@link PlayerBuilder}
@@ -50,7 +50,7 @@ public class PlayerBuilder {
     }
 
     /**
-     * Sets {@link PlayerBuilder} to build a Player which supports Widevine modular download DRM.
+     * Sets {@link PlayerBuilder} to build a {@link NoPlayer} which supports Widevine modular download DRM.
      *
      * @param downloadedModularDrm Implementation of {@link DownloadedModularDrm}.
      * @return {@link PlayerBuilder}
@@ -61,7 +61,7 @@ public class PlayerBuilder {
     }
 
     /**
-     * Sets {@link PlayerBuilder} to build a Player which supports the specified parameters.
+     * Sets {@link PlayerBuilder} to build a {@link NoPlayer} which supports the specified parameters.
      *
      * @param drmType    {@link DrmType}
      * @param drmHandler {@link DrmHandler}
@@ -75,7 +75,7 @@ public class PlayerBuilder {
     }
 
     /**
-     * Sets {@link PlayerBuilder} to build a Player which will prioritise the underlying player when
+     * Sets {@link PlayerBuilder} to build a {@link NoPlayer} which will prioritise the underlying player when
      * multiple underlying players share the same features.
      *
      * @param playerTypes Priority order of {@link PlayerType} with the first being the highest.
@@ -102,10 +102,10 @@ public class PlayerBuilder {
     }
 
     /**
-     * Builds a new Player instance.
+     * Builds a new {@link NoPlayer} instance.
      *
      * @param context
-     * @return a Player instance.
+     * @return a {@link NoPlayer} instance.
      * @throws UnableToCreatePlayerException thrown when the configuration is not supported and there is no way to recover.
      * @see NoPlayer
      */

--- a/core/src/main/java/com/novoda/noplayer/PlayerView.java
+++ b/core/src/main/java/com/novoda/noplayer/PlayerView.java
@@ -10,9 +10,9 @@ public interface PlayerView {
 
     SurfaceHolderRequester getSurfaceHolderRequester();
 
-    Player.VideoSizeChangedListener getVideoSizeChangedListener();
+    NoPlayer.VideoSizeChangedListener getVideoSizeChangedListener();
 
-    Player.StateChangedListener getStateChangedListener();
+    NoPlayer.StateChangedListener getStateChangedListener();
 
     void showSubtitles();
 

--- a/core/src/main/java/com/novoda/noplayer/internal/Heart.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/Heart.java
@@ -2,7 +2,7 @@ package com.novoda.noplayer.internal;
 
 import android.os.Handler;
 
-import com.novoda.noplayer.Player;
+import com.novoda.noplayer.NoPlayer;
 
 public class Heart {
 
@@ -67,10 +67,10 @@ public class Heart {
 
     public static class Heartbeat implements Runnable {
 
-        private final Player.HeartbeatCallback callback;
-        private final Player player;
+        private final NoPlayer.HeartbeatCallback callback;
+        private final NoPlayer player;
 
-        public Heartbeat(Player.HeartbeatCallback callback, Player player) {
+        public Heartbeat(NoPlayer.HeartbeatCallback callback, NoPlayer player) {
             this.callback = callback;
             this.player = player;
         }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImpl.java
@@ -7,7 +7,7 @@ import android.view.View;
 
 import com.google.android.exoplayer2.mediacodec.MediaCodecSelector;
 import com.novoda.noplayer.ContentType;
-import com.novoda.noplayer.Player;
+import com.novoda.noplayer.NoPlayer;
 import com.novoda.noplayer.PlayerInformation;
 import com.novoda.noplayer.PlayerState;
 import com.novoda.noplayer.PlayerView;
@@ -26,7 +26,7 @@ import com.novoda.noplayer.model.VideoPosition;
 
 import java.util.List;
 
-class ExoPlayerTwoImpl implements Player {
+class ExoPlayerTwoImpl implements NoPlayer {
 
     private final ExoPlayerFacade exoPlayer;
     private final PlayerListenersHolder listenersHolder;

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerExoPlayerCreator.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerExoPlayerCreator.java
@@ -8,7 +8,7 @@ import com.google.android.exoplayer2.trackselection.DefaultTrackSelector;
 import com.google.android.exoplayer2.trackselection.FixedTrackSelection;
 import com.google.android.exoplayer2.upstream.DefaultDataSourceFactory;
 import com.novoda.noplayer.internal.Heart;
-import com.novoda.noplayer.Player;
+import com.novoda.noplayer.NoPlayer;
 import com.novoda.noplayer.internal.listeners.PlayerListenersHolder;
 import com.novoda.noplayer.internal.SystemClock;
 import com.novoda.noplayer.internal.exoplayer.drm.DrmSessionCreator;
@@ -32,7 +32,7 @@ public class NoPlayerExoPlayerCreator {
         this.internalCreator = internalCreator;
     }
 
-    public Player createExoPlayer(Context context, DrmSessionCreator drmSessionCreator, boolean downgradeSecureDecoder) {
+    public NoPlayer createExoPlayer(Context context, DrmSessionCreator drmSessionCreator, boolean downgradeSecureDecoder) {
         ExoPlayerTwoImpl player = internalCreator.create(context, drmSessionCreator, downgradeSecureDecoder);
         player.initialise();
         return player;

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/BitrateForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/BitrateForwarder.java
@@ -4,7 +4,7 @@ import com.google.android.exoplayer2.C;
 import com.google.android.exoplayer2.Format;
 import com.google.android.exoplayer2.source.AdaptiveMediaSourceEventListener;
 import com.google.android.exoplayer2.upstream.DataSpec;
-import com.novoda.noplayer.Player;
+import com.novoda.noplayer.NoPlayer;
 import com.novoda.noplayer.model.Bitrate;
 
 import java.io.IOException;
@@ -14,9 +14,9 @@ class BitrateForwarder implements AdaptiveMediaSourceEventListener {
     private Bitrate videoBitrate = Bitrate.fromBitsPerSecond(0);
     private Bitrate audioBitrate = Bitrate.fromBitsPerSecond(0);
 
-    private final Player.BitrateChangedListener bitrateChangedListener;
+    private final NoPlayer.BitrateChangedListener bitrateChangedListener;
 
-    BitrateForwarder(Player.BitrateChangedListener bitrateChangedListener) {
+    BitrateForwarder(NoPlayer.BitrateChangedListener bitrateChangedListener) {
         this.bitrateChangedListener = bitrateChangedListener;
     }
 

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/BufferStateForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/BufferStateForwarder.java
@@ -5,13 +5,13 @@ import com.google.android.exoplayer2.PlaybackParameters;
 import com.google.android.exoplayer2.Timeline;
 import com.google.android.exoplayer2.source.TrackGroupArray;
 import com.google.android.exoplayer2.trackselection.TrackSelectionArray;
-import com.novoda.noplayer.Player;
+import com.novoda.noplayer.NoPlayer;
 
 class BufferStateForwarder implements com.google.android.exoplayer2.Player.EventListener {
 
-    private final Player.BufferStateListener bufferStateListener;
+    private final NoPlayer.BufferStateListener bufferStateListener;
 
-    BufferStateForwarder(Player.BufferStateListener bufferStateListener) {
+    BufferStateForwarder(NoPlayer.BufferStateListener bufferStateListener) {
         this.bufferStateListener = bufferStateListener;
     }
 

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/BufferStateForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/BufferStateForwarder.java
@@ -2,12 +2,13 @@ package com.novoda.noplayer.internal.exoplayer.forwarder;
 
 import com.google.android.exoplayer2.ExoPlaybackException;
 import com.google.android.exoplayer2.PlaybackParameters;
+import com.google.android.exoplayer2.Player;
 import com.google.android.exoplayer2.Timeline;
 import com.google.android.exoplayer2.source.TrackGroupArray;
 import com.google.android.exoplayer2.trackselection.TrackSelectionArray;
 import com.novoda.noplayer.NoPlayer;
 
-class BufferStateForwarder implements com.google.android.exoplayer2.Player.EventListener {
+class BufferStateForwarder implements Player.EventListener {
 
     private final NoPlayer.BufferStateListener bufferStateListener;
 
@@ -17,15 +18,15 @@ class BufferStateForwarder implements com.google.android.exoplayer2.Player.Event
 
     @Override
     public void onPlayerStateChanged(boolean playWhenReady, int playbackState) {
-        if (playbackState == com.google.android.exoplayer2.Player.STATE_BUFFERING) {
+        if (playbackState == Player.STATE_BUFFERING) {
             bufferStateListener.onBufferStarted();
-        } else if (playbackState == com.google.android.exoplayer2.Player.STATE_READY) {
+        } else if (playbackState == Player.STATE_READY) {
             bufferStateListener.onBufferCompleted();
         }
     }
 
     @Override
-    public void onRepeatModeChanged(@com.google.android.exoplayer2.Player.RepeatMode int repeatMode) {
+    public void onRepeatModeChanged(@Player.RepeatMode int repeatMode) {
         // TODO: should we send?
     }
 

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/DrmSessionErrorForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/DrmSessionErrorForwarder.java
@@ -2,16 +2,16 @@ package com.novoda.noplayer.internal.exoplayer.forwarder;
 
 import com.google.android.exoplayer2.drm.DefaultDrmSessionManager;
 import com.novoda.noplayer.NoPlayerError;
-import com.novoda.noplayer.Player;
+import com.novoda.noplayer.NoPlayer;
 import com.novoda.noplayer.PlayerErrorType;
 
 import static com.novoda.noplayer.internal.exoplayer.forwarder.ErrorFormatter.formatMessage;
 
 class DrmSessionErrorForwarder implements DefaultDrmSessionManager.EventListener {
 
-    private final Player.ErrorListener errorListener;
+    private final NoPlayer.ErrorListener errorListener;
 
-    DrmSessionErrorForwarder(Player.ErrorListener errorListener) {
+    DrmSessionErrorForwarder(NoPlayer.ErrorListener errorListener) {
         this.errorListener = errorListener;
     }
 
@@ -22,7 +22,7 @@ class DrmSessionErrorForwarder implements DefaultDrmSessionManager.EventListener
 
     @Override
     public void onDrmSessionManagerError(Exception e) {
-        Player.PlayerError playerError = new NoPlayerError(PlayerErrorType.FAILED_DRM_INITIATING, formatMessage(e));
+        NoPlayer.PlayerError playerError = new NoPlayerError(PlayerErrorType.FAILED_DRM_INITIATING, formatMessage(e));
         errorListener.onError(playerError);
     }
 

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/EventInfoForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/EventInfoForwarder.java
@@ -5,15 +5,15 @@ import com.google.android.exoplayer2.PlaybackParameters;
 import com.google.android.exoplayer2.Timeline;
 import com.google.android.exoplayer2.source.TrackGroupArray;
 import com.google.android.exoplayer2.trackselection.TrackSelectionArray;
-import com.novoda.noplayer.Player;
+import com.novoda.noplayer.NoPlayer;
 
 import java.util.HashMap;
 
 class EventInfoForwarder implements com.google.android.exoplayer2.Player.EventListener {
 
-    private final Player.InfoListener infoListener;
+    private final NoPlayer.InfoListener infoListener;
 
-    EventInfoForwarder(Player.InfoListener infoListener) {
+    EventInfoForwarder(NoPlayer.InfoListener infoListener) {
         this.infoListener = infoListener;
     }
 

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/EventInfoForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/EventInfoForwarder.java
@@ -2,6 +2,7 @@ package com.novoda.noplayer.internal.exoplayer.forwarder;
 
 import com.google.android.exoplayer2.ExoPlaybackException;
 import com.google.android.exoplayer2.PlaybackParameters;
+import com.google.android.exoplayer2.Player;
 import com.google.android.exoplayer2.Timeline;
 import com.google.android.exoplayer2.source.TrackGroupArray;
 import com.google.android.exoplayer2.trackselection.TrackSelectionArray;
@@ -9,7 +10,7 @@ import com.novoda.noplayer.NoPlayer;
 
 import java.util.HashMap;
 
-class EventInfoForwarder implements com.google.android.exoplayer2.Player.EventListener {
+class EventInfoForwarder implements Player.EventListener {
 
     private final NoPlayer.InfoListener infoListener;
 
@@ -57,7 +58,7 @@ class EventInfoForwarder implements com.google.android.exoplayer2.Player.EventLi
     }
 
     @Override
-    public void onRepeatModeChanged(@com.google.android.exoplayer2.Player.RepeatMode int repeatMode) {
+    public void onRepeatModeChanged(@Player.RepeatMode int repeatMode) {
         HashMap<String, String> callingMethodParameters = new HashMap<>();
 
         callingMethodParameters.put("repeatMode", String.valueOf(repeatMode));

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/ExoPlayerErrorMapper.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/ExoPlayerErrorMapper.java
@@ -4,8 +4,8 @@ import android.media.MediaCodec;
 
 import com.google.android.exoplayer2.ParserException;
 import com.google.android.exoplayer2.upstream.HttpDataSource;
+import com.novoda.noplayer.NoPlayer;
 import com.novoda.noplayer.NoPlayerError;
-import com.novoda.noplayer.Player;
 import com.novoda.noplayer.PlayerErrorType;
 import com.novoda.noplayer.drm.StreamingModularDrm;
 
@@ -19,7 +19,7 @@ final class ExoPlayerErrorMapper {
         // Static class.
     }
 
-    static Player.PlayerError errorFor(Exception e) {
+    static NoPlayer.PlayerError errorFor(Exception e) {
         if (e instanceof HttpDataSource.InvalidResponseCodeException) {
             return new NoPlayerError(PlayerErrorType.INVALID_RESPONSE_CODE, formatMessage(e));
         }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/ExoPlayerForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/ExoPlayerForwarder.java
@@ -4,7 +4,7 @@ import com.google.android.exoplayer2.drm.DefaultDrmSessionManager;
 import com.google.android.exoplayer2.source.AdaptiveMediaSourceEventListener;
 import com.google.android.exoplayer2.source.ExtractorMediaSource;
 import com.google.android.exoplayer2.video.VideoRendererEventListener;
-import com.novoda.noplayer.Player;
+import com.novoda.noplayer.NoPlayer;
 import com.novoda.noplayer.PlayerState;
 
 public class ExoPlayerForwarder {
@@ -43,34 +43,34 @@ public class ExoPlayerForwarder {
         return drmSessionEventListener;
     }
 
-    public void bind(Player.PreparedListener preparedListener, PlayerState playerState) {
+    public void bind(NoPlayer.PreparedListener preparedListener, PlayerState playerState) {
         exoPlayerEventListener.add(new OnPrepareForwarder(preparedListener, playerState));
     }
 
-    public void bind(Player.CompletionListener completionListener, Player.StateChangedListener stateChangedListener) {
+    public void bind(NoPlayer.CompletionListener completionListener, NoPlayer.StateChangedListener stateChangedListener) {
         exoPlayerEventListener.add(new OnCompletionForwarder(completionListener));
         exoPlayerEventListener.add(new OnCompletionStateChangedForwarder(stateChangedListener));
     }
 
-    public void bind(Player.ErrorListener errorListener) {
+    public void bind(NoPlayer.ErrorListener errorListener) {
         exoPlayerEventListener.add(new PlayerOnErrorForwarder(errorListener));
         extractorMediaSourceListener.add(new MediaSourceOnErrorForwarder(errorListener));
         drmSessionEventListener.add(new DrmSessionErrorForwarder(errorListener));
     }
 
-    public void bind(Player.BufferStateListener bufferStateListener) {
+    public void bind(NoPlayer.BufferStateListener bufferStateListener) {
         exoPlayerEventListener.add(new BufferStateForwarder(bufferStateListener));
     }
 
-    public void bind(Player.VideoSizeChangedListener videoSizeChangedListener) {
+    public void bind(NoPlayer.VideoSizeChangedListener videoSizeChangedListener) {
         videoRendererEventListener.add(new VideoSizeChangedForwarder(videoSizeChangedListener));
     }
 
-    public void bind(Player.BitrateChangedListener bitrateChangedListener) {
+    public void bind(NoPlayer.BitrateChangedListener bitrateChangedListener) {
         mediaSourceEventListener.add(new BitrateForwarder(bitrateChangedListener));
     }
 
-    public void bind(Player.InfoListener infoListeners) {
+    public void bind(NoPlayer.InfoListener infoListeners) {
         exoPlayerEventListener.add(new EventInfoForwarder(infoListeners));
         mediaSourceEventListener.add(new MediaSourceInfoForwarder(infoListeners));
         videoRendererEventListener.add(new VideoRendererInfoForwarder(infoListeners));

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/ExtractorInfoForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/ExtractorInfoForwarder.java
@@ -1,16 +1,16 @@
 package com.novoda.noplayer.internal.exoplayer.forwarder;
 
 import com.google.android.exoplayer2.source.ExtractorMediaSource;
-import com.novoda.noplayer.Player;
+import com.novoda.noplayer.NoPlayer;
 
 import java.io.IOException;
 import java.util.HashMap;
 
 class ExtractorInfoForwarder implements ExtractorMediaSource.EventListener {
 
-    private final Player.InfoListener infoListener;
+    private final NoPlayer.InfoListener infoListener;
 
-    ExtractorInfoForwarder(Player.InfoListener infoListener) {
+    ExtractorInfoForwarder(NoPlayer.InfoListener infoListener) {
         this.infoListener = infoListener;
     }
 

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/MediaSourceInfoForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/MediaSourceInfoForwarder.java
@@ -3,16 +3,16 @@ package com.novoda.noplayer.internal.exoplayer.forwarder;
 import com.google.android.exoplayer2.Format;
 import com.google.android.exoplayer2.source.AdaptiveMediaSourceEventListener;
 import com.google.android.exoplayer2.upstream.DataSpec;
-import com.novoda.noplayer.Player;
+import com.novoda.noplayer.NoPlayer;
 
 import java.io.IOException;
 import java.util.HashMap;
 
 class MediaSourceInfoForwarder implements AdaptiveMediaSourceEventListener {
 
-    private final Player.InfoListener infoListener;
+    private final NoPlayer.InfoListener infoListener;
 
-    MediaSourceInfoForwarder(Player.InfoListener infoListener) {
+    MediaSourceInfoForwarder(NoPlayer.InfoListener infoListener) {
         this.infoListener = infoListener;
     }
 

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/MediaSourceOnErrorForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/MediaSourceOnErrorForwarder.java
@@ -1,8 +1,8 @@
 package com.novoda.noplayer.internal.exoplayer.forwarder;
 
 import com.google.android.exoplayer2.source.ExtractorMediaSource;
+import com.novoda.noplayer.NoPlayer;
 import com.novoda.noplayer.NoPlayerError;
-import com.novoda.noplayer.Player;
 import com.novoda.noplayer.PlayerErrorType;
 
 import java.io.IOException;
@@ -11,15 +11,15 @@ import static com.novoda.noplayer.internal.exoplayer.forwarder.ErrorFormatter.fo
 
 class MediaSourceOnErrorForwarder implements ExtractorMediaSource.EventListener {
 
-    private final Player.ErrorListener errorListener;
+    private final NoPlayer.ErrorListener errorListener;
 
-    MediaSourceOnErrorForwarder(Player.ErrorListener errorListener) {
+    MediaSourceOnErrorForwarder(NoPlayer.ErrorListener errorListener) {
         this.errorListener = errorListener;
     }
 
     @Override
     public void onLoadError(IOException error) {
-        Player.PlayerError playerError = new NoPlayerError(PlayerErrorType.MEDIA_SOURCE_ERROR, formatMessage(error));
+        NoPlayer.PlayerError playerError = new NoPlayerError(PlayerErrorType.MEDIA_SOURCE_ERROR, formatMessage(error));
         errorListener.onError(playerError);
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/OnCompletionForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/OnCompletionForwarder.java
@@ -5,13 +5,13 @@ import com.google.android.exoplayer2.PlaybackParameters;
 import com.google.android.exoplayer2.Timeline;
 import com.google.android.exoplayer2.source.TrackGroupArray;
 import com.google.android.exoplayer2.trackselection.TrackSelectionArray;
-import com.novoda.noplayer.Player;
+import com.novoda.noplayer.NoPlayer;
 
 class OnCompletionForwarder implements com.google.android.exoplayer2.Player.EventListener {
 
-    private final Player.CompletionListener completionListener;
+    private final NoPlayer.CompletionListener completionListener;
 
-    OnCompletionForwarder(Player.CompletionListener completionListener) {
+    OnCompletionForwarder(NoPlayer.CompletionListener completionListener) {
         this.completionListener = completionListener;
     }
 

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/OnCompletionForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/OnCompletionForwarder.java
@@ -2,12 +2,13 @@ package com.novoda.noplayer.internal.exoplayer.forwarder;
 
 import com.google.android.exoplayer2.ExoPlaybackException;
 import com.google.android.exoplayer2.PlaybackParameters;
+import com.google.android.exoplayer2.Player;
 import com.google.android.exoplayer2.Timeline;
 import com.google.android.exoplayer2.source.TrackGroupArray;
 import com.google.android.exoplayer2.trackselection.TrackSelectionArray;
 import com.novoda.noplayer.NoPlayer;
 
-class OnCompletionForwarder implements com.google.android.exoplayer2.Player.EventListener {
+class OnCompletionForwarder implements Player.EventListener {
 
     private final NoPlayer.CompletionListener completionListener;
 
@@ -17,13 +18,13 @@ class OnCompletionForwarder implements com.google.android.exoplayer2.Player.Even
 
     @Override
     public void onPlayerStateChanged(boolean playWhenReady, int playbackState) {
-        if (playbackState == com.google.android.exoplayer2.Player.STATE_ENDED) {
+        if (playbackState == Player.STATE_ENDED) {
             completionListener.onCompletion();
         }
     }
 
     @Override
-    public void onRepeatModeChanged(@com.google.android.exoplayer2.Player.RepeatMode int repeatMode) {
+    public void onRepeatModeChanged(@Player.RepeatMode int repeatMode) {
         // TODO: should we send?
     }
 

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/OnCompletionStateChangedForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/OnCompletionStateChangedForwarder.java
@@ -2,12 +2,13 @@ package com.novoda.noplayer.internal.exoplayer.forwarder;
 
 import com.google.android.exoplayer2.ExoPlaybackException;
 import com.google.android.exoplayer2.PlaybackParameters;
+import com.google.android.exoplayer2.Player;
 import com.google.android.exoplayer2.Timeline;
 import com.google.android.exoplayer2.source.TrackGroupArray;
 import com.google.android.exoplayer2.trackselection.TrackSelectionArray;
 import com.novoda.noplayer.NoPlayer;
 
-class OnCompletionStateChangedForwarder implements com.google.android.exoplayer2.Player.EventListener {
+class OnCompletionStateChangedForwarder implements Player.EventListener {
 
     private final NoPlayer.StateChangedListener stateChangedListener;
 
@@ -17,7 +18,7 @@ class OnCompletionStateChangedForwarder implements com.google.android.exoplayer2
 
     @Override
     public void onPlayerStateChanged(boolean playWhenReady, int playbackState) {
-        if (playbackState == com.google.android.exoplayer2.Player.STATE_ENDED) {
+        if (playbackState == Player.STATE_ENDED) {
             stateChangedListener.onVideoStopped();
         }
     }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/OnCompletionStateChangedForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/OnCompletionStateChangedForwarder.java
@@ -5,13 +5,13 @@ import com.google.android.exoplayer2.PlaybackParameters;
 import com.google.android.exoplayer2.Timeline;
 import com.google.android.exoplayer2.source.TrackGroupArray;
 import com.google.android.exoplayer2.trackselection.TrackSelectionArray;
-import com.novoda.noplayer.Player;
+import com.novoda.noplayer.NoPlayer;
 
 class OnCompletionStateChangedForwarder implements com.google.android.exoplayer2.Player.EventListener {
 
-    private final Player.StateChangedListener stateChangedListener;
+    private final NoPlayer.StateChangedListener stateChangedListener;
 
-    OnCompletionStateChangedForwarder(Player.StateChangedListener stateChangedListener) {
+    OnCompletionStateChangedForwarder(NoPlayer.StateChangedListener stateChangedListener) {
         this.stateChangedListener = stateChangedListener;
     }
 

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/OnPrepareForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/OnPrepareForwarder.java
@@ -5,15 +5,15 @@ import com.google.android.exoplayer2.PlaybackParameters;
 import com.google.android.exoplayer2.Timeline;
 import com.google.android.exoplayer2.source.TrackGroupArray;
 import com.google.android.exoplayer2.trackselection.TrackSelectionArray;
-import com.novoda.noplayer.Player;
+import com.novoda.noplayer.NoPlayer;
 import com.novoda.noplayer.PlayerState;
 
 class OnPrepareForwarder implements com.google.android.exoplayer2.Player.EventListener {
 
-    private final Player.PreparedListener preparedListener;
+    private final NoPlayer.PreparedListener preparedListener;
     private final PlayerState playerState;
 
-    OnPrepareForwarder(Player.PreparedListener preparedListener, PlayerState playerState) {
+    OnPrepareForwarder(NoPlayer.PreparedListener preparedListener, PlayerState playerState) {
         this.preparedListener = preparedListener;
         this.playerState = playerState;
     }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/OnPrepareForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/OnPrepareForwarder.java
@@ -2,13 +2,14 @@ package com.novoda.noplayer.internal.exoplayer.forwarder;
 
 import com.google.android.exoplayer2.ExoPlaybackException;
 import com.google.android.exoplayer2.PlaybackParameters;
+import com.google.android.exoplayer2.Player;
 import com.google.android.exoplayer2.Timeline;
 import com.google.android.exoplayer2.source.TrackGroupArray;
 import com.google.android.exoplayer2.trackselection.TrackSelectionArray;
 import com.novoda.noplayer.NoPlayer;
 import com.novoda.noplayer.PlayerState;
 
-class OnPrepareForwarder implements com.google.android.exoplayer2.Player.EventListener {
+class OnPrepareForwarder implements Player.EventListener {
 
     private final NoPlayer.PreparedListener preparedListener;
     private final PlayerState playerState;
@@ -26,12 +27,12 @@ class OnPrepareForwarder implements com.google.android.exoplayer2.Player.EventLi
     }
 
     @Override
-    public void onRepeatModeChanged(@com.google.android.exoplayer2.Player.RepeatMode int repeatMode) {
+    public void onRepeatModeChanged(@Player.RepeatMode int repeatMode) {
         // TODO: should we send?
     }
 
     private boolean isReady(int playbackState) {
-        return playbackState == com.google.android.exoplayer2.Player.STATE_READY;
+        return playbackState == Player.STATE_READY;
     }
 
     @Override

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/PlayerOnErrorForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/PlayerOnErrorForwarder.java
@@ -5,19 +5,19 @@ import com.google.android.exoplayer2.PlaybackParameters;
 import com.google.android.exoplayer2.Timeline;
 import com.google.android.exoplayer2.source.TrackGroupArray;
 import com.google.android.exoplayer2.trackselection.TrackSelectionArray;
-import com.novoda.noplayer.Player;
+import com.novoda.noplayer.NoPlayer;
 
 class PlayerOnErrorForwarder implements com.google.android.exoplayer2.Player.EventListener {
 
-    private final Player.ErrorListener errorListener;
+    private final NoPlayer.ErrorListener errorListener;
 
-    PlayerOnErrorForwarder(Player.ErrorListener errorListener) {
+    PlayerOnErrorForwarder(NoPlayer.ErrorListener errorListener) {
         this.errorListener = errorListener;
     }
 
     @Override
     public void onPlayerError(ExoPlaybackException error) {
-        Player.PlayerError playerError = ExoPlayerErrorMapper.errorFor(error);
+        NoPlayer.PlayerError playerError = ExoPlayerErrorMapper.errorFor(error);
         errorListener.onError(playerError);
     }
 

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/PlayerOnErrorForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/PlayerOnErrorForwarder.java
@@ -2,12 +2,13 @@ package com.novoda.noplayer.internal.exoplayer.forwarder;
 
 import com.google.android.exoplayer2.ExoPlaybackException;
 import com.google.android.exoplayer2.PlaybackParameters;
+import com.google.android.exoplayer2.Player;
 import com.google.android.exoplayer2.Timeline;
 import com.google.android.exoplayer2.source.TrackGroupArray;
 import com.google.android.exoplayer2.trackselection.TrackSelectionArray;
 import com.novoda.noplayer.NoPlayer;
 
-class PlayerOnErrorForwarder implements com.google.android.exoplayer2.Player.EventListener {
+class PlayerOnErrorForwarder implements Player.EventListener {
 
     private final NoPlayer.ErrorListener errorListener;
 
@@ -42,7 +43,7 @@ class PlayerOnErrorForwarder implements com.google.android.exoplayer2.Player.Eve
     }
 
     @Override
-    public void onRepeatModeChanged(@com.google.android.exoplayer2.Player.RepeatMode int repeatMode) {
+    public void onRepeatModeChanged(@Player.RepeatMode int repeatMode) {
         // TODO: should we send?
     }
 

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/VideoRendererInfoForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/VideoRendererInfoForwarder.java
@@ -5,15 +5,15 @@ import android.view.Surface;
 import com.google.android.exoplayer2.Format;
 import com.google.android.exoplayer2.decoder.DecoderCounters;
 import com.google.android.exoplayer2.video.VideoRendererEventListener;
-import com.novoda.noplayer.Player;
+import com.novoda.noplayer.NoPlayer;
 
 import java.util.HashMap;
 
 class VideoRendererInfoForwarder implements VideoRendererEventListener {
 
-    private final Player.InfoListener infoListener;
+    private final NoPlayer.InfoListener infoListener;
 
-    VideoRendererInfoForwarder(Player.InfoListener infoListener) {
+    VideoRendererInfoForwarder(NoPlayer.InfoListener infoListener) {
         this.infoListener = infoListener;
     }
 

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/VideoSizeChangedForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/VideoSizeChangedForwarder.java
@@ -5,13 +5,13 @@ import android.view.Surface;
 import com.google.android.exoplayer2.Format;
 import com.google.android.exoplayer2.decoder.DecoderCounters;
 import com.google.android.exoplayer2.video.VideoRendererEventListener;
-import com.novoda.noplayer.Player;
+import com.novoda.noplayer.NoPlayer;
 
 class VideoSizeChangedForwarder implements VideoRendererEventListener {
 
-    private final Player.VideoSizeChangedListener videoSizeChangedListener;
+    private final NoPlayer.VideoSizeChangedListener videoSizeChangedListener;
 
-    VideoSizeChangedForwarder(Player.VideoSizeChangedListener videoSizeChangedListener) {
+    VideoSizeChangedForwarder(NoPlayer.VideoSizeChangedListener videoSizeChangedListener) {
         this.videoSizeChangedListener = videoSizeChangedListener;
     }
 

--- a/core/src/main/java/com/novoda/noplayer/internal/listeners/BitrateChangedListeners.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/listeners/BitrateChangedListeners.java
@@ -1,20 +1,20 @@
 package com.novoda.noplayer.internal.listeners;
 
-import com.novoda.noplayer.Player;
+import com.novoda.noplayer.NoPlayer;
 import com.novoda.noplayer.model.Bitrate;
 
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 
-class BitrateChangedListeners implements Player.BitrateChangedListener {
+class BitrateChangedListeners implements NoPlayer.BitrateChangedListener {
 
-    private final Set<Player.BitrateChangedListener> listeners = new CopyOnWriteArraySet<>();
+    private final Set<NoPlayer.BitrateChangedListener> listeners = new CopyOnWriteArraySet<>();
 
-    void add(Player.BitrateChangedListener listener) {
+    void add(NoPlayer.BitrateChangedListener listener) {
         listeners.add(listener);
     }
 
-    void remove(Player.BitrateChangedListener listener) {
+    void remove(NoPlayer.BitrateChangedListener listener) {
         listeners.remove(listener);
     }
 
@@ -24,7 +24,7 @@ class BitrateChangedListeners implements Player.BitrateChangedListener {
 
     @Override
     public void onBitrateChanged(Bitrate audioBitrate, Bitrate videoBitrate) {
-        for (Player.BitrateChangedListener listener : listeners) {
+        for (NoPlayer.BitrateChangedListener listener : listeners) {
             listener.onBitrateChanged(audioBitrate, videoBitrate);
         }
     }

--- a/core/src/main/java/com/novoda/noplayer/internal/listeners/BufferStateListeners.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/listeners/BufferStateListeners.java
@@ -1,19 +1,19 @@
 package com.novoda.noplayer.internal.listeners;
 
-import com.novoda.noplayer.Player;
+import com.novoda.noplayer.NoPlayer;
 
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 
-class BufferStateListeners implements Player.BufferStateListener {
+class BufferStateListeners implements NoPlayer.BufferStateListener {
 
-    private final Set<Player.BufferStateListener> listeners = new CopyOnWriteArraySet<>();
+    private final Set<NoPlayer.BufferStateListener> listeners = new CopyOnWriteArraySet<>();
 
-    void add(Player.BufferStateListener listener) {
+    void add(NoPlayer.BufferStateListener listener) {
         listeners.add(listener);
     }
 
-    void remove(Player.BufferStateListener listener) {
+    void remove(NoPlayer.BufferStateListener listener) {
         listeners.remove(listener);
     }
 
@@ -23,14 +23,14 @@ class BufferStateListeners implements Player.BufferStateListener {
 
     @Override
     public void onBufferStarted() {
-        for (Player.BufferStateListener listener : listeners) {
+        for (NoPlayer.BufferStateListener listener : listeners) {
             listener.onBufferStarted();
         }
     }
 
     @Override
     public void onBufferCompleted() {
-        for (Player.BufferStateListener listener : listeners) {
+        for (NoPlayer.BufferStateListener listener : listeners) {
             listener.onBufferCompleted();
         }
     }

--- a/core/src/main/java/com/novoda/noplayer/internal/listeners/CompletionListeners.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/listeners/CompletionListeners.java
@@ -1,19 +1,19 @@
 package com.novoda.noplayer.internal.listeners;
 
-import com.novoda.noplayer.Player;
+import com.novoda.noplayer.NoPlayer;
 
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 
-class CompletionListeners implements Player.CompletionListener {
+class CompletionListeners implements NoPlayer.CompletionListener {
 
-    private final Set<Player.CompletionListener> listeners = new CopyOnWriteArraySet<>();
+    private final Set<NoPlayer.CompletionListener> listeners = new CopyOnWriteArraySet<>();
 
-    void add(Player.CompletionListener listener) {
+    void add(NoPlayer.CompletionListener listener) {
         listeners.add(listener);
     }
 
-    void remove(Player.CompletionListener listener) {
+    void remove(NoPlayer.CompletionListener listener) {
         listeners.remove(listener);
     }
 
@@ -23,7 +23,7 @@ class CompletionListeners implements Player.CompletionListener {
 
     @Override
     public void onCompletion() {
-        for (Player.CompletionListener listener : listeners) {
+        for (NoPlayer.CompletionListener listener : listeners) {
             listener.onCompletion();
         }
     }

--- a/core/src/main/java/com/novoda/noplayer/internal/listeners/ErrorListeners.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/listeners/ErrorListeners.java
@@ -1,19 +1,19 @@
 package com.novoda.noplayer.internal.listeners;
 
-import com.novoda.noplayer.Player;
+import com.novoda.noplayer.NoPlayer;
 
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 
-class ErrorListeners implements Player.ErrorListener {
+class ErrorListeners implements NoPlayer.ErrorListener {
 
-    private final Set<Player.ErrorListener> listeners = new CopyOnWriteArraySet<>();
+    private final Set<NoPlayer.ErrorListener> listeners = new CopyOnWriteArraySet<>();
 
-    void add(Player.ErrorListener listener) {
+    void add(NoPlayer.ErrorListener listener) {
         listeners.add(listener);
     }
 
-    void remove(Player.ErrorListener listener) {
+    void remove(NoPlayer.ErrorListener listener) {
         listeners.remove(listener);
     }
 
@@ -22,8 +22,8 @@ class ErrorListeners implements Player.ErrorListener {
     }
 
     @Override
-    public void onError(Player.PlayerError error) {
-        for (Player.ErrorListener listener : listeners) {
+    public void onError(NoPlayer.PlayerError error) {
+        for (NoPlayer.ErrorListener listener : listeners) {
             listener.onError(error);
         }
     }

--- a/core/src/main/java/com/novoda/noplayer/internal/listeners/HeartbeatCallbacks.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/listeners/HeartbeatCallbacks.java
@@ -1,15 +1,15 @@
 package com.novoda.noplayer.internal.listeners;
 
-import com.novoda.noplayer.Player;
+import com.novoda.noplayer.NoPlayer;
 
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 
-class HeartbeatCallbacks implements Player.HeartbeatCallback {
+class HeartbeatCallbacks implements NoPlayer.HeartbeatCallback {
 
-    private final Set<Player.HeartbeatCallback> callbacks = new CopyOnWriteArraySet<>();
+    private final Set<NoPlayer.HeartbeatCallback> callbacks = new CopyOnWriteArraySet<>();
 
-    void registerCallback(Player.HeartbeatCallback heartbeatCallback) {
+    void registerCallback(NoPlayer.HeartbeatCallback heartbeatCallback) {
         callbacks.add(heartbeatCallback);
     }
 
@@ -18,13 +18,13 @@ class HeartbeatCallbacks implements Player.HeartbeatCallback {
     }
 
     @Override
-    public void onBeat(Player player) {
-        for (Player.HeartbeatCallback callback : callbacks) {
+    public void onBeat(NoPlayer player) {
+        for (NoPlayer.HeartbeatCallback callback : callbacks) {
             callback.onBeat(player);
         }
     }
 
-    void unregisterCallback(Player.HeartbeatCallback heartbeatCallback) {
+    void unregisterCallback(NoPlayer.HeartbeatCallback heartbeatCallback) {
         callbacks.remove(heartbeatCallback);
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/listeners/InfoListeners.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/listeners/InfoListeners.java
@@ -1,20 +1,20 @@
 package com.novoda.noplayer.internal.listeners;
 
-import com.novoda.noplayer.Player;
+import com.novoda.noplayer.NoPlayer;
 
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 
-class InfoListeners implements Player.InfoListener {
+class InfoListeners implements NoPlayer.InfoListener {
 
-    private final Set<Player.InfoListener> listeners = new CopyOnWriteArraySet<>();
+    private final Set<NoPlayer.InfoListener> listeners = new CopyOnWriteArraySet<>();
 
-    void add(Player.InfoListener listener) {
+    void add(NoPlayer.InfoListener listener) {
         listeners.add(listener);
     }
 
-    void remove(Player.InfoListener listener) {
+    void remove(NoPlayer.InfoListener listener) {
         listeners.remove(listener);
     }
 
@@ -24,7 +24,7 @@ class InfoListeners implements Player.InfoListener {
 
     @Override
     public void onNewInfo(String callingMethod, Map<String, String> callingMethodParams) {
-        for (Player.InfoListener listener : listeners) {
+        for (NoPlayer.InfoListener listener : listeners) {
             listener.onNewInfo(callingMethod, callingMethodParams);
         }
     }

--- a/core/src/main/java/com/novoda/noplayer/internal/listeners/PlayerListenersHolder.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/listeners/PlayerListenersHolder.java
@@ -1,8 +1,8 @@
 package com.novoda.noplayer.internal.listeners;
 
 import com.novoda.noplayer.Listeners;
-import com.novoda.noplayer.Player;
-import com.novoda.noplayer.Player.BitrateChangedListener;
+import com.novoda.noplayer.NoPlayer;
+import com.novoda.noplayer.NoPlayer.BitrateChangedListener;
 
 public class PlayerListenersHolder implements Listeners {
 
@@ -30,62 +30,62 @@ public class PlayerListenersHolder implements Listeners {
     }
 
     @Override
-    public void addErrorListener(Player.ErrorListener errorListener) {
+    public void addErrorListener(NoPlayer.ErrorListener errorListener) {
         errorListeners.add(errorListener);
     }
 
     @Override
-    public void removeErrorListener(Player.ErrorListener errorListener) {
+    public void removeErrorListener(NoPlayer.ErrorListener errorListener) {
         errorListeners.remove(errorListener);
     }
 
     @Override
-    public void addPreparedListener(Player.PreparedListener preparedListener) {
+    public void addPreparedListener(NoPlayer.PreparedListener preparedListener) {
         preparedListeners.add(preparedListener);
     }
 
     @Override
-    public void removePreparedListener(Player.PreparedListener preparedListener) {
+    public void removePreparedListener(NoPlayer.PreparedListener preparedListener) {
         preparedListeners.remove(preparedListener);
     }
 
     @Override
-    public void addBufferStateListener(Player.BufferStateListener bufferStateListener) {
+    public void addBufferStateListener(NoPlayer.BufferStateListener bufferStateListener) {
         bufferStateListeners.add(bufferStateListener);
     }
 
     @Override
-    public void removeBufferStateListener(Player.BufferStateListener bufferStateListener) {
+    public void removeBufferStateListener(NoPlayer.BufferStateListener bufferStateListener) {
         bufferStateListeners.remove(bufferStateListener);
     }
 
     @Override
-    public void addCompletionListener(Player.CompletionListener completionListener) {
+    public void addCompletionListener(NoPlayer.CompletionListener completionListener) {
         completionListeners.add(completionListener);
     }
 
     @Override
-    public void removeCompletionListener(Player.CompletionListener completionListener) {
+    public void removeCompletionListener(NoPlayer.CompletionListener completionListener) {
         completionListeners.remove(completionListener);
     }
 
     @Override
-    public void addStateChangedListener(Player.StateChangedListener stateChangedListener) {
+    public void addStateChangedListener(NoPlayer.StateChangedListener stateChangedListener) {
         stateChangedListeners.add(stateChangedListener);
     }
 
     @Override
-    public void removeStateChangedListener(Player.StateChangedListener stateChangedListener) {
+    public void removeStateChangedListener(NoPlayer.StateChangedListener stateChangedListener) {
         stateChangedListeners.remove(stateChangedListener);
     }
 
     @Override
-    public void addInfoListener(Player.InfoListener infoListener) {
+    public void addInfoListener(NoPlayer.InfoListener infoListener) {
         infoListeners.add(infoListener);
     }
 
     @Override
-    public void removeInfoListener(Player.InfoListener infoListener) {
+    public void removeInfoListener(NoPlayer.InfoListener infoListener) {
         infoListeners.remove(infoListener);
     }
 
@@ -100,58 +100,58 @@ public class PlayerListenersHolder implements Listeners {
     }
 
     @Override
-    public void addHeartbeatCallback(Player.HeartbeatCallback heartbeatCallback) {
+    public void addHeartbeatCallback(NoPlayer.HeartbeatCallback heartbeatCallback) {
         heartbeatCallbacks.registerCallback(heartbeatCallback);
     }
 
     @Override
-    public void removeHeartbeatCallback(Player.HeartbeatCallback heartbeatCallback) {
+    public void removeHeartbeatCallback(NoPlayer.HeartbeatCallback heartbeatCallback) {
         heartbeatCallbacks.unregisterCallback(heartbeatCallback);
     }
 
     @Override
-    public void addVideoSizeChangedListener(Player.VideoSizeChangedListener videoSizeChangedListener) {
+    public void addVideoSizeChangedListener(NoPlayer.VideoSizeChangedListener videoSizeChangedListener) {
         videoSizeChangedListeners.add(videoSizeChangedListener);
     }
 
     @Override
-    public void removeVideoSizeChangedListener(Player.VideoSizeChangedListener videoSizeChangedListener) {
+    public void removeVideoSizeChangedListener(NoPlayer.VideoSizeChangedListener videoSizeChangedListener) {
         videoSizeChangedListeners.remove(videoSizeChangedListener);
     }
 
-    public Player.ErrorListener getErrorListeners() {
+    public NoPlayer.ErrorListener getErrorListeners() {
         return errorListeners;
     }
 
-    public Player.PreparedListener getPreparedListeners() {
+    public NoPlayer.PreparedListener getPreparedListeners() {
         return preparedListeners;
     }
 
-    public Player.BufferStateListener getBufferStateListeners() {
+    public NoPlayer.BufferStateListener getBufferStateListeners() {
         return bufferStateListeners;
     }
 
-    public Player.CompletionListener getCompletionListeners() {
+    public NoPlayer.CompletionListener getCompletionListeners() {
         return completionListeners;
     }
 
-    public Player.StateChangedListener getStateChangedListeners() {
+    public NoPlayer.StateChangedListener getStateChangedListeners() {
         return stateChangedListeners;
     }
 
-    public Player.InfoListener getInfoListeners() {
+    public NoPlayer.InfoListener getInfoListeners() {
         return infoListeners;
     }
 
-    public Player.HeartbeatCallback getHeartbeatCallbacks() {
+    public NoPlayer.HeartbeatCallback getHeartbeatCallbacks() {
         return heartbeatCallbacks;
     }
 
-    public Player.VideoSizeChangedListener getVideoSizeChangedListeners() {
+    public NoPlayer.VideoSizeChangedListener getVideoSizeChangedListeners() {
         return videoSizeChangedListeners;
     }
 
-    public Player.BitrateChangedListener getBitrateChangedListeners() {
+    public NoPlayer.BitrateChangedListener getBitrateChangedListeners() {
         return bitrateChangedListeners;
     }
 

--- a/core/src/main/java/com/novoda/noplayer/internal/listeners/PreparedListeners.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/listeners/PreparedListeners.java
@@ -1,22 +1,22 @@
 package com.novoda.noplayer.internal.listeners;
 
-import com.novoda.noplayer.Player;
+import com.novoda.noplayer.NoPlayer;
 import com.novoda.noplayer.PlayerState;
 
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 
-class PreparedListeners implements Player.PreparedListener {
+class PreparedListeners implements NoPlayer.PreparedListener {
 
-    private final Set<Player.PreparedListener> listeners = new CopyOnWriteArraySet<>();
+    private final Set<NoPlayer.PreparedListener> listeners = new CopyOnWriteArraySet<>();
 
     private boolean hasPrepared = false;
 
-    void add(Player.PreparedListener listener) {
+    void add(NoPlayer.PreparedListener listener) {
         listeners.add(listener);
     }
 
-    void remove(Player.PreparedListener listener) {
+    void remove(NoPlayer.PreparedListener listener) {
         listeners.remove(listener);
     }
 
@@ -28,7 +28,7 @@ class PreparedListeners implements Player.PreparedListener {
     public void onPrepared(PlayerState playerState) {
         if (hasNotPreviouslyPrepared()) {
             hasPrepared = true;
-            for (Player.PreparedListener listener : listeners) {
+            for (NoPlayer.PreparedListener listener : listeners) {
                 listener.onPrepared(playerState);
             }
         }

--- a/core/src/main/java/com/novoda/noplayer/internal/listeners/StateChangedListeners.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/listeners/StateChangedListeners.java
@@ -1,12 +1,12 @@
 package com.novoda.noplayer.internal.listeners;
 
-import com.novoda.noplayer.Player;
+import com.novoda.noplayer.NoPlayer;
 import com.novoda.utils.NoPlayerLog;
 
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 
-class StateChangedListeners implements Player.StateChangedListener {
+class StateChangedListeners implements NoPlayer.StateChangedListener {
 
     private enum State {
         PLAYING,
@@ -16,13 +16,13 @@ class StateChangedListeners implements Player.StateChangedListener {
 
     private State currentState;
 
-    private final Set<Player.StateChangedListener> listeners = new CopyOnWriteArraySet<>();
+    private final Set<NoPlayer.StateChangedListener> listeners = new CopyOnWriteArraySet<>();
 
-    void add(Player.StateChangedListener listener) {
+    void add(NoPlayer.StateChangedListener listener) {
         listeners.add(listener);
     }
 
-    void remove(Player.StateChangedListener listener) {
+    void remove(NoPlayer.StateChangedListener listener) {
         listeners.remove(listener);
     }
 
@@ -37,7 +37,7 @@ class StateChangedListeners implements Player.StateChangedListener {
             return;
         }
 
-        for (Player.StateChangedListener listener : listeners) {
+        for (NoPlayer.StateChangedListener listener : listeners) {
             listener.onVideoPlaying();
         }
 
@@ -51,7 +51,7 @@ class StateChangedListeners implements Player.StateChangedListener {
             return;
         }
 
-        for (Player.StateChangedListener listener : listeners) {
+        for (NoPlayer.StateChangedListener listener : listeners) {
             listener.onVideoPaused();
         }
 
@@ -65,7 +65,7 @@ class StateChangedListeners implements Player.StateChangedListener {
             return;
         }
 
-        for (Player.StateChangedListener listener : listeners) {
+        for (NoPlayer.StateChangedListener listener : listeners) {
             listener.onVideoStopped();
         }
 

--- a/core/src/main/java/com/novoda/noplayer/internal/listeners/VideoSizeChangedListeners.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/listeners/VideoSizeChangedListeners.java
@@ -1,19 +1,19 @@
 package com.novoda.noplayer.internal.listeners;
 
-import com.novoda.noplayer.Player;
+import com.novoda.noplayer.NoPlayer;
 
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 
-class VideoSizeChangedListeners implements Player.VideoSizeChangedListener {
+class VideoSizeChangedListeners implements NoPlayer.VideoSizeChangedListener {
 
-    private final Set<Player.VideoSizeChangedListener> listeners = new CopyOnWriteArraySet<>();
+    private final Set<NoPlayer.VideoSizeChangedListener> listeners = new CopyOnWriteArraySet<>();
 
-    void add(Player.VideoSizeChangedListener listener) {
+    void add(NoPlayer.VideoSizeChangedListener listener) {
         listeners.add(listener);
     }
 
-    void remove(Player.VideoSizeChangedListener listener) {
+    void remove(NoPlayer.VideoSizeChangedListener listener) {
         listeners.remove(listener);
     }
 
@@ -23,7 +23,7 @@ class VideoSizeChangedListeners implements Player.VideoSizeChangedListener {
 
     @Override
     public void onVideoSizeChanged(int width, int height, int unappliedRotationDegrees, float pixelWidthHeightRatio) {
-        for (Player.VideoSizeChangedListener listener : listeners) {
+        for (NoPlayer.VideoSizeChangedListener listener : listeners) {
             listener.onVideoSizeChanged(width, height, unappliedRotationDegrees, pixelWidthHeightRatio);
         }
     }

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImpl.java
@@ -8,7 +8,7 @@ import android.view.View;
 
 import com.novoda.noplayer.ContentType;
 import com.novoda.noplayer.Listeners;
-import com.novoda.noplayer.Player;
+import com.novoda.noplayer.NoPlayer;
 import com.novoda.noplayer.PlayerInformation;
 import com.novoda.noplayer.PlayerState;
 import com.novoda.noplayer.PlayerView;
@@ -27,7 +27,7 @@ import com.novoda.noplayer.model.VideoPosition;
 import java.util.ArrayList;
 import java.util.List;
 
-class AndroidMediaPlayerImpl implements Player {
+class AndroidMediaPlayerImpl implements NoPlayer {
 
     private static final VideoPosition NO_SEEK_TO_POSITION = VideoPosition.INVALID;
     private static final int INITIAL_PLAY_SEEK_DELAY_IN_MILLIS = 500;

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/BuggyVideoDriverPreventer.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/BuggyVideoDriverPreventer.java
@@ -2,7 +2,7 @@ package com.novoda.noplayer.internal.mediaplayer;
 
 import android.view.View;
 
-import com.novoda.noplayer.Player;
+import com.novoda.noplayer.NoPlayer;
 
 /**
  * The intent for this component is to workaround a buggy video driver affecting AwesomePlayer on Nexus 5.
@@ -21,7 +21,7 @@ class BuggyVideoDriverPreventer {
         this.mediaPlayerTypeReader = mediaPlayerTypeReader;
     }
 
-    void preventVideoDriverBug(Player player, View containerView) {
+    void preventVideoDriverBug(NoPlayer player, View containerView) {
         if (videoDriverCanBeBuggy()) {
             attemptToCorrectMediaPlayerStatus(player, containerView);
         }
@@ -31,7 +31,7 @@ class BuggyVideoDriverPreventer {
         return mediaPlayerTypeReader.getPlayerType() == AndroidMediaPlayerType.AWESOME;
     }
 
-    private void attemptToCorrectMediaPlayerStatus(Player player, View containerView) {
+    private void attemptToCorrectMediaPlayerStatus(NoPlayer player, View containerView) {
         preventerListener = new OnPotentialBuggyDriverLayoutListener(player);
         containerView.addOnLayoutChangeListener(preventerListener);
     }

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/CheckBufferHeartbeatCallback.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/CheckBufferHeartbeatCallback.java
@@ -1,9 +1,9 @@
 package com.novoda.noplayer.internal.mediaplayer;
 
-import com.novoda.noplayer.Player;
+import com.novoda.noplayer.NoPlayer;
 import com.novoda.noplayer.model.VideoPosition;
 
-public class CheckBufferHeartbeatCallback implements Player.HeartbeatCallback {
+public class CheckBufferHeartbeatCallback implements NoPlayer.HeartbeatCallback {
 
     private static final int FORCED_BUFFERING_BEATS_THRESHOLD = 4;
 
@@ -16,7 +16,7 @@ public class CheckBufferHeartbeatCallback implements Player.HeartbeatCallback {
     }
 
     @Override
-    public void onBeat(Player player) {
+    public void onBeat(NoPlayer player) {
         if (mediaPlayerIsUnavailable(player)) {
             stopBuffering();
             return;
@@ -47,7 +47,7 @@ public class CheckBufferHeartbeatCallback implements Player.HeartbeatCallback {
         bufferListener.onBufferStart();
     }
 
-    private boolean mediaPlayerIsUnavailable(Player player) {
+    private boolean mediaPlayerIsUnavailable(NoPlayer player) {
         try {
             return !player.isPlaying();
         } catch (IllegalStateException e) {

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/ErrorFactory.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/ErrorFactory.java
@@ -2,8 +2,8 @@ package com.novoda.noplayer.internal.mediaplayer;
 
 import android.media.MediaPlayer;
 
+import com.novoda.noplayer.NoPlayer;
 import com.novoda.noplayer.NoPlayerError;
-import com.novoda.noplayer.Player;
 import com.novoda.noplayer.PlayerErrorType;
 
 import static com.novoda.noplayer.internal.mediaplayer.ErrorFormatter.formatMessage;
@@ -14,7 +14,7 @@ public final class ErrorFactory {
         // no instances
     }
 
-    public static Player.PlayerError createErrorFrom(int type, int extra) {
+    public static NoPlayer.PlayerError createErrorFrom(int type, int extra) {
         switch (type) {
             case MediaPlayer.MEDIA_ERROR_NOT_VALID_FOR_PROGRESSIVE_PLAYBACK:
                 return new NoPlayerError(PlayerErrorType.STREAMED_VIDEO_ERROR, formatMessage(type, extra));

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/NoPlayerMediaPlayerCreator.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/NoPlayerMediaPlayerCreator.java
@@ -4,7 +4,7 @@ import android.content.Context;
 import android.os.Build;
 import android.os.Handler;
 
-import com.novoda.noplayer.Player;
+import com.novoda.noplayer.NoPlayer;
 import com.novoda.noplayer.internal.Heart;
 import com.novoda.noplayer.internal.SystemClock;
 import com.novoda.noplayer.internal.listeners.PlayerListenersHolder;
@@ -24,7 +24,7 @@ public class NoPlayerMediaPlayerCreator {
         this.internalCreator = internalCreator;
     }
 
-    public Player createMediaPlayer(Context context) {
+    public NoPlayer createMediaPlayer(Context context) {
         AndroidMediaPlayerImpl player = internalCreator.create(context);
         player.initialise();
         return player;

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/OnPotentialBuggyDriverLayoutListener.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/OnPotentialBuggyDriverLayoutListener.java
@@ -2,13 +2,13 @@ package com.novoda.noplayer.internal.mediaplayer;
 
 import android.view.View;
 
-import com.novoda.noplayer.Player;
+import com.novoda.noplayer.NoPlayer;
 
 class OnPotentialBuggyDriverLayoutListener implements View.OnLayoutChangeListener {
 
-    private final Player player;
+    private final NoPlayer player;
 
-    OnPotentialBuggyDriverLayoutListener(Player player) {
+    OnPotentialBuggyDriverLayoutListener(NoPlayer player) {
         this.player = player;
     }
 

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/forwarder/BufferHeartbeatListener.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/forwarder/BufferHeartbeatListener.java
@@ -1,13 +1,13 @@
 package com.novoda.noplayer.internal.mediaplayer.forwarder;
 
-import com.novoda.noplayer.Player;
+import com.novoda.noplayer.NoPlayer;
 import com.novoda.noplayer.internal.mediaplayer.CheckBufferHeartbeatCallback;
 
 class BufferHeartbeatListener implements CheckBufferHeartbeatCallback.BufferListener {
 
-    private final Player.BufferStateListener bufferStateListener;
+    private final NoPlayer.BufferStateListener bufferStateListener;
 
-    BufferHeartbeatListener(Player.BufferStateListener bufferStateListener) {
+    BufferHeartbeatListener(NoPlayer.BufferStateListener bufferStateListener) {
         this.bufferStateListener = bufferStateListener;
     }
 

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/forwarder/BufferInfoForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/forwarder/BufferInfoForwarder.java
@@ -1,15 +1,15 @@
 package com.novoda.noplayer.internal.mediaplayer.forwarder;
 
-import com.novoda.noplayer.Player;
+import com.novoda.noplayer.NoPlayer;
 import com.novoda.noplayer.internal.mediaplayer.CheckBufferHeartbeatCallback;
 
 import java.util.HashMap;
 
 class BufferInfoForwarder implements CheckBufferHeartbeatCallback.BufferListener {
 
-    private final Player.InfoListener infoListener;
+    private final NoPlayer.InfoListener infoListener;
 
-    BufferInfoForwarder(Player.InfoListener infoListener) {
+    BufferInfoForwarder(NoPlayer.InfoListener infoListener) {
         this.infoListener = infoListener;
     }
 

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/forwarder/BufferOnPreparedListener.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/forwarder/BufferOnPreparedListener.java
@@ -2,13 +2,13 @@ package com.novoda.noplayer.internal.mediaplayer.forwarder;
 
 import android.media.MediaPlayer;
 
-import com.novoda.noplayer.Player;
+import com.novoda.noplayer.NoPlayer;
 
 class BufferOnPreparedListener implements MediaPlayer.OnPreparedListener {
 
-    private final Player.BufferStateListener bufferStateListener;
+    private final NoPlayer.BufferStateListener bufferStateListener;
 
-    BufferOnPreparedListener(Player.BufferStateListener bufferStateListener) {
+    BufferOnPreparedListener(NoPlayer.BufferStateListener bufferStateListener) {
         this.bufferStateListener = bufferStateListener;
     }
 

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/forwarder/CompletionForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/forwarder/CompletionForwarder.java
@@ -2,13 +2,13 @@ package com.novoda.noplayer.internal.mediaplayer.forwarder;
 
 import android.media.MediaPlayer;
 
-import com.novoda.noplayer.Player;
+import com.novoda.noplayer.NoPlayer;
 
 class CompletionForwarder implements MediaPlayer.OnCompletionListener {
 
-    private final Player.CompletionListener completionListener;
+    private final NoPlayer.CompletionListener completionListener;
 
-    CompletionForwarder(Player.CompletionListener completionListener) {
+    CompletionForwarder(NoPlayer.CompletionListener completionListener) {
         this.completionListener = completionListener;
     }
 

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/forwarder/CompletionInfoForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/forwarder/CompletionInfoForwarder.java
@@ -2,15 +2,15 @@ package com.novoda.noplayer.internal.mediaplayer.forwarder;
 
 import android.media.MediaPlayer;
 
-import com.novoda.noplayer.Player;
+import com.novoda.noplayer.NoPlayer;
 
 import java.util.HashMap;
 
 class CompletionInfoForwarder implements MediaPlayer.OnCompletionListener {
 
-    private final Player.InfoListener infoListener;
+    private final NoPlayer.InfoListener infoListener;
 
-    CompletionInfoForwarder(Player.InfoListener infoListener) {
+    CompletionInfoForwarder(NoPlayer.InfoListener infoListener) {
         this.infoListener = infoListener;
     }
 

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/forwarder/CompletionStateChangedForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/forwarder/CompletionStateChangedForwarder.java
@@ -2,13 +2,13 @@ package com.novoda.noplayer.internal.mediaplayer.forwarder;
 
 import android.media.MediaPlayer;
 
-import com.novoda.noplayer.Player;
+import com.novoda.noplayer.NoPlayer;
 
 class CompletionStateChangedForwarder implements MediaPlayer.OnCompletionListener {
 
-    private final Player.StateChangedListener stateChangedListener;
+    private final NoPlayer.StateChangedListener stateChangedListener;
 
-    CompletionStateChangedForwarder(Player.StateChangedListener stateChangedListener) {
+    CompletionStateChangedForwarder(NoPlayer.StateChangedListener stateChangedListener) {
         this.stateChangedListener = stateChangedListener;
     }
 

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/forwarder/ErrorForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/forwarder/ErrorForwarder.java
@@ -2,15 +2,15 @@ package com.novoda.noplayer.internal.mediaplayer.forwarder;
 
 import android.media.MediaPlayer;
 
-import com.novoda.noplayer.Player;
+import com.novoda.noplayer.NoPlayer;
 import com.novoda.noplayer.internal.mediaplayer.ErrorFactory;
 
 class ErrorForwarder implements MediaPlayer.OnErrorListener {
 
-    private final Player.BufferStateListener bufferStateListener;
-    private final Player.ErrorListener errorListener;
+    private final NoPlayer.BufferStateListener bufferStateListener;
+    private final NoPlayer.ErrorListener errorListener;
 
-    ErrorForwarder(Player.BufferStateListener bufferStateListener, Player.ErrorListener errorListener) {
+    ErrorForwarder(NoPlayer.BufferStateListener bufferStateListener, NoPlayer.ErrorListener errorListener) {
         this.bufferStateListener = bufferStateListener;
         this.errorListener = errorListener;
     }
@@ -18,7 +18,7 @@ class ErrorForwarder implements MediaPlayer.OnErrorListener {
     @Override
     public boolean onError(MediaPlayer mp, int what, int extra) {
         bufferStateListener.onBufferCompleted();
-        Player.PlayerError error = ErrorFactory.createErrorFrom(what, extra);
+        NoPlayer.PlayerError error = ErrorFactory.createErrorFrom(what, extra);
         errorListener.onError(error);
         return true;
     }

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/forwarder/ErrorInfoForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/forwarder/ErrorInfoForwarder.java
@@ -2,15 +2,15 @@ package com.novoda.noplayer.internal.mediaplayer.forwarder;
 
 import android.media.MediaPlayer;
 
-import com.novoda.noplayer.Player;
+import com.novoda.noplayer.NoPlayer;
 
 import java.util.HashMap;
 
 class ErrorInfoForwarder implements MediaPlayer.OnErrorListener {
 
-    private final Player.InfoListener infoListener;
+    private final NoPlayer.InfoListener infoListener;
 
-    ErrorInfoForwarder(Player.InfoListener infoListener) {
+    ErrorInfoForwarder(NoPlayer.InfoListener infoListener) {
         this.infoListener = infoListener;
     }
 

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/forwarder/MediaPlayerForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/forwarder/MediaPlayerForwarder.java
@@ -2,7 +2,7 @@ package com.novoda.noplayer.internal.mediaplayer.forwarder;
 
 import android.media.MediaPlayer;
 
-import com.novoda.noplayer.Player;
+import com.novoda.noplayer.NoPlayer;
 import com.novoda.noplayer.PlayerState;
 import com.novoda.noplayer.internal.mediaplayer.CheckBufferHeartbeatCallback;
 
@@ -22,26 +22,26 @@ public class MediaPlayerForwarder {
         videoSizeChangedListener = new VideoSizeChangedListener();
     }
 
-    public void bind(Player.PreparedListener preparedListener, PlayerState playerState) {
+    public void bind(NoPlayer.PreparedListener preparedListener, PlayerState playerState) {
         this.preparedListener.add(new OnPreparedForwarder(preparedListener, playerState));
     }
 
-    public void bind(Player.BufferStateListener bufferStateListener, Player.ErrorListener errorListener) {
+    public void bind(NoPlayer.BufferStateListener bufferStateListener, NoPlayer.ErrorListener errorListener) {
         preparedListener.add(new BufferOnPreparedListener(bufferStateListener));
         heartBeatListener.add(new BufferHeartbeatListener(bufferStateListener));
         this.errorListener.add(new ErrorForwarder(bufferStateListener, errorListener));
     }
 
-    public void bind(Player.CompletionListener completionListener, Player.StateChangedListener stateChangedListener) {
+    public void bind(NoPlayer.CompletionListener completionListener, NoPlayer.StateChangedListener stateChangedListener) {
         this.completionListener.add(new CompletionForwarder(completionListener));
         this.completionListener.add(new CompletionStateChangedForwarder(stateChangedListener));
     }
 
-    public void bind(Player.VideoSizeChangedListener videoSizeChangedListener) {
+    public void bind(NoPlayer.VideoSizeChangedListener videoSizeChangedListener) {
         this.videoSizeChangedListener.add(new VideoSizeChangedForwarder(videoSizeChangedListener));
     }
 
-    public void bind(Player.InfoListener infoListener) {
+    public void bind(NoPlayer.InfoListener infoListener) {
         preparedListener.add(new OnPreparedInfoForwarder(infoListener));
         heartBeatListener.add(new BufferInfoForwarder(infoListener));
         completionListener.add(new CompletionInfoForwarder(infoListener));

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/forwarder/OnPreparedForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/forwarder/OnPreparedForwarder.java
@@ -2,15 +2,15 @@ package com.novoda.noplayer.internal.mediaplayer.forwarder;
 
 import android.media.MediaPlayer;
 
-import com.novoda.noplayer.Player;
+import com.novoda.noplayer.NoPlayer;
 import com.novoda.noplayer.PlayerState;
 
 class OnPreparedForwarder implements MediaPlayer.OnPreparedListener {
 
-    private final Player.PreparedListener preparedListener;
+    private final NoPlayer.PreparedListener preparedListener;
     private final PlayerState playerState;
 
-    OnPreparedForwarder(Player.PreparedListener preparedListener, PlayerState playerState) {
+    OnPreparedForwarder(NoPlayer.PreparedListener preparedListener, PlayerState playerState) {
         this.preparedListener = preparedListener;
         this.playerState = playerState;
     }

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/forwarder/OnPreparedInfoForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/forwarder/OnPreparedInfoForwarder.java
@@ -2,15 +2,15 @@ package com.novoda.noplayer.internal.mediaplayer.forwarder;
 
 import android.media.MediaPlayer;
 
-import com.novoda.noplayer.Player;
+import com.novoda.noplayer.NoPlayer;
 
 import java.util.HashMap;
 
 class OnPreparedInfoForwarder implements MediaPlayer.OnPreparedListener {
 
-    private final Player.InfoListener infoListener;
+    private final NoPlayer.InfoListener infoListener;
 
-    OnPreparedInfoForwarder(Player.InfoListener infoListener) {
+    OnPreparedInfoForwarder(NoPlayer.InfoListener infoListener) {
         this.infoListener = infoListener;
     }
 

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/forwarder/VideoSizeChangedForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/forwarder/VideoSizeChangedForwarder.java
@@ -2,17 +2,17 @@ package com.novoda.noplayer.internal.mediaplayer.forwarder;
 
 import android.media.MediaPlayer;
 
-import com.novoda.noplayer.Player;
+import com.novoda.noplayer.NoPlayer;
 import com.novoda.utils.NoPlayerLog;
 
 class VideoSizeChangedForwarder implements MediaPlayer.OnVideoSizeChangedListener {
 
-    private final Player.VideoSizeChangedListener videoSizeChangedListener;
+    private final NoPlayer.VideoSizeChangedListener videoSizeChangedListener;
 
     private int previousWidth;
     private int previousHeight;
 
-    VideoSizeChangedForwarder(Player.VideoSizeChangedListener videoSizeChangedListener) {
+    VideoSizeChangedForwarder(NoPlayer.VideoSizeChangedListener videoSizeChangedListener) {
         this.videoSizeChangedListener = videoSizeChangedListener;
     }
 

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/forwarder/VideoSizeChangedInfoForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/forwarder/VideoSizeChangedInfoForwarder.java
@@ -2,15 +2,15 @@ package com.novoda.noplayer.internal.mediaplayer.forwarder;
 
 import android.media.MediaPlayer;
 
-import com.novoda.noplayer.Player;
+import com.novoda.noplayer.NoPlayer;
 
 import java.util.HashMap;
 
 class VideoSizeChangedInfoForwarder implements MediaPlayer.OnVideoSizeChangedListener {
 
-    private final Player.InfoListener infoListener;
+    private final NoPlayer.InfoListener infoListener;
 
-    VideoSizeChangedInfoForwarder(Player.InfoListener infoListener) {
+    VideoSizeChangedInfoForwarder(NoPlayer.InfoListener infoListener) {
         this.infoListener = infoListener;
     }
 

--- a/core/src/main/java/com/novoda/noplayer/model/LoadTimeout.java
+++ b/core/src/main/java/com/novoda/noplayer/model/LoadTimeout.java
@@ -3,7 +3,7 @@ package com.novoda.noplayer.model;
 import android.os.Handler;
 
 import com.novoda.noplayer.internal.Clock;
-import com.novoda.noplayer.Player;
+import com.novoda.noplayer.NoPlayer;
 
 public class LoadTimeout {
 
@@ -14,14 +14,14 @@ public class LoadTimeout {
 
     private long startTime;
     private long endTime;
-    private Player.LoadTimeoutCallback loadTimeoutCallback;
+    private NoPlayer.LoadTimeoutCallback loadTimeoutCallback;
 
     public LoadTimeout(Clock clock, Handler handler) {
         this.clock = clock;
         this.handler = handler;
     }
 
-    public void start(Timeout timeout, Player.LoadTimeoutCallback loadTimeoutCallback) {
+    public void start(Timeout timeout, NoPlayer.LoadTimeoutCallback loadTimeoutCallback) {
         cancel();
         this.loadTimeoutCallback = loadTimeoutCallback;
         startTime = clock.getCurrentTime();
@@ -43,7 +43,7 @@ public class LoadTimeout {
 
     public void cancel() {
         startTime = 0;
-        loadTimeoutCallback = Player.LoadTimeoutCallback.NULL_IMPL;
+        loadTimeoutCallback = NoPlayer.LoadTimeoutCallback.NULL_IMPL;
         handler.removeCallbacks(loadTimeoutCheck);
     }
 

--- a/core/src/test/java/com/novoda/noplayer/LoadTimeoutTest.java
+++ b/core/src/test/java/com/novoda/noplayer/LoadTimeoutTest.java
@@ -39,7 +39,7 @@ public class LoadTimeoutTest {
     Handler handler;
 
     @Mock
-    Player.LoadTimeoutCallback loadTimeoutCallback;
+    NoPlayer.LoadTimeoutCallback loadTimeoutCallback;
 
     private LoadTimeout loadTimeout;
 

--- a/core/src/test/java/com/novoda/noplayer/NoPlayerCreatorTest.java
+++ b/core/src/test/java/com/novoda/noplayer/NoPlayerCreatorTest.java
@@ -37,8 +37,8 @@ public class NoPlayerCreatorTest {
         static final boolean USE_SECURE_CODEC = false;
         static final StreamingModularDrm STREAMING_MODULAR_DRM = mock(StreamingModularDrm.class);
         static final DownloadedModularDrm DOWNLOADED_MODULAR_DRM = mock(DownloadedModularDrm.class);
-        static final Player EXO_PLAYER = mock(Player.class);
-        static final Player MEDIA_PLAYER = mock(Player.class);
+        static final NoPlayer EXO_PLAYER = mock(NoPlayer.class);
+        static final NoPlayer MEDIA_PLAYER = mock(NoPlayer.class);
 
         @Rule
         public MockitoRule mockitoRule = MockitoJUnit.rule();
@@ -77,28 +77,28 @@ public class NoPlayerCreatorTest {
 
         @Test
         public void whenCreatingPlayerWithDrmTypeNone_thenReturnsMediaPlayer() {
-            Player player = noPlayerCreator.create(DrmType.NONE, DrmHandler.NO_DRM, USE_SECURE_CODEC);
+            NoPlayer player = noPlayerCreator.create(DrmType.NONE, DrmHandler.NO_DRM, USE_SECURE_CODEC);
 
             assertThat(player).isEqualTo(MEDIA_PLAYER);
         }
 
         @Test
         public void whenCreatingPlayerWithDrmTypeWidevineClassic_thenReturnsMediaPlayer() {
-            Player player = noPlayerCreator.create(DrmType.WIDEVINE_CLASSIC, DrmHandler.NO_DRM, USE_SECURE_CODEC);
+            NoPlayer player = noPlayerCreator.create(DrmType.WIDEVINE_CLASSIC, DrmHandler.NO_DRM, USE_SECURE_CODEC);
 
             assertThat(player).isEqualTo(MEDIA_PLAYER);
         }
 
         @Test
         public void whenCreatingPlayerWithDrmTypeWidevineModularStream_thenReturnsExoPlayer() {
-            Player player = noPlayerCreator.create(DrmType.WIDEVINE_MODULAR_STREAM, STREAMING_MODULAR_DRM, USE_SECURE_CODEC);
+            NoPlayer player = noPlayerCreator.create(DrmType.WIDEVINE_MODULAR_STREAM, STREAMING_MODULAR_DRM, USE_SECURE_CODEC);
 
             assertThat(player).isEqualTo(EXO_PLAYER);
         }
 
         @Test
         public void whenCreatingPlayerWithDrmTypeWidevineModularDownload_thenReturnsExoPlayer() {
-            Player player = noPlayerCreator.create(DrmType.WIDEVINE_MODULAR_DOWNLOAD, DOWNLOADED_MODULAR_DRM, USE_SECURE_CODEC);
+            NoPlayer player = noPlayerCreator.create(DrmType.WIDEVINE_MODULAR_DOWNLOAD, DOWNLOADED_MODULAR_DRM, USE_SECURE_CODEC);
 
             assertThat(player).isEqualTo(EXO_PLAYER);
         }
@@ -113,28 +113,28 @@ public class NoPlayerCreatorTest {
 
         @Test
         public void whenCreatingPlayerWithDrmTypeNone_thenReturnsExoPlayer() {
-            Player player = noPlayerCreator.create(DrmType.NONE, DrmHandler.NO_DRM, USE_SECURE_CODEC);
+            NoPlayer player = noPlayerCreator.create(DrmType.NONE, DrmHandler.NO_DRM, USE_SECURE_CODEC);
 
             assertThat(player).isEqualTo(EXO_PLAYER);
         }
 
         @Test
         public void whenCreatingPlayerWithDrmTypeWidevineClassic_thenReturnsMediaPlayer() {
-            Player player = noPlayerCreator.create(DrmType.WIDEVINE_CLASSIC, DrmHandler.NO_DRM, USE_SECURE_CODEC);
+            NoPlayer player = noPlayerCreator.create(DrmType.WIDEVINE_CLASSIC, DrmHandler.NO_DRM, USE_SECURE_CODEC);
 
             assertThat(player).isEqualTo(MEDIA_PLAYER);
         }
 
         @Test
         public void whenCreatingPlayerWithDrmTypeWidevineModularStream_thenReturnsExoPlayer() {
-            Player player = noPlayerCreator.create(DrmType.WIDEVINE_MODULAR_STREAM, STREAMING_MODULAR_DRM, USE_SECURE_CODEC);
+            NoPlayer player = noPlayerCreator.create(DrmType.WIDEVINE_MODULAR_STREAM, STREAMING_MODULAR_DRM, USE_SECURE_CODEC);
 
             assertThat(player).isEqualTo(EXO_PLAYER);
         }
 
         @Test
         public void whenCreatingPlayerWithDrmTypeWidevineModularDownload_thenReturnsExoPlayer() {
-            Player player = noPlayerCreator.create(DrmType.WIDEVINE_MODULAR_DOWNLOAD, DOWNLOADED_MODULAR_DRM, USE_SECURE_CODEC);
+            NoPlayer player = noPlayerCreator.create(DrmType.WIDEVINE_MODULAR_DOWNLOAD, DOWNLOADED_MODULAR_DRM, USE_SECURE_CODEC);
 
             assertThat(player).isEqualTo(EXO_PLAYER);
         }

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImplTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImplTest.java
@@ -8,8 +8,8 @@ import com.google.android.exoplayer2.ExoPlayerLibraryInfo;
 import com.google.android.exoplayer2.mediacodec.MediaCodecSelector;
 import com.google.android.exoplayer2.text.Cue;
 import com.novoda.noplayer.ContentType;
-import com.novoda.noplayer.Player;
-import com.novoda.noplayer.Player.StateChangedListener;
+import com.novoda.noplayer.NoPlayer;
+import com.novoda.noplayer.NoPlayer.StateChangedListener;
 import com.novoda.noplayer.PlayerInformation;
 import com.novoda.noplayer.PlayerType;
 import com.novoda.noplayer.PlayerView;
@@ -67,7 +67,7 @@ public class ExoPlayerTwoImplTest {
 
     private static final ContentType ANY_CONTENT_TYPE = ContentType.DASH;
     private static final Timeout ANY_TIMEOUT = Timeout.fromSeconds(TEN_SECONDS);
-    private static final Player.LoadTimeoutCallback ANY_LOAD_TIMEOUT_CALLBACK = new Player.LoadTimeoutCallback() {
+    private static final NoPlayer.LoadTimeoutCallback ANY_LOAD_TIMEOUT_CALLBACK = new NoPlayer.LoadTimeoutCallback() {
         @Override
         public void onLoadTimeout() {
 
@@ -105,10 +105,10 @@ public class ExoPlayerTwoImplTest {
         public void givenPlayerIsInitialised_whenVideoIsPrepared_thenCancelsTimeout() {
             player.initialise();
 
-            ArgumentCaptor<Player.PreparedListener> argumentCaptor = ArgumentCaptor.forClass(Player.PreparedListener.class);
+            ArgumentCaptor<NoPlayer.PreparedListener> argumentCaptor = ArgumentCaptor.forClass(NoPlayer.PreparedListener.class);
 
             verify(listenersHolder).addPreparedListener(argumentCaptor.capture());
-            Player.PreparedListener preparedListener = argumentCaptor.getValue();
+            NoPlayer.PreparedListener preparedListener = argumentCaptor.getValue();
             preparedListener.onPrepared(player);
 
             verify(loadTimeout).cancel();
@@ -118,11 +118,11 @@ public class ExoPlayerTwoImplTest {
         public void givenPlayerIsInitialised_whenVideoHasError_thenPlayerResourcesAreReleased_andNotListeners() {
             player.initialise();
 
-            ArgumentCaptor<Player.ErrorListener> argumentCaptor = ArgumentCaptor.forClass(Player.ErrorListener.class);
+            ArgumentCaptor<NoPlayer.ErrorListener> argumentCaptor = ArgumentCaptor.forClass(NoPlayer.ErrorListener.class);
 
             verify(listenersHolder).addErrorListener(argumentCaptor.capture());
-            Player.ErrorListener errorListener = argumentCaptor.getValue();
-            errorListener.onError(mock(Player.PlayerError.class));
+            NoPlayer.ErrorListener errorListener = argumentCaptor.getValue();
+            errorListener.onError(mock(NoPlayer.PlayerError.class));
 
             verify(listenersHolder).resetPreparedState();
             verify(loadTimeout).cancel();
@@ -137,10 +137,10 @@ public class ExoPlayerTwoImplTest {
             player.initialise();
             player.attach(playerView);
 
-            ArgumentCaptor<Player.VideoSizeChangedListener> argumentCaptor = ArgumentCaptor.forClass(Player.VideoSizeChangedListener.class);
+            ArgumentCaptor<NoPlayer.VideoSizeChangedListener> argumentCaptor = ArgumentCaptor.forClass(NoPlayer.VideoSizeChangedListener.class);
             verify(listenersHolder, times(2)).addVideoSizeChangedListener(argumentCaptor.capture());
 
-            Player.VideoSizeChangedListener videoSizeChangedListener = argumentCaptor.getAllValues().get(INDEX_INTERNAL_VIDEO_SIZE_CHANGED_LISTENER);
+            NoPlayer.VideoSizeChangedListener videoSizeChangedListener = argumentCaptor.getAllValues().get(INDEX_INTERNAL_VIDEO_SIZE_CHANGED_LISTENER);
             videoSizeChangedListener.onVideoSizeChanged(WIDTH, HEIGHT, ANY_ROTATION_DEGREES, ANY_PIXEL_WIDTH_HEIGHT);
 
             int actualWidth = player.getVideoWidth();
@@ -156,9 +156,9 @@ public class ExoPlayerTwoImplTest {
 
             player.attach(playerView);
 
-            ArgumentCaptor<Player.VideoSizeChangedListener> argumentCaptor = ArgumentCaptor.forClass(Player.VideoSizeChangedListener.class);
+            ArgumentCaptor<NoPlayer.VideoSizeChangedListener> argumentCaptor = ArgumentCaptor.forClass(NoPlayer.VideoSizeChangedListener.class);
             verify(listenersHolder, times(2)).addVideoSizeChangedListener(argumentCaptor.capture());
-            Player.VideoSizeChangedListener videoSizeChangedListener = argumentCaptor.getAllValues().get(1);
+            NoPlayer.VideoSizeChangedListener videoSizeChangedListener = argumentCaptor.getAllValues().get(1);
             assertThat(videoSizeChangedListener).isSameAs(playerView.getVideoSizeChangedListener());
         }
 
@@ -573,23 +573,23 @@ public class ExoPlayerTwoImplTest {
         @Mock
         StateChangedListener stateChangeListener;
         @Mock
-        Player.VideoSizeChangedListener videoSizeChangedListener;
+        NoPlayer.VideoSizeChangedListener videoSizeChangedListener;
         @Mock
         PlayerListenersHolder listenersHolder;
         @Mock
-        Player.ErrorListener errorListener;
+        NoPlayer.ErrorListener errorListener;
         @Mock
-        Player.PreparedListener preparedListener;
+        NoPlayer.PreparedListener preparedListener;
         @Mock
-        Player.BufferStateListener bufferStateListener;
+        NoPlayer.BufferStateListener bufferStateListener;
         @Mock
-        Player.CompletionListener completionListener;
+        NoPlayer.CompletionListener completionListener;
         @Mock
-        Player.StateChangedListener stateChangedListener;
+        NoPlayer.StateChangedListener stateChangedListener;
         @Mock
-        Player.InfoListener infoListener;
+        NoPlayer.InfoListener infoListener;
         @Mock
-        Player.BitrateChangedListener bitrateChangedListener;
+        NoPlayer.BitrateChangedListener bitrateChangedListener;
         @Mock
         ExoPlayerFacade exoPlayerFacade;
         @Mock

--- a/core/src/test/java/com/novoda/noplayer/internal/listeners/BufferStateListenersTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/listeners/BufferStateListenersTest.java
@@ -1,6 +1,6 @@
 package com.novoda.noplayer.internal.listeners;
 
-import com.novoda.noplayer.Player;
+import com.novoda.noplayer.NoPlayer;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -17,10 +17,10 @@ public class BufferStateListenersTest {
     public MockitoRule mockitoRule = MockitoJUnit.rule();
 
     @Mock
-    private Player.BufferStateListener aBufferStateListener;
+    private NoPlayer.BufferStateListener aBufferStateListener;
 
     @Mock
-    private Player.BufferStateListener anotherBufferStateListener;
+    private NoPlayer.BufferStateListener anotherBufferStateListener;
 
     private BufferStateListeners bufferStateListeners;
 

--- a/core/src/test/java/com/novoda/noplayer/internal/listeners/StateChangedListenersTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/listeners/StateChangedListenersTest.java
@@ -1,6 +1,6 @@
 package com.novoda.noplayer.internal.listeners;
 
-import com.novoda.noplayer.Player;
+import com.novoda.noplayer.NoPlayer;
 import com.novoda.utils.NoPlayerLog;
 
 import org.junit.Before;
@@ -18,7 +18,7 @@ public class StateChangedListenersTest {
     public MockitoRule mockitoRule = MockitoJUnit.rule();
 
     @Mock
-    private Player.StateChangedListener stateChangedListener;
+    private NoPlayer.StateChangedListener stateChangedListener;
 
     private StateChangedListeners stateChangedListeners;
 

--- a/core/src/test/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImplTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImplTest.java
@@ -7,7 +7,7 @@ import android.view.SurfaceHolder;
 import android.view.View;
 
 import com.novoda.noplayer.ContentType;
-import com.novoda.noplayer.Player;
+import com.novoda.noplayer.NoPlayer;
 import com.novoda.noplayer.PlayerInformation;
 import com.novoda.noplayer.PlayerView;
 import com.novoda.noplayer.SurfaceHolderRequester;
@@ -95,10 +95,10 @@ public class AndroidMediaPlayerImplTest {
         public void givenInitialised_whenCallingOnPrepared_thenCancelsTimeout() {
             player.initialise();
 
-            ArgumentCaptor<Player.PreparedListener> preparedListenerCaptor = ArgumentCaptor.forClass(Player.PreparedListener.class);
+            ArgumentCaptor<NoPlayer.PreparedListener> preparedListenerCaptor = ArgumentCaptor.forClass(NoPlayer.PreparedListener.class);
             verify(listenersHolder).addPreparedListener(preparedListenerCaptor.capture());
 
-            Player.PreparedListener preparedListener = preparedListenerCaptor.getValue();
+            NoPlayer.PreparedListener preparedListener = preparedListenerCaptor.getValue();
             preparedListener.onPrepared(player);
 
             verify(loadTimeout).cancel();
@@ -114,10 +114,10 @@ public class AndroidMediaPlayerImplTest {
         @Test
         public void givenInitialised_whenCallingOnPrepared_thenSetsOnSeekCompleteListener() {
             player.initialise();
-            ArgumentCaptor<Player.PreparedListener> preparedListenerCaptor = ArgumentCaptor.forClass(Player.PreparedListener.class);
+            ArgumentCaptor<NoPlayer.PreparedListener> preparedListenerCaptor = ArgumentCaptor.forClass(NoPlayer.PreparedListener.class);
             verify(listenersHolder).addPreparedListener(preparedListenerCaptor.capture());
 
-            Player.PreparedListener preparedListener = preparedListenerCaptor.getValue();
+            NoPlayer.PreparedListener preparedListener = preparedListenerCaptor.getValue();
             preparedListener.onPrepared(player);
 
             verify(mediaPlayer).setOnSeekCompleteListener(any(MediaPlayer.OnSeekCompleteListener.class));
@@ -126,11 +126,11 @@ public class AndroidMediaPlayerImplTest {
         @Test
         public void givenInitialised_whenCallingOnError_thenCancelsTimeout() {
             player.initialise();
-            ArgumentCaptor<Player.ErrorListener> errorListenerCaptor = ArgumentCaptor.forClass(Player.ErrorListener.class);
+            ArgumentCaptor<NoPlayer.ErrorListener> errorListenerCaptor = ArgumentCaptor.forClass(NoPlayer.ErrorListener.class);
             verify(listenersHolder).addErrorListener(errorListenerCaptor.capture());
 
-            Player.ErrorListener errorListener = errorListenerCaptor.getValue();
-            errorListener.onError(mock(Player.PlayerError.class));
+            NoPlayer.ErrorListener errorListener = errorListenerCaptor.getValue();
+            errorListener.onError(mock(NoPlayer.PlayerError.class));
 
             verify(loadTimeout).cancel();
         }
@@ -138,11 +138,11 @@ public class AndroidMediaPlayerImplTest {
         @Test
         public void givenInitialised_whenCallingOnError_thenPlayerResourcesAreReleased_andNotListeners() {
             player.initialise();
-            ArgumentCaptor<Player.ErrorListener> errorListenerCaptor = ArgumentCaptor.forClass(Player.ErrorListener.class);
+            ArgumentCaptor<NoPlayer.ErrorListener> errorListenerCaptor = ArgumentCaptor.forClass(NoPlayer.ErrorListener.class);
             verify(listenersHolder).addErrorListener(errorListenerCaptor.capture());
 
-            Player.ErrorListener errorListener = errorListenerCaptor.getValue();
-            errorListener.onError(mock(Player.PlayerError.class));
+            NoPlayer.ErrorListener errorListener = errorListenerCaptor.getValue();
+            errorListener.onError(mock(NoPlayer.PlayerError.class));
 
             verify(listenersHolder).resetPreparedState();
             verify(loadTimeout).cancel();
@@ -155,10 +155,10 @@ public class AndroidMediaPlayerImplTest {
         @Test
         public void givenInitialised_whenCallingOnVideoSizeChanged_thenVideoWidthAndHeightMatches() {
             player.initialise();
-            ArgumentCaptor<Player.VideoSizeChangedListener> videoSizeChangedListenerCaptor = ArgumentCaptor.forClass(Player.VideoSizeChangedListener.class);
+            ArgumentCaptor<NoPlayer.VideoSizeChangedListener> videoSizeChangedListenerCaptor = ArgumentCaptor.forClass(NoPlayer.VideoSizeChangedListener.class);
             verify(listenersHolder).addVideoSizeChangedListener(videoSizeChangedListenerCaptor.capture());
 
-            Player.VideoSizeChangedListener videoSizeChangedListener = videoSizeChangedListenerCaptor.getValue();
+            NoPlayer.VideoSizeChangedListener videoSizeChangedListener = videoSizeChangedListenerCaptor.getValue();
             videoSizeChangedListener.onVideoSizeChanged(WIDTH, HEIGHT, ANY_ROTATION_DEGREES, ANY_PIXEL_WIDTH_HEIGHT);
 
             assertThat(player.getVideoWidth()).isEqualTo(WIDTH);
@@ -279,7 +279,7 @@ public class AndroidMediaPlayerImplTest {
         @Test
         public void whenAttachingPlayerView_thenAddsVideoSizeChangedListener() {
             PlayerView playerView = mock(PlayerView.class);
-            Player.VideoSizeChangedListener videoSizeChangedListener = mock(Player.VideoSizeChangedListener.class);
+            NoPlayer.VideoSizeChangedListener videoSizeChangedListener = mock(NoPlayer.VideoSizeChangedListener.class);
             given(playerView.getVideoSizeChangedListener()).willReturn(videoSizeChangedListener);
             player.attach(playerView);
 
@@ -289,7 +289,7 @@ public class AndroidMediaPlayerImplTest {
         @Test
         public void whenAttachingPlayerView_thenAddsStateChangedListener() {
             PlayerView playerView = mock(PlayerView.class);
-            Player.StateChangedListener stateChangedListener = mock(Player.StateChangedListener.class);
+            NoPlayer.StateChangedListener stateChangedListener = mock(NoPlayer.StateChangedListener.class);
             given(playerView.getStateChangedListener()).willReturn(stateChangedListener);
             player.attach(playerView);
 
@@ -306,7 +306,7 @@ public class AndroidMediaPlayerImplTest {
         @Test
         public void whenDetachingPlayerView_thenRemovesVideoSizeChangedListener() {
             PlayerView playerView = mock(PlayerView.class);
-            Player.VideoSizeChangedListener videoSizeChangedListener = mock(Player.VideoSizeChangedListener.class);
+            NoPlayer.VideoSizeChangedListener videoSizeChangedListener = mock(NoPlayer.VideoSizeChangedListener.class);
             given(playerView.getVideoSizeChangedListener()).willReturn(videoSizeChangedListener);
             player.detach(playerView);
 
@@ -316,7 +316,7 @@ public class AndroidMediaPlayerImplTest {
         @Test
         public void whenDetachingPlayerView_thenRemovesStateChangedListener() {
             PlayerView playerView = mock(PlayerView.class);
-            Player.StateChangedListener stateChangedListener = mock(Player.StateChangedListener.class);
+            NoPlayer.StateChangedListener stateChangedListener = mock(NoPlayer.StateChangedListener.class);
             given(playerView.getStateChangedListener()).willReturn(stateChangedListener);
             player.detach(playerView);
 
@@ -620,7 +620,7 @@ public class AndroidMediaPlayerImplTest {
         static final Uri URI = Mockito.mock(Uri.class);
         static final int TEN_SECONDS = 10;
         static final Timeout ANY_TIMEOUT = Timeout.fromSeconds(TEN_SECONDS);
-        static final Player.LoadTimeoutCallback ANY_LOAD_TIMEOUT_CALLBACK = new Player.LoadTimeoutCallback() {
+        static final NoPlayer.LoadTimeoutCallback ANY_LOAD_TIMEOUT_CALLBACK = new NoPlayer.LoadTimeoutCallback() {
             @Override
             public void onLoadTimeout() {
 
@@ -649,25 +649,25 @@ public class AndroidMediaPlayerImplTest {
         @Mock
         BuggyVideoDriverPreventer buggyVideoDriverPreventer;
         @Mock
-        Player.PreparedListener preparedListener;
+        NoPlayer.PreparedListener preparedListener;
         @Mock
-        Player.BufferStateListener bufferStateListener;
+        NoPlayer.BufferStateListener bufferStateListener;
         @Mock
-        Player.ErrorListener errorListener;
+        NoPlayer.ErrorListener errorListener;
         @Mock
-        Player.CompletionListener completionListener;
+        NoPlayer.CompletionListener completionListener;
         @Mock
-        Player.VideoSizeChangedListener videoSizeChangedListener;
+        NoPlayer.VideoSizeChangedListener videoSizeChangedListener;
         @Mock
-        Player.InfoListener infoListener;
+        NoPlayer.InfoListener infoListener;
         @Mock
-        Player.StateChangedListener stateChangedListener;
+        NoPlayer.StateChangedListener stateChangedListener;
         @Mock
         SurfaceHolder surfaceHolder;
         @Mock
         PlayerView playerView;
         @Mock
-        Player.StateChangedListener stateChangeListener;
+        NoPlayer.StateChangedListener stateChangeListener;
         @Mock
         MediaPlayer.OnPreparedListener onPreparedListener;
         @Mock

--- a/core/src/test/java/com/novoda/noplayer/internal/mediaplayer/BuggyVideoDriverPreventerTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/mediaplayer/BuggyVideoDriverPreventerTest.java
@@ -2,7 +2,7 @@ package com.novoda.noplayer.internal.mediaplayer;
 
 import android.view.View;
 
-import com.novoda.noplayer.Player;
+import com.novoda.noplayer.NoPlayer;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -22,7 +22,7 @@ public class BuggyVideoDriverPreventerTest {
     private View videoContainer;
 
     @Mock
-    private Player player;
+    private NoPlayer player;
 
     @Mock
     private MediaPlayerTypeReader mediaPlayerTypeReader;

--- a/core/src/test/java/com/novoda/noplayer/internal/mediaplayer/LoadTimeoutTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/mediaplayer/LoadTimeoutTest.java
@@ -2,7 +2,7 @@ package com.novoda.noplayer.internal.mediaplayer;
 
 import android.os.Handler;
 
-import com.novoda.noplayer.Player;
+import com.novoda.noplayer.NoPlayer;
 import com.novoda.noplayer.internal.Clock;
 import com.novoda.noplayer.model.LoadTimeout;
 import com.novoda.noplayer.model.Timeout;
@@ -37,7 +37,7 @@ public class LoadTimeoutTest {
     @Test
     public void whenStartingATimeout_thenAnyPreviouslySetTimeoutRunnableAreRemoved() {
 
-        loadTimeout.start(ANY_TIME, any(Player.LoadTimeoutCallback.class));
+        loadTimeout.start(ANY_TIME, any(NoPlayer.LoadTimeoutCallback.class));
 
         verify(handler).removeCallbacks(any(Runnable.class));
     }
@@ -45,7 +45,7 @@ public class LoadTimeoutTest {
     @Test
     public void whenStartingATimeout_thenTheTimeoutRunnableIsPosted() {
 
-        loadTimeout.start(ANY_TIME, any(Player.LoadTimeoutCallback.class));
+        loadTimeout.start(ANY_TIME, any(NoPlayer.LoadTimeoutCallback.class));
 
         verify(handler).post(any(Runnable.class));
     }

--- a/core/src/test/java/com/novoda/noplayer/internal/mediaplayer/OnPotentialBuggyDriverLayoutListenerTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/mediaplayer/OnPotentialBuggyDriverLayoutListenerTest.java
@@ -2,7 +2,7 @@ package com.novoda.noplayer.internal.mediaplayer;
 
 import android.view.View;
 
-import com.novoda.noplayer.Player;
+import com.novoda.noplayer.NoPlayer;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -21,7 +21,7 @@ public class OnPotentialBuggyDriverLayoutListenerTest {
     public MockitoRule mockitoRule = MockitoJUnit.rule();
 
     @Mock
-    Player player;
+    NoPlayer player;
 
     @InjectMocks
     OnPotentialBuggyDriverLayoutListener buggyDriverLayoutListener;

--- a/demo/src/main/java/com/novoda/demo/MainActivity.java
+++ b/demo/src/main/java/com/novoda/demo/MainActivity.java
@@ -10,7 +10,7 @@ import android.widget.ArrayAdapter;
 import android.widget.Toast;
 
 import com.novoda.noplayer.ContentType;
-import com.novoda.noplayer.Player;
+import com.novoda.noplayer.NoPlayer;
 import com.novoda.noplayer.PlayerBuilder;
 import com.novoda.noplayer.PlayerState;
 import com.novoda.noplayer.PlayerView;
@@ -31,7 +31,7 @@ public class MainActivity extends Activity {
     private static final String URI_VIDEO_WIDEVINE_EXAMPLE_MODULAR_MPD = "https://storage.googleapis.com/wvmedia/cenc/h264/tears/tears.mpd";
     private static final String EXAMPLE_MODULAR_LICENSE_SERVER_PROXY = "https://proxy.uat.widevine.com/proxy?provider=widevine_test";
 
-    private Player player;
+    private NoPlayer player;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -52,7 +52,7 @@ public class MainActivity extends Activity {
                 .withDowngradedSecureDecoder()
                 .build(this);
 
-        player.getListeners().addPreparedListener(new Player.PreparedListener() {
+        player.getListeners().addPreparedListener(new NoPlayer.PreparedListener() {
             @Override
             public void onPrepared(PlayerState playerState) {
                 player.play();


### PR DESCRIPTION
## Problem
In the latest version of ExoPlayer (#73), a `Player` interface was introduced 😬 This can make our code base confusing where our interfaces overlap.

## Solution
Rename the `Player` interface to `NoPlayer`.

### Test(s) added 
No, just a name change.

### Screenshots
No Ui changes.

### Paired with 
Nobody.
