### PR TITLE
Avoid emitting multiple `onComplete` events

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ task wrapper(type: Wrapper) {
 }
 
 allprojects {
-    version = "3.0.1"
+    version = "3.0.2"
 }
 
 buildscript {

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImpl.java
@@ -162,7 +162,7 @@ class ExoPlayerTwoImpl implements NoPlayer {
     }
 
     private void reset() {
-        listenersHolder.resetPreparedState();
+        listenersHolder.resetState();
         loadTimeout.cancel();
         heart.stopBeatingHeart();
         exoPlayer.release();

--- a/core/src/main/java/com/novoda/noplayer/internal/listeners/CompletionListeners.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/listeners/CompletionListeners.java
@@ -9,6 +9,8 @@ class CompletionListeners implements NoPlayer.CompletionListener {
 
     private final Set<NoPlayer.CompletionListener> listeners = new CopyOnWriteArraySet<>();
 
+    private boolean hasCompleted = false;
+
     void add(NoPlayer.CompletionListener listener) {
         listeners.add(listener);
     }
@@ -23,8 +25,15 @@ class CompletionListeners implements NoPlayer.CompletionListener {
 
     @Override
     public void onCompletion() {
-        for (NoPlayer.CompletionListener listener : listeners) {
-            listener.onCompletion();
+        if (!hasCompleted) {
+            hasCompleted = true;
+            for (NoPlayer.CompletionListener listener : listeners) {
+                listener.onCompletion();
+            }
         }
+    }
+
+    void resetCompletedState() {
+        hasCompleted = false;
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/listeners/PlayerListenersHolder.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/listeners/PlayerListenersHolder.java
@@ -155,8 +155,9 @@ public class PlayerListenersHolder implements Listeners {
         return bitrateChangedListeners;
     }
 
-    public void resetPreparedState() {
+    public void resetState() {
         preparedListeners.resetPreparedState();
+        completionListeners.resetCompletedState();
     }
 
     public void clear() {

--- a/core/src/main/java/com/novoda/noplayer/internal/listeners/PreparedListeners.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/listeners/PreparedListeners.java
@@ -26,7 +26,7 @@ class PreparedListeners implements NoPlayer.PreparedListener {
 
     @Override
     public void onPrepared(PlayerState playerState) {
-        if (hasNotPreviouslyPrepared()) {
+        if (!hasPrepared) {
             hasPrepared = true;
             for (NoPlayer.PreparedListener listener : listeners) {
                 listener.onPrepared(playerState);
@@ -36,9 +36,5 @@ class PreparedListeners implements NoPlayer.PreparedListener {
 
     void resetPreparedState() {
         hasPrepared = false;
-    }
-
-    private boolean hasNotPreviouslyPrepared() {
-        return !hasPrepared;
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImpl.java
@@ -333,7 +333,7 @@ class AndroidMediaPlayerImpl implements NoPlayer {
     }
 
     private void reset() {
-        listenersHolder.resetPreparedState();
+        listenersHolder.resetState();
         loadTimeout.cancel();
         heart.stopBeatingHeart();
         mediaPlayer.release();

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImplTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImplTest.java
@@ -124,7 +124,7 @@ public class ExoPlayerTwoImplTest {
             NoPlayer.ErrorListener errorListener = argumentCaptor.getValue();
             errorListener.onError(mock(NoPlayer.PlayerError.class));
 
-            verify(listenersHolder).resetPreparedState();
+            verify(listenersHolder).resetState();
             verify(loadTimeout).cancel();
             verify(heart).stopBeatingHeart();
             verify(exoPlayerFacade).release();
@@ -167,7 +167,7 @@ public class ExoPlayerTwoImplTest {
 
             player.stop();
 
-            verify(listenersHolder).resetPreparedState();
+            verify(listenersHolder).resetState();
             verify(stateChangedListener).onVideoStopped();
             verify(loadTimeout).cancel();
             verify(heart).stopBeatingHeart();
@@ -179,7 +179,7 @@ public class ExoPlayerTwoImplTest {
 
             player.release();
 
-            verify(listenersHolder).resetPreparedState();
+            verify(listenersHolder).resetState();
             verify(stateChangedListener).onVideoStopped();
             verify(loadTimeout).cancel();
             verify(heart).stopBeatingHeart();
@@ -193,7 +193,7 @@ public class ExoPlayerTwoImplTest {
 
             player.stop();
 
-            verify(listenersHolder).resetPreparedState();
+            verify(listenersHolder).resetState();
             verify(stateChangedListener).onVideoStopped();
             verify(loadTimeout).cancel();
             verify(heart).stopBeatingHeart();
@@ -207,7 +207,7 @@ public class ExoPlayerTwoImplTest {
 
             player.release();
 
-            verify(listenersHolder).resetPreparedState();
+            verify(listenersHolder).resetState();
             verify(stateChangedListener).onVideoStopped();
             verify(loadTimeout).cancel();
             verify(heart).stopBeatingHeart();

--- a/core/src/test/java/com/novoda/noplayer/internal/listeners/CompletionListenersTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/listeners/CompletionListenersTest.java
@@ -1,0 +1,48 @@
+package com.novoda.noplayer.internal.listeners;
+
+import com.novoda.noplayer.NoPlayer;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+
+public class CompletionListenersTest {
+
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Mock
+    private NoPlayer.CompletionListener completionListener;
+
+    private CompletionListeners completionListeners;
+
+    @Before
+    public void setUp() {
+        completionListeners = new CompletionListeners();
+        completionListeners.add(completionListener);
+    }
+
+    @Test
+    public void whenCallingOnCompletion_thenNotifiesOnCompletion() {
+        completionListeners.onCompletion();
+
+        verify(completionListener).onCompletion();
+    }
+
+    @Test
+    public void whenCallingOnCompletionTwice_thenDoesNothing() {
+        completionListeners.onCompletion();
+        reset(completionListener);
+
+        completionListeners.onCompletion();
+
+        verify(completionListener, never()).onCompletion();
+    }
+}

--- a/core/src/test/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImplTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImplTest.java
@@ -144,7 +144,7 @@ public class AndroidMediaPlayerImplTest {
             NoPlayer.ErrorListener errorListener = errorListenerCaptor.getValue();
             errorListener.onError(mock(NoPlayer.PlayerError.class));
 
-            verify(listenersHolder).resetPreparedState();
+            verify(listenersHolder).resetState();
             verify(loadTimeout).cancel();
             verify(heart).stopBeatingHeart();
             verify(mediaPlayer).release();
@@ -355,7 +355,7 @@ public class AndroidMediaPlayerImplTest {
 
             player.stop();
 
-            verify(listenersHolder).resetPreparedState();
+            verify(listenersHolder).resetState();
             verify(stateChangedListener).onVideoStopped();
             verify(loadTimeout).cancel();
             verify(heart).stopBeatingHeart();
@@ -368,7 +368,7 @@ public class AndroidMediaPlayerImplTest {
 
             player.release();
 
-            verify(listenersHolder).resetPreparedState();
+            verify(listenersHolder).resetState();
             verify(stateChangedListener).onVideoStopped();
             verify(loadTimeout).cancel();
             verify(heart).stopBeatingHeart();
@@ -382,7 +382,7 @@ public class AndroidMediaPlayerImplTest {
 
             player.stop();
 
-            verify(listenersHolder).resetPreparedState();
+            verify(listenersHolder).resetState();
             verify(stateChangedListener).onVideoStopped();
             verify(loadTimeout).cancel();
             verify(heart).stopBeatingHeart();
@@ -397,7 +397,7 @@ public class AndroidMediaPlayerImplTest {
 
             player.release();
 
-            verify(listenersHolder).resetPreparedState();
+            verify(listenersHolder).resetState();
             verify(stateChangedListener).onVideoStopped();
             verify(loadTimeout).cancel();
             verify(heart).stopBeatingHeart();


### PR DESCRIPTION
## Problem
It's possible for client to receive two `onComplete` events from `no-player`. One comes from a `handler` in `exo-player` and another comes `onPause` of the activity. The `onPause` is problematic because internally `exo-player` checks the last state a notifies the `StateChangedListener` which will return `complete` again 😬 

## Solution
Add a `boolean` flag 😷  to the `OnCompletionListeners`. We have this in the `OnPreparedListeners` also but this is not the ideal solution in both cases. It would be better to simplify the logic around the listeners and forwarders in `no-player`. We have created an issue for this at #95 

### Test(s) added 
Added tests for the `CompletionListeners`.

### Screenshots
No UI changes.

### Paired with 
@jonreeve 
