### PR TITLE
Adaptive track selection

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ task wrapper(type: Wrapper) {
 }
 
 allprojects {
-    version = "3.0.0"
+    version = "3.0.1"
 }
 
 buildscript {

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerExoPlayerCreator.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerExoPlayerCreator.java
@@ -4,12 +4,14 @@ import android.content.Context;
 import android.os.Handler;
 
 import com.google.android.exoplayer2.mediacodec.MediaCodecSelector;
+import com.google.android.exoplayer2.trackselection.AdaptiveTrackSelection;
 import com.google.android.exoplayer2.trackselection.DefaultTrackSelector;
 import com.google.android.exoplayer2.trackselection.FixedTrackSelection;
+import com.google.android.exoplayer2.trackselection.TrackSelection;
+import com.google.android.exoplayer2.upstream.DefaultBandwidthMeter;
 import com.google.android.exoplayer2.upstream.DefaultDataSourceFactory;
-import com.novoda.noplayer.internal.Heart;
 import com.novoda.noplayer.NoPlayer;
-import com.novoda.noplayer.internal.listeners.PlayerListenersHolder;
+import com.novoda.noplayer.internal.Heart;
 import com.novoda.noplayer.internal.SystemClock;
 import com.novoda.noplayer.internal.exoplayer.drm.DrmSessionCreator;
 import com.novoda.noplayer.internal.exoplayer.forwarder.ExoPlayerForwarder;
@@ -17,6 +19,7 @@ import com.novoda.noplayer.internal.exoplayer.mediasource.ExoPlayerAudioTrackSel
 import com.novoda.noplayer.internal.exoplayer.mediasource.ExoPlayerSubtitleTrackSelector;
 import com.novoda.noplayer.internal.exoplayer.mediasource.ExoPlayerTrackSelector;
 import com.novoda.noplayer.internal.exoplayer.mediasource.MediaSourceFactory;
+import com.novoda.noplayer.internal.listeners.PlayerListenersHolder;
 import com.novoda.noplayer.model.LoadTimeout;
 
 public class NoPlayerExoPlayerCreator {
@@ -50,7 +53,8 @@ public class NoPlayerExoPlayerCreator {
             DefaultDataSourceFactory defaultDataSourceFactory = new DefaultDataSourceFactory(context, "user-agent");
             MediaSourceFactory mediaSourceFactory = new MediaSourceFactory(defaultDataSourceFactory, handler);
 
-            DefaultTrackSelector trackSelector = new DefaultTrackSelector();
+            TrackSelection.Factory adaptiveTrackSelectionFactory = new AdaptiveTrackSelection.Factory(new DefaultBandwidthMeter());
+            DefaultTrackSelector trackSelector = new DefaultTrackSelector(adaptiveTrackSelectionFactory);
 
             MediaCodecSelector mediaCodecSelector = downgradeSecureDecoder ? SecurityDowngradingCodecSelector.newInstance() : MediaCodecSelector.DEFAULT;
 

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerExoPlayerCreator.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerExoPlayerCreator.java
@@ -50,10 +50,11 @@ public class NoPlayerExoPlayerCreator {
         }
 
         ExoPlayerTwoImpl create(Context context, DrmSessionCreator drmSessionCreator, boolean downgradeSecureDecoder) {
-            DefaultDataSourceFactory defaultDataSourceFactory = new DefaultDataSourceFactory(context, "user-agent");
+            DefaultBandwidthMeter bandwidthMeter = new DefaultBandwidthMeter();
+            DefaultDataSourceFactory defaultDataSourceFactory = new DefaultDataSourceFactory(context, "user-agent", bandwidthMeter);
             MediaSourceFactory mediaSourceFactory = new MediaSourceFactory(defaultDataSourceFactory, handler);
 
-            TrackSelection.Factory adaptiveTrackSelectionFactory = new AdaptiveTrackSelection.Factory(new DefaultBandwidthMeter());
+            TrackSelection.Factory adaptiveTrackSelectionFactory = new AdaptiveTrackSelection.Factory(bandwidthMeter);
             DefaultTrackSelector trackSelector = new DefaultTrackSelector(adaptiveTrackSelectionFactory);
 
             MediaCodecSelector mediaCodecSelector = downgradeSecureDecoder ? SecurityDowngradingCodecSelector.newInstance() : MediaCodecSelector.DEFAULT;


### PR DESCRIPTION
## Problem
Clients have been experiencing a long buffer period and occasionally `BehindLiveWindowException` which occurs when the video playback cannot keep pace with the live stream.

These problems are all associated with `no-player` playing the highest quality video representation all of the time 😱  We should be adaptively switching between representations based on the bandwidth available to play content.

## Solution
Make use of the `DefaultBandwidthMeter` passing it into both the `DefaultDataSourceFactory` and the `DefaultTrackSelector`.

Adding it to the `DefaultDataSourceFactory` attaches it to any media that is fetched in order to acquire the estimated bitrate. Passing to the `DefaultTrackSelector` ensures that tracks are switched based on this bitrate.

The following logs show the switching of tracks based on bitrate.

```
09-14 15:23:07.644 20141-20199/com.novoda.demo E/FOO: bitrateEstimate: 1854275
09-14 15:23:07.644 20141-20199/com.novoda.demo E/FOO: effectiveBitrate: 1390706
09-14 15:23:07.644 20141-20199/com.novoda.demo E/FOO: format.bitrate <= effectiveBitrate false
09-14 15:23:07.644 20141-20199/com.novoda.demo E/FOO: format.bitrate <= effectiveBitrate false
09-14 15:23:07.644 20141-20199/com.novoda.demo E/FOO: format.bitrate <= effectiveBitrate false
09-14 15:23:07.644 20141-20199/com.novoda.demo E/FOO: format.bitrate <= effectiveBitrate true
09-14 15:23:07.644 20141-20199/com.novoda.demo E/FOO: selectedIndex: 3
09-14 15:23:26.169 20141-20199/com.novoda.demo E/FOO: bitrateEstimate: 2234009
09-14 15:23:26.169 20141-20199/com.novoda.demo E/FOO: effectiveBitrate: 1675506
09-14 15:23:26.169 20141-20199/com.novoda.demo E/FOO: format.bitrate <= effectiveBitrate false
09-14 15:23:26.169 20141-20199/com.novoda.demo E/FOO: format.bitrate <= effectiveBitrate false
09-14 15:23:26.169 20141-20199/com.novoda.demo E/FOO: format.bitrate <= effectiveBitrate false
09-14 15:23:26.169 20141-20199/com.novoda.demo E/FOO: format.bitrate <= effectiveBitrate true
09-14 15:23:26.169 20141-20199/com.novoda.demo E/FOO: selectedIndex: 3
09-14 15:23:28.837 20141-20199/com.novoda.demo E/FOO: bitrateEstimate: 4298112
09-14 15:23:28.837 20141-20199/com.novoda.demo E/FOO: effectiveBitrate: 3223584
09-14 15:23:28.837 20141-20199/com.novoda.demo E/FOO: format.bitrate <= effectiveBitrate false
09-14 15:23:28.837 20141-20199/com.novoda.demo E/FOO: format.bitrate <= effectiveBitrate false
09-14 15:23:28.837 20141-20199/com.novoda.demo E/FOO: format.bitrate <= effectiveBitrate true
09-14 15:23:28.837 20141-20199/com.novoda.demo E/FOO: selectedIndex: 2
09-14 15:23:50.172 20141-20199/com.novoda.demo E/FOO: bitrateEstimate: 8757550
09-14 15:23:50.172 20141-20199/com.novoda.demo E/FOO: effectiveBitrate: 6568162
09-14 15:23:50.172 20141-20199/com.novoda.demo E/FOO: format.bitrate <= effectiveBitrate false
09-14 15:23:50.172 20141-20199/com.novoda.demo E/FOO: format.bitrate <= effectiveBitrate false
09-14 15:23:50.172 20141-20199/com.novoda.demo E/FOO: format.bitrate <= effectiveBitrate true
09-14 15:23:50.172 20141-20199/com.novoda.demo E/FOO: selectedIndex: 2
09-14 15:23:53.094 20141-20199/com.novoda.demo E/FOO: bitrateEstimate: 8884962
09-14 15:23:53.094 20141-20199/com.novoda.demo E/FOO: effectiveBitrate: 6663721
09-14 15:23:53.094 20141-20199/com.novoda.demo E/FOO: format.bitrate <= effectiveBitrate false
09-14 15:23:53.094 20141-20199/com.novoda.demo E/FOO: format.bitrate <= effectiveBitrate false
09-14 15:23:53.094 20141-20199/com.novoda.demo E/FOO: format.bitrate <= effectiveBitrate true
09-14 15:23:53.094 20141-20199/com.novoda.demo E/FOO: selectedIndex: 2
09-14 15:24:14.166 20141-20199/com.novoda.demo E/FOO: bitrateEstimate: 17150580
09-14 15:24:14.166 20141-20199/com.novoda.demo E/FOO: effectiveBitrate: 12862935
09-14 15:24:14.167 20141-20199/com.novoda.demo E/FOO: format.bitrate <= effectiveBitrate false
09-14 15:24:14.167 20141-20199/com.novoda.demo E/FOO: format.bitrate <= effectiveBitrate true
09-14 15:24:14.167 20141-20199/com.novoda.demo E/FOO: selectedIndex: 1
```

### Test(s) added 
No, just updating a small piece of creation logic. We have tested this both in `no-player` and a client application.

### Screenshots
No UI changes.

### Paired with 
@zegnus 
