### PR TITLE
Handler seek exception

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ task wrapper(type: Wrapper) {
 }
 
 allprojects {
-    version = "3.0.2"
+    version = "3.0.3"
 }
 
 buildscript {

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ task wrapper(type: Wrapper) {
 }
 
 allprojects {
-    version = "3.0.3"
+    version = "3.0.2"
 }
 
 buildscript {

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImpl.java
@@ -29,7 +29,7 @@ import java.util.List;
 class AndroidMediaPlayerImpl implements NoPlayer {
 
     private static final VideoPosition NO_SEEK_TO_POSITION = VideoPosition.INVALID;
-    private static final int INITIAL_PLAY_SEEK_DELAY_IN_MILLIS = 500;
+    private static final long INITIAL_PLAY_SEEK_DELAY_IN_MILLIS = 500;
 
     private final List<SurfaceHolderRequester.Callback> surfaceHolderRequesterCallbacks = new ArrayList<>();
 

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImpl.java
@@ -2,7 +2,6 @@ package com.novoda.noplayer.internal.mediaplayer;
 
 import android.media.MediaPlayer;
 import android.net.Uri;
-import android.os.Handler;
 import android.view.SurfaceHolder;
 import android.view.View;
 
@@ -38,7 +37,7 @@ class AndroidMediaPlayerImpl implements NoPlayer {
     private final AndroidMediaPlayerFacade mediaPlayer;
     private final MediaPlayerForwarder forwarder;
     private final CheckBufferHeartbeatCallback bufferHeartbeatCallback;
-    private final Handler handler;
+    private final DelayedActionExecutor delayedActionExecutor;
     private final Heart heart;
     private final PlayerListenersHolder listenersHolder;
     private final LoadTimeout loadTimeout;
@@ -59,7 +58,7 @@ class AndroidMediaPlayerImpl implements NoPlayer {
                            CheckBufferHeartbeatCallback bufferHeartbeatCallback,
                            LoadTimeout loadTimeout,
                            Heart heart,
-                           Handler handler,
+                           DelayedActionExecutor delayedActionExecutor,
                            BuggyVideoDriverPreventer buggyVideoDriverPreventer) {
         this.mediaPlayerInformation = mediaPlayerInformation;
         this.mediaPlayer = mediaPlayer;
@@ -68,7 +67,7 @@ class AndroidMediaPlayerImpl implements NoPlayer {
         this.bufferHeartbeatCallback = bufferHeartbeatCallback;
         this.loadTimeout = loadTimeout;
         this.heart = heart;
-        this.handler = handler;
+        this.delayedActionExecutor = delayedActionExecutor;
         this.buggyVideoDriverPreventer = buggyVideoDriverPreventer;
     }
 
@@ -151,9 +150,9 @@ class AndroidMediaPlayerImpl implements NoPlayer {
     private void initialSeekWorkaround(SurfaceHolder surfaceHolder, final VideoPosition initialPlayPosition) throws IllegalStateException {
         listenersHolder.getBufferStateListeners().onBufferStarted();
         initialisePlaybackForSeeking(surfaceHolder);
-        handler.postDelayed(new Runnable() {
+        delayedActionExecutor.performAfterDelay(new DelayedActionExecutor.Action() {
             @Override
-            public void run() {
+            public void perform() {
                 seekWithIntentToPlay(initialPlayPosition);
             }
         }, INITIAL_PLAY_SEEK_DELAY_IN_MILLIS);
@@ -333,7 +332,7 @@ class AndroidMediaPlayerImpl implements NoPlayer {
     }
 
     private void reset() {
-        handler.removeCallbacksAndMessages(null);
+        delayedActionExecutor.clearAllActions();
         listenersHolder.resetState();
         loadTimeout.cancel();
         heart.stopBeatingHeart();

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImpl.java
@@ -333,6 +333,7 @@ class AndroidMediaPlayerImpl implements NoPlayer {
     }
 
     private void reset() {
+        handler.removeCallbacksAndMessages(null);
         listenersHolder.resetState();
         loadTimeout.cancel();
         heart.stopBeatingHeart();

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/DelayedActionExecutor.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/DelayedActionExecutor.java
@@ -1,0 +1,43 @@
+package com.novoda.noplayer.internal.mediaplayer;
+
+import android.os.Handler;
+
+import java.util.Iterator;
+import java.util.Map;
+
+class DelayedActionExecutor {
+
+    private final Handler handler;
+    private final Map<Action, Runnable> runnables;
+
+    DelayedActionExecutor(Handler handler, Map<Action, Runnable> runnables) {
+        this.handler = handler;
+        this.runnables = runnables;
+    }
+
+    void performAfterDelay(final Action action, long delayInMillis) {
+        Runnable actionRunnable = new Runnable() {
+            @Override
+            public void run() {
+                action.perform();
+                runnables.remove(action);
+            }
+        };
+        runnables.put(action, actionRunnable);
+        handler.postDelayed(actionRunnable, delayInMillis);
+    }
+
+    void clearAllActions() {
+        Iterator<Map.Entry<Action, Runnable>> it = runnables.entrySet().iterator();
+        while (it.hasNext()) {
+            Map.Entry<Action, Runnable> entry = it.next();
+            handler.removeCallbacks(entry.getValue());
+            it.remove();
+        }
+    }
+
+    interface Action {
+
+        void perform();
+    }
+}

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/NoPlayerMediaPlayerCreator.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/NoPlayerMediaPlayerCreator.java
@@ -11,6 +11,8 @@ import com.novoda.noplayer.internal.listeners.PlayerListenersHolder;
 import com.novoda.noplayer.internal.mediaplayer.forwarder.MediaPlayerForwarder;
 import com.novoda.noplayer.model.LoadTimeout;
 
+import java.util.HashMap;
+
 public class NoPlayerMediaPlayerCreator {
 
     private final InternalCreator internalCreator;
@@ -46,6 +48,7 @@ public class NoPlayerMediaPlayerCreator {
             CheckBufferHeartbeatCallback bufferHeartbeatCallback = new CheckBufferHeartbeatCallback();
             Heart heart = Heart.newInstance(handler);
             MediaPlayerTypeReader mediaPlayerTypeReader = new MediaPlayerTypeReader(new SystemProperties(), Build.VERSION.SDK_INT);
+            DelayedActionExecutor delayedActionExecutor = new DelayedActionExecutor(handler, new HashMap<DelayedActionExecutor.Action, Runnable>());
             BuggyVideoDriverPreventer preventer = new BuggyVideoDriverPreventer(mediaPlayerTypeReader);
             MediaPlayerInformation mediaPlayerInformation = new MediaPlayerInformation(mediaPlayerTypeReader);
             return new AndroidMediaPlayerImpl(
@@ -56,7 +59,7 @@ public class NoPlayerMediaPlayerCreator {
                     bufferHeartbeatCallback,
                     loadTimeout,
                     heart,
-                    handler,
+                    delayedActionExecutor,
                     preventer
             );
         }

--- a/core/src/test/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImplTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImplTest.java
@@ -2,7 +2,6 @@ package com.novoda.noplayer.internal.mediaplayer;
 
 import android.media.MediaPlayer;
 import android.net.Uri;
-import android.os.Handler;
 import android.view.SurfaceHolder;
 import android.view.View;
 
@@ -144,7 +143,7 @@ public class AndroidMediaPlayerImplTest {
             NoPlayer.ErrorListener errorListener = errorListenerCaptor.getValue();
             errorListener.onError(mock(NoPlayer.PlayerError.class));
 
-            verify(handler).removeCallbacksAndMessages(null);
+            verify(delayedActionExecutor).clearAllActions();
             verify(listenersHolder).resetState();
             verify(loadTimeout).cancel();
             verify(heart).stopBeatingHeart();
@@ -356,7 +355,7 @@ public class AndroidMediaPlayerImplTest {
 
             player.stop();
 
-            verify(handler).removeCallbacksAndMessages(null);
+            verify(delayedActionExecutor).clearAllActions();
             verify(listenersHolder).resetState();
             verify(stateChangedListener).onVideoStopped();
             verify(loadTimeout).cancel();
@@ -370,7 +369,7 @@ public class AndroidMediaPlayerImplTest {
 
             player.release();
 
-            verify(handler).removeCallbacksAndMessages(null);
+            verify(delayedActionExecutor).clearAllActions();
             verify(listenersHolder).resetState();
             verify(stateChangedListener).onVideoStopped();
             verify(loadTimeout).cancel();
@@ -385,7 +384,7 @@ public class AndroidMediaPlayerImplTest {
 
             player.stop();
 
-            verify(handler).removeCallbacksAndMessages(null);
+            verify(delayedActionExecutor).clearAllActions();
             verify(listenersHolder).resetState();
             verify(stateChangedListener).onVideoStopped();
             verify(loadTimeout).cancel();
@@ -401,7 +400,7 @@ public class AndroidMediaPlayerImplTest {
 
             player.release();
 
-            verify(handler).removeCallbacksAndMessages(null);
+            verify(delayedActionExecutor).clearAllActions();
             verify(listenersHolder).resetState();
             verify(stateChangedListener).onVideoStopped();
             verify(loadTimeout).cancel();
@@ -414,7 +413,7 @@ public class AndroidMediaPlayerImplTest {
 
     public static class GivenPlayerIsAttached extends Base {
 
-        private static final long DELAY_MILLIS = 500;
+        private static final int DELAY_MILLIS = 500;
         private static final boolean IS_PLAYING = true;
         private static final boolean IS_NOT_PLAYING = false;
 
@@ -590,9 +589,9 @@ public class AndroidMediaPlayerImplTest {
             VideoPosition differentPosition = givenPositionThatDiffersFromPlayheadPosition();
 
             player.play(differentPosition);
-            ArgumentCaptor<Runnable> runnableCaptor = ArgumentCaptor.forClass(Runnable.class);
-            verify(handler).postDelayed(runnableCaptor.capture(), eq(DELAY_MILLIS));
-            runnableCaptor.getValue().run();
+            ArgumentCaptor<DelayedActionExecutor.Action> argumentCaptor = ArgumentCaptor.forClass(DelayedActionExecutor.Action.class);
+            verify(delayedActionExecutor).performAfterDelay(argumentCaptor.capture(), eq(DELAY_MILLIS));
+            argumentCaptor.getValue().perform();
 
             verify(mediaPlayer).seekTo(differentPosition.inImpreciseMillis());
         }
@@ -650,7 +649,7 @@ public class AndroidMediaPlayerImplTest {
         @Mock
         Heart heart;
         @Mock
-        Handler handler;
+        DelayedActionExecutor delayedActionExecutor;
         @Mock
         BuggyVideoDriverPreventer buggyVideoDriverPreventer;
         @Mock
@@ -727,7 +726,7 @@ public class AndroidMediaPlayerImplTest {
                     checkBufferHeartbeatCallback,
                     loadTimeout,
                     heart,
-                    handler,
+                    delayedActionExecutor,
                     buggyVideoDriverPreventer
             );
         }

--- a/core/src/test/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImplTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImplTest.java
@@ -144,6 +144,7 @@ public class AndroidMediaPlayerImplTest {
             NoPlayer.ErrorListener errorListener = errorListenerCaptor.getValue();
             errorListener.onError(mock(NoPlayer.PlayerError.class));
 
+            verify(handler).removeCallbacksAndMessages(null);
             verify(listenersHolder).resetState();
             verify(loadTimeout).cancel();
             verify(heart).stopBeatingHeart();
@@ -355,6 +356,7 @@ public class AndroidMediaPlayerImplTest {
 
             player.stop();
 
+            verify(handler).removeCallbacksAndMessages(null);
             verify(listenersHolder).resetState();
             verify(stateChangedListener).onVideoStopped();
             verify(loadTimeout).cancel();
@@ -368,6 +370,7 @@ public class AndroidMediaPlayerImplTest {
 
             player.release();
 
+            verify(handler).removeCallbacksAndMessages(null);
             verify(listenersHolder).resetState();
             verify(stateChangedListener).onVideoStopped();
             verify(loadTimeout).cancel();
@@ -382,6 +385,7 @@ public class AndroidMediaPlayerImplTest {
 
             player.stop();
 
+            verify(handler).removeCallbacksAndMessages(null);
             verify(listenersHolder).resetState();
             verify(stateChangedListener).onVideoStopped();
             verify(loadTimeout).cancel();
@@ -397,6 +401,7 @@ public class AndroidMediaPlayerImplTest {
 
             player.release();
 
+            verify(handler).removeCallbacksAndMessages(null);
             verify(listenersHolder).resetState();
             verify(stateChangedListener).onVideoStopped();
             verify(loadTimeout).cancel();

--- a/core/src/test/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImplTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImplTest.java
@@ -413,8 +413,7 @@ public class AndroidMediaPlayerImplTest {
 
     public static class GivenPlayerIsAttached extends Base {
 
-        private static final int DELAY_MILLIS = 500;
-        private static final boolean IS_PLAYING = true;
+        private static final long DELAY_MILLIS = 500;
         private static final boolean IS_NOT_PLAYING = false;
 
         @Override

--- a/core/src/test/java/com/novoda/noplayer/internal/mediaplayer/DelayedActionExecutorTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/mediaplayer/DelayedActionExecutorTest.java
@@ -1,0 +1,86 @@
+package com.novoda.noplayer.internal.mediaplayer;
+
+import android.os.Handler;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.willAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class DelayedActionExecutorTest {
+
+    private static final long ANY_DELAY_IN_MILLIS = 10;
+
+    private final DelayedActionExecutor.Action action = mock(DelayedActionExecutor.Action.class);
+    private final DelayedActionExecutor.Action secondaryAction = mock(DelayedActionExecutor.Action.class);
+
+    private final Handler immediatelyExecutingHandler = createImmediatelyExecutingHandler();
+    private final Handler nonExecutingHandler = mock(Handler.class);
+
+    private final Map<DelayedActionExecutor.Action, Runnable> runnables = new HashMap<>();
+
+    private DelayedActionExecutor delayedActionExecutor;
+
+    @Test
+    public void whenActionIsNotPerformedYet_thenMapContainsAction() {
+        delayedActionExecutor = new DelayedActionExecutor(nonExecutingHandler, runnables);
+
+        delayedActionExecutor.performAfterDelay(action, ANY_DELAY_IN_MILLIS);
+
+        assertThat(runnables).hasSize(1);
+    }
+
+    @Test
+    public void whenPerformingActionAfterDelay_thenRemovesActionFromMap() {
+        delayedActionExecutor = new DelayedActionExecutor(immediatelyExecutingHandler, runnables);
+
+        delayedActionExecutor.performAfterDelay(action, ANY_DELAY_IN_MILLIS);
+
+        assertThat(runnables).isEmpty();
+    }
+
+    @Test
+    public void whenPerformingActionAfterDelay_thenPerformsAction() {
+        delayedActionExecutor = new DelayedActionExecutor(immediatelyExecutingHandler, runnables);
+
+        delayedActionExecutor.performAfterDelay(action, ANY_DELAY_IN_MILLIS);
+
+        verify(action).perform();
+    }
+
+    @Test
+    public void givenMultipleQueuedActions_whenClearingActions_thenRemovesAllActions() {
+        delayedActionExecutor = new DelayedActionExecutor(nonExecutingHandler, runnables);
+        delayedActionExecutor.performAfterDelay(action, ANY_DELAY_IN_MILLIS);
+        delayedActionExecutor.performAfterDelay(secondaryAction, ANY_DELAY_IN_MILLIS);
+
+        delayedActionExecutor.clearAllActions();
+
+        assertThat(runnables).isEmpty();
+        verify(nonExecutingHandler, times(2)).removeCallbacks(any(Runnable.class));
+    }
+
+    private Handler createImmediatelyExecutingHandler() {
+        Handler handler = mock(Handler.class);
+        final ArgumentCaptor<Runnable> argumentCaptor = ArgumentCaptor.forClass(Runnable.class);
+        willAnswer(new Answer<Object>() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                argumentCaptor.getValue().run();
+                return null;
+            }
+        }).given(handler).postDelayed(argumentCaptor.capture(), eq(ANY_DELAY_IN_MILLIS));
+        return handler;
+    }
+}


### PR DESCRIPTION
## Problem
We've seen this `stack trace` on some client applications (replicated in no-player)

![screen shot 2017-10-13 at 11 33 48](https://user-images.githubusercontent.com/3380092/31543203-073da402-b00d-11e7-97e4-fd5043ebcb23.png)

In some client applications we attempt to catch any `IllegalStateExceptions` that occur when calling methods out of sync on `NoPlayer`. Unfortunately, the calling code from this trace does not come from any client app but internally from inside `no-player` because of a workaround that is implemented on `MediaPlayer`:

```
    /**
     * Workaround to fix some devices (nexus 7 2013 in particular) from natively crashing the mediaplayer
     * by starting the mediaplayer before seeking it.
     */
```
See [here](https://github.com/novoda/no-player/blob/master/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImpl.java#L151-L160) for the problematic code.

This workaround internally uses a `Handler.postDelayed`. This runnable is never removed on `reset` of `Player` so if a user leaves a `Player` activity before this has executed it will crash. It crashes because on exit of a `Player` activity will release all internal collaborators of `MediaPlayer` which essentially means `mediaPlayer` will be `null` and so failing the `assertIsInPlaybackState()` which will throw an `IllegalStateException` as designed.

## Solution
To find this I increased the `DELAY` on the `Runnable` in the `MediaPlayer` and ran in a client application, navigating away from the activity before this `Runnable` is called = insta crash 😄 

Looking at the code you could add a check for `mediaPlayerFacade.isPlaying` [here](https://github.com/novoda/no-player/blob/master/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImpl.java#L151-L160) which will internally do the same checks as are done for the `assertIsInPlaybackState()` but instead just return in the runnable, avoiding the throw that is called later. BUT this seemed like a workaround rather than an actual fix. 

So I added `handler.removeCallbacksAndMessages(null);` which will remove all callbacks and messages whenever `reset()` is called in `MediaPlayerImpl`. For all of those that are worried about the `null` on this method this is what the docs say about this call:

``` 
    /**
     * Remove any pending posts of callbacks and sent messages whose
     * <var>obj</var> is <var>token</var>.  If <var>token</var> is null,
     * all callbacks and messages will be removed.
     */
```

### Test(s) added 
Updated the `MediaPlayerImpl` tests to take into account the reset on the handler.

### Screenshots
No UI changes.

### Paired with 
Nobody.
