### PR TITLE
Update to latest version of exoplayer

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -22,7 +22,7 @@ android {
 }
 
 dependencies {
-    compile 'com.google.android.exoplayer:exoplayer:r2.5.1'
+    compile 'com.google.android.exoplayer:exoplayer:r2.5.2'
     compile 'com.novoda:notils-java:3.0.2'
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:2.7.22'


### PR DESCRIPTION
## Problem
ExoPlayer has a new version and we aren't using it 😱 

Release Notes: https://github.com/google/ExoPlayer/blob/release-v2/RELEASENOTES.md

## Solution
Update to the latest version of `ExoPlayer`.

### Test(s) added 
No, just updating the version. Tested manually on demo and on a client application.

### Screenshots
No UI changes.

### Paired with 
Nobody.
