### PR TITLE
NP-85/Fix incorrect flag value

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ task wrapper(type: Wrapper) {
 }
 
 allprojects {
-    version = "2.0.7"
+    version = "3.0.7"
 }
 
 buildscript {

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/mediasource/AudioTrackType.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/mediasource/AudioTrackType.java
@@ -2,8 +2,8 @@ package com.novoda.noplayer.internal.exoplayer.mediasource;
 
 public enum AudioTrackType {
 
-    MAIN(0),
-    ALTERNATIVE(1),
+    MAIN(1),
+    ALTERNATIVE(0),
     UNKNOWN(-1);
 
     private final int selectionFlag;

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/mediasource/AudioTrackTypeTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/mediasource/AudioTrackTypeTest.java
@@ -6,8 +6,8 @@ import static org.fest.assertions.api.Assertions.assertThat;
 
 public class AudioTrackTypeTest {
 
-    private static final int MAIN_SELECTION_FLAG = 0;
-    private static final int ALTERNATIVE_SELECTION_FLAG = 1;
+    private static final int MAIN_SELECTION_FLAG = 1;
+    private static final int ALTERNATIVE_SELECTION_FLAG = 0;
     private static final int RANDOM_SELECTION_FLAG = 2;
 
     @Test


### PR DESCRIPTION
## Problem
When adding the `AudioTrackType` code I checked whether it worked on a client app and it didn't so I recklessly changed the flag number, big mistake, on further investigation it turns out it was correct before! 

## Solution
Revert the changes to the `AudioTrackType` selection flag int.

```
    protected int parseRole(XmlPullParser xpp) throws XmlPullParserException, IOException {
        String schemeIdUri = parseString(xpp, "schemeIdUri", (String)null);
        String value = parseString(xpp, "value", (String)null);

        do {
            xpp.next();
        } while(!XmlPullParserUtil.isEndTag(xpp, "Role"));

        return "urn:mpeg:dash:role:2011".equals(schemeIdUri) && "main".equals(value)?1:0;
    }
```
The selection flag will be `1` when the manifest schemeId matches and the role is `MAIN`. All others will default to `0`, which will appear as `ALTERNATIVE`. This does have the annoying drawback that if no role is specified then all tracks will be `ALTERNATIVE`. Until we can implement our own `DashManifestParser` clients will need to handle this case.

Dash manifest issue created: https://github.com/novoda/no-player/issues/90

⚠️ I've bumped the version in this PR too. Notice that this is a major release due to the breaking `Player` interface change ⚠️ 

### Test(s) added 
No just updated some constants.

### Screenshots
No UI changes.

### Paired with 
Nobody.
