### PR TITLE
Video track selection

### DIFF
--- a/core/src/main/java/com/novoda/noplayer/NoPlayer.java
+++ b/core/src/main/java/com/novoda/noplayer/NoPlayer.java
@@ -112,6 +112,15 @@ public interface NoPlayer extends PlayerState {
     AudioTracks getAudioTracks() throws IllegalStateException;
 
     /**
+     * Selects a given {@link PlayerVideoTrack}.
+     *
+     * @param videoTrack the video track to select.
+     * @return whether the selection was successful.
+     * @throws IllegalStateException - if called before {@link NoPlayer#loadVideo(Uri, ContentType)}.
+     */
+    boolean selectVideoTrack(PlayerVideoTrack videoTrack) throws IllegalStateException;
+
+    /**
      * Retrieves the currently playing {@link PlayerVideoTrack} of a prepared Player.
      *
      * @return {@link PlayerVideoTrack}.

--- a/core/src/main/java/com/novoda/noplayer/NoPlayer.java
+++ b/core/src/main/java/com/novoda/noplayer/NoPlayer.java
@@ -9,6 +9,7 @@ import com.novoda.noplayer.model.PlayerSubtitleTrack;
 import com.novoda.noplayer.model.PlayerVideoTrack;
 import com.novoda.noplayer.model.Timeout;
 import com.novoda.noplayer.model.VideoPosition;
+import com.novoda.utils.Optional;
 
 import java.util.List;
 import java.util.Map;
@@ -121,13 +122,14 @@ public interface NoPlayer extends PlayerState {
     boolean selectVideoTrack(PlayerVideoTrack videoTrack) throws IllegalStateException;
 
     /**
-     * Retrieves the currently playing {@link PlayerVideoTrack} of a prepared Player.
+     * Retrieves the currently playing {@link PlayerVideoTrack} of a prepared Player wrapped
+     * as an {@link Optional} or {@link Optional#absent()} if unavailable.
      *
      * @return {@link PlayerVideoTrack}.
      * @throws IllegalStateException - if called before {@link NoPlayer#loadVideo(Uri, ContentType)}.
      * @see NoPlayer.PreparedListener
      */
-    PlayerVideoTrack getSelectedVideoTrack() throws IllegalStateException;
+    Optional<PlayerVideoTrack> getSelectedVideoTrack() throws IllegalStateException;
 
     /**
      * Retrieves all of the available {@link PlayerVideoTrack} of a prepared Player.

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
@@ -4,7 +4,6 @@ import android.net.Uri;
 import android.support.annotation.Nullable;
 import android.view.SurfaceHolder;
 
-import com.google.android.exoplayer2.Format;
 import com.google.android.exoplayer2.SimpleExoPlayer;
 import com.google.android.exoplayer2.mediacodec.MediaCodecSelector;
 import com.google.android.exoplayer2.source.MediaSource;

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
@@ -138,17 +138,14 @@ class ExoPlayerFacade {
         return audioTrackSelector.getAudioTracks(rendererTypeRequester);
     }
 
+    boolean selectVideoTrack(PlayerVideoTrack playerVideoTrack) {
+        assertVideoLoaded();
+        return exoPlayerVideoTrackSelector.selectVideoTrack(playerVideoTrack, rendererTypeRequester);
+    }
+
     PlayerVideoTrack getSelectedVideoTrack() {
         assertVideoLoaded();
-        Format format = exoPlayer.getVideoFormat();
-        return new PlayerVideoTrack(
-                format.id,
-                contentType,
-                format.width,
-                format.height,
-                (int) format.frameRate,
-                format.bitrate
-        );
+        return exoPlayerVideoTrackSelector.getSelectedVideoTrack(exoPlayer, rendererTypeRequester, contentType);
     }
 
     List<PlayerVideoTrack> getVideoTracks() {

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
@@ -20,6 +20,7 @@ import com.novoda.noplayer.model.PlayerSubtitleTrack;
 import com.novoda.noplayer.model.PlayerVideoTrack;
 import com.novoda.noplayer.model.VideoDuration;
 import com.novoda.noplayer.model.VideoPosition;
+import com.novoda.utils.Optional;
 
 import java.util.List;
 
@@ -142,7 +143,7 @@ class ExoPlayerFacade {
         return exoPlayerVideoTrackSelector.selectVideoTrack(playerVideoTrack, rendererTypeRequester);
     }
 
-    PlayerVideoTrack getSelectedVideoTrack() {
+    Optional<PlayerVideoTrack> getSelectedVideoTrack() {
         assertVideoLoaded();
         return exoPlayerVideoTrackSelector.getSelectedVideoTrack(exoPlayer, rendererTypeRequester, contentType);
     }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImpl.java
@@ -24,6 +24,7 @@ import com.novoda.noplayer.model.PlayerVideoTrack;
 import com.novoda.noplayer.model.Timeout;
 import com.novoda.noplayer.model.VideoDuration;
 import com.novoda.noplayer.model.VideoPosition;
+import com.novoda.utils.Optional;
 
 import java.util.List;
 
@@ -268,7 +269,7 @@ class ExoPlayerTwoImpl implements NoPlayer {
     }
 
     @Override
-    public PlayerVideoTrack getSelectedVideoTrack() throws IllegalStateException {
+    public Optional<PlayerVideoTrack> getSelectedVideoTrack() throws IllegalStateException {
         return exoPlayer.getSelectedVideoTrack();
     }
 

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImpl.java
@@ -263,6 +263,11 @@ class ExoPlayerTwoImpl implements NoPlayer {
     }
 
     @Override
+    public boolean selectVideoTrack(PlayerVideoTrack videoTrack) throws IllegalStateException {
+        return exoPlayer.selectVideoTrack(videoTrack);
+    }
+
+    @Override
     public PlayerVideoTrack getSelectedVideoTrack() throws IllegalStateException {
         return exoPlayer.getSelectedVideoTrack();
     }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerExoPlayerCreator.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerExoPlayerCreator.java
@@ -63,7 +63,7 @@ public class NoPlayerExoPlayerCreator {
             ExoPlayerTrackSelector exoPlayerTrackSelector = ExoPlayerTrackSelector.newInstance(trackSelector);
             FixedTrackSelection.Factory trackSelectionFactory = new FixedTrackSelection.Factory();
             ExoPlayerAudioTrackSelector exoPlayerAudioTrackSelector = new ExoPlayerAudioTrackSelector(exoPlayerTrackSelector, trackSelectionFactory);
-            ExoPlayerVideoTrackSelector exoPlayerVideoTrackSelector = new ExoPlayerVideoTrackSelector(exoPlayerTrackSelector);
+            ExoPlayerVideoTrackSelector exoPlayerVideoTrackSelector = new ExoPlayerVideoTrackSelector(exoPlayerTrackSelector, trackSelectionFactory);
             ExoPlayerSubtitleTrackSelector exoPlayerSubtitleTrackSelector = new ExoPlayerSubtitleTrackSelector(
                     exoPlayerTrackSelector,
                     trackSelectionFactory

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/mediasource/ExoPlayerVideoTrackSelector.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/mediasource/ExoPlayerVideoTrackSelector.java
@@ -9,6 +9,7 @@ import com.google.android.exoplayer2.trackselection.TrackSelection;
 import com.novoda.noplayer.ContentType;
 import com.novoda.noplayer.internal.exoplayer.RendererTypeRequester;
 import com.novoda.noplayer.model.PlayerVideoTrack;
+import com.novoda.utils.Optional;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -65,15 +66,15 @@ public class ExoPlayerVideoTrackSelector {
         return videoTracks;
     }
 
-    public PlayerVideoTrack getSelectedVideoTrack(SimpleExoPlayer exoPlayer, RendererTypeRequester rendererTypeRequester, ContentType contentType) {
+    public Optional<PlayerVideoTrack> getSelectedVideoTrack(SimpleExoPlayer exoPlayer, RendererTypeRequester rendererTypeRequester, ContentType contentType) {
         Format selectedVideoFormat = exoPlayer.getVideoFormat();
         List<PlayerVideoTrack> videoTracks = getVideoTracks(rendererTypeRequester, contentType);
 
         for (PlayerVideoTrack videoTrack : videoTracks) {
             if (videoTrack.id().equals(selectedVideoFormat.id)) {
-                return videoTrack;
+                return Optional.of(videoTrack);
             }
         }
-        return new PlayerVideoTrack(0, 0, "", contentType, 0, 0, 0, 0);
+        return Optional.absent();
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/mediasource/ExoPlayerVideoTrackSelector.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/mediasource/ExoPlayerVideoTrackSelector.java
@@ -68,8 +68,16 @@ public class ExoPlayerVideoTrackSelector {
 
     public Optional<PlayerVideoTrack> getSelectedVideoTrack(SimpleExoPlayer exoPlayer, RendererTypeRequester rendererTypeRequester, ContentType contentType) {
         Format selectedVideoFormat = exoPlayer.getVideoFormat();
-        List<PlayerVideoTrack> videoTracks = getVideoTracks(rendererTypeRequester, contentType);
 
+        if (selectedVideoFormat == null) {
+            return Optional.absent();
+        }
+
+        List<PlayerVideoTrack> videoTracks = getVideoTracks(rendererTypeRequester, contentType);
+        return findSelectedVideoTrack(selectedVideoFormat, videoTracks);
+    }
+
+    private Optional<PlayerVideoTrack> findSelectedVideoTrack(Format selectedVideoFormat, List<PlayerVideoTrack> videoTracks) {
         for (PlayerVideoTrack videoTrack : videoTracks) {
             if (videoTrack.id().equals(selectedVideoFormat.id)) {
                 return Optional.of(videoTrack);

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/mediasource/ExoPlayerVideoTrackSelector.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/mediasource/ExoPlayerVideoTrackSelector.java
@@ -13,7 +13,6 @@ import com.novoda.noplayer.model.PlayerVideoTrack;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.novoda.noplayer.internal.exoplayer.mediasource.TrackType.AUDIO;
 import static com.novoda.noplayer.internal.exoplayer.mediasource.TrackType.VIDEO;
 
 public class ExoPlayerVideoTrackSelector {
@@ -34,7 +33,7 @@ public class ExoPlayerVideoTrackSelector {
                 videoTrack.groupIndex(),
                 videoTrack.formatIndex()
         );
-        return trackSelector.setSelectionOverride(AUDIO, rendererTypeRequester, trackGroups, selectionOverride);
+        return trackSelector.setSelectionOverride(VIDEO, rendererTypeRequester, trackGroups, selectionOverride);
     }
 
     public List<PlayerVideoTrack> getVideoTracks(RendererTypeRequester rendererTypeRequester, ContentType contentType) {

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerFacade.java
@@ -243,7 +243,7 @@ class AndroidMediaPlayerFacade {
 
     boolean selectSubtitleTrack(PlayerSubtitleTrack subtitleTrack) throws IllegalStateException {
         assertIsInPlaybackState();
-        NoPlayerLog.w("Tried to show subtitle track but has not been implemented for MediaPlayer.");
+        NoPlayerLog.w("Tried to select subtitle track but has not been implemented for MediaPlayer.");
         return false;
     }
 
@@ -269,5 +269,11 @@ class AndroidMediaPlayerFacade {
         assertIsInPlaybackState();
         NoPlayerLog.w("Tried to get video tracks but has not been implemented for MediaPlayer.");
         return Collections.emptyList();
+    }
+
+    boolean selectVideoTrack(PlayerVideoTrack videoTrack) {
+        assertIsInPlaybackState();
+        NoPlayerLog.w("Tried to select a video track but has not been implemented for MediaPlayer.");
+        return false;
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerFacade.java
@@ -262,7 +262,7 @@ class AndroidMediaPlayerFacade {
     PlayerVideoTrack getSelectedVideoTrack() {
         assertIsInPlaybackState();
         NoPlayerLog.w("Tried to get the currently playing video track but has not been implemented for MediaPlayer.");
-        return new PlayerVideoTrack("n/a", contentType, 0, 0, 0, 0);
+        return new PlayerVideoTrack(0, 0, "n/a", contentType, 0, 0, 0, 0);
     }
 
     List<PlayerVideoTrack> getVideoTracks() {

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerFacade.java
@@ -7,7 +7,6 @@ import android.net.Uri;
 import android.support.annotation.Nullable;
 import android.view.SurfaceHolder;
 
-import com.novoda.noplayer.ContentType;
 import com.novoda.noplayer.internal.mediaplayer.PlaybackStateChecker.PlaybackState;
 import com.novoda.noplayer.internal.mediaplayer.forwarder.MediaPlayerForwarder;
 import com.novoda.noplayer.model.AudioTracks;
@@ -15,6 +14,7 @@ import com.novoda.noplayer.model.PlayerAudioTrack;
 import com.novoda.noplayer.model.PlayerSubtitleTrack;
 import com.novoda.noplayer.model.PlayerVideoTrack;
 import com.novoda.utils.NoPlayerLog;
+import com.novoda.utils.Optional;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -42,8 +42,6 @@ class AndroidMediaPlayerFacade {
 
     @Nullable
     private MediaPlayer mediaPlayer;
-    @Nullable
-    private ContentType contentType;
 
     static AndroidMediaPlayerFacade newInstance(Context context, MediaPlayerForwarder forwarder) {
         TrackInfosFactory trackInfosFactory = new TrackInfosFactory();
@@ -68,12 +66,11 @@ class AndroidMediaPlayerFacade {
         this.mediaPlayerCreator = mediaPlayerCreator;
     }
 
-    void prepareVideo(Uri videoUri, SurfaceHolder surfaceHolder, ContentType contentType) {
+    void prepareVideo(Uri videoUri, SurfaceHolder surfaceHolder) {
         requestAudioFocus();
         release();
         try {
             currentState = PlaybackState.PREPARING;
-            this.contentType = contentType;
             mediaPlayer = createAndBindMediaPlayer(surfaceHolder, videoUri);
             mediaPlayer.prepareAsync();
         } catch (IOException | IllegalArgumentException | IllegalStateException ex) {
@@ -259,10 +256,10 @@ class AndroidMediaPlayerFacade {
         }
     }
 
-    PlayerVideoTrack getSelectedVideoTrack() {
+    Optional<PlayerVideoTrack> getSelectedVideoTrack() {
         assertIsInPlaybackState();
         NoPlayerLog.w("Tried to get the currently playing video track but has not been implemented for MediaPlayer.");
-        return new PlayerVideoTrack(0, 0, "n/a", contentType, 0, 0, 0, 0);
+        return Optional.absent();
     }
 
     List<PlayerVideoTrack> getVideoTracks() {

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImpl.java
@@ -311,6 +311,11 @@ class AndroidMediaPlayerImpl implements NoPlayer {
     }
 
     @Override
+    public boolean selectVideoTrack(PlayerVideoTrack videoTrack) throws IllegalStateException {
+        return mediaPlayer.selectVideoTrack(videoTrack);
+    }
+
+    @Override
     public PlayerVideoTrack getSelectedVideoTrack() throws IllegalStateException {
         return mediaPlayer.getSelectedVideoTrack();
     }

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImpl.java
@@ -23,6 +23,7 @@ import com.novoda.noplayer.model.PlayerVideoTrack;
 import com.novoda.noplayer.model.Timeout;
 import com.novoda.noplayer.model.VideoDuration;
 import com.novoda.noplayer.model.VideoPosition;
+import com.novoda.utils.Optional;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -209,7 +210,7 @@ class AndroidMediaPlayerImpl implements NoPlayer {
         requestSurface(new SurfaceHolderRequester.Callback() {
             @Override
             public void onSurfaceHolderReady(SurfaceHolder surfaceHolder) {
-                mediaPlayer.prepareVideo(uri, surfaceHolder, contentType);
+                mediaPlayer.prepareVideo(uri, surfaceHolder);
             }
         });
     }
@@ -316,7 +317,7 @@ class AndroidMediaPlayerImpl implements NoPlayer {
     }
 
     @Override
-    public PlayerVideoTrack getSelectedVideoTrack() throws IllegalStateException {
+    public Optional<PlayerVideoTrack> getSelectedVideoTrack() throws IllegalStateException {
         return mediaPlayer.getSelectedVideoTrack();
     }
 

--- a/core/src/main/java/com/novoda/noplayer/model/PlayerVideoTrack.java
+++ b/core/src/main/java/com/novoda/noplayer/model/PlayerVideoTrack.java
@@ -4,20 +4,32 @@ import com.novoda.noplayer.ContentType;
 
 public class PlayerVideoTrack {
 
-    private String id;
+    private final int groupIndex;
+    private final int formatIndex;
+    private final String id;
     private final ContentType contentType;
     private final int width;
     private final int height;
     private final int fps;
     private final int bitrate;
 
-    public PlayerVideoTrack(String id, ContentType contentType, int width, int height, int fps, int bitrate) {
+    public PlayerVideoTrack(int groupIndex, int formatIndex, String id, ContentType contentType, int width, int height, int fps, int bitrate) {
+        this.groupIndex = groupIndex;
+        this.formatIndex = formatIndex;
         this.id = id;
         this.contentType = contentType;
         this.width = width;
         this.height = height;
         this.fps = fps;
         this.bitrate = bitrate;
+    }
+
+    public int groupIndex() {
+        return groupIndex;
+    }
+
+    public int formatIndex() {
+        return formatIndex;
     }
 
     public String id() {
@@ -55,6 +67,12 @@ public class PlayerVideoTrack {
 
         PlayerVideoTrack that = (PlayerVideoTrack) o;
 
+        if (groupIndex != that.groupIndex) {
+            return false;
+        }
+        if (formatIndex != that.formatIndex) {
+            return false;
+        }
         if (width != that.width) {
             return false;
         }
@@ -75,7 +93,9 @@ public class PlayerVideoTrack {
 
     @Override
     public int hashCode() {
-        int result = id != null ? id.hashCode() : 0;
+        int result = groupIndex;
+        result = 31 * result + formatIndex;
+        result = 31 * result + (id != null ? id.hashCode() : 0);
         result = 31 * result + (contentType != null ? contentType.hashCode() : 0);
         result = 31 * result + width;
         result = 31 * result + height;
@@ -87,7 +107,9 @@ public class PlayerVideoTrack {
     @Override
     public String toString() {
         return "PlayerVideoTrack{" +
-                "id='" + id + '\'' +
+                "groupIndex=" + groupIndex +
+                ", formatIndex=" + formatIndex +
+                ", id='" + id + '\'' +
                 ", contentType=" + contentType +
                 ", width=" + width +
                 ", height=" + height +

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacadeTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacadeTest.java
@@ -23,6 +23,7 @@ import com.novoda.noplayer.model.PlayerVideoTrack;
 import com.novoda.noplayer.model.PlayerVideoTrackFixture;
 import com.novoda.noplayer.model.VideoDuration;
 import com.novoda.noplayer.model.VideoPosition;
+import com.novoda.utils.Optional;
 
 import java.util.Collections;
 import java.util.List;
@@ -360,9 +361,9 @@ public class ExoPlayerFacadeTest {
                     PLAYER_VIDEO_TRACK.width(), PLAYER_VIDEO_TRACK.height(), PLAYER_VIDEO_TRACK.fps(), Collections.<byte[]>emptyList(), 0
             ));
 
-            PlayerVideoTrack videoTrack = facade.getSelectedVideoTrack();
+            Optional<PlayerVideoTrack> videoTrack = facade.getSelectedVideoTrack();
 
-            assertThat(videoTrack).isEqualTo(PLAYER_VIDEO_TRACK);
+            assertThat(videoTrack).isEqualTo(Optional.of(PLAYER_VIDEO_TRACK));
         }
 
         @Test

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacadeTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacadeTest.java
@@ -3,7 +3,6 @@ package com.novoda.noplayer.internal.exoplayer;
 import android.net.Uri;
 import android.view.SurfaceHolder;
 
-import com.google.android.exoplayer2.Format;
 import com.google.android.exoplayer2.SimpleExoPlayer;
 import com.google.android.exoplayer2.drm.DefaultDrmSessionManager;
 import com.google.android.exoplayer2.mediacodec.MediaCodecSelector;
@@ -42,6 +41,7 @@ import utils.ExceptionMatcher;
 
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -50,6 +50,9 @@ import static org.mockito.Mockito.when;
 
 @RunWith(Enclosed.class)
 public class ExoPlayerFacadeTest {
+
+    private static final boolean SELECTED = true;
+    private static final PlayerVideoTrack PLAYER_VIDEO_TRACK = PlayerVideoTrackFixture.aPlayerVideoTrack().build();
 
     private static final long TWO_MINUTES_IN_MILLIS = 120000;
     private static final long TEN_MINUTES_IN_MILLIS = 600000;
@@ -355,15 +358,21 @@ public class ExoPlayerFacadeTest {
         }
 
         @Test
-        public void whenGettingSelectedVideoTrack_thenDelegatesToExoPlayer() {
-            given(exoPlayer.getVideoFormat()).willReturn(Format.createVideoContainerFormat(
-                    PLAYER_VIDEO_TRACK.id(), "ignored", "ignored", "ignored", PLAYER_VIDEO_TRACK.bitrate(),
-                    PLAYER_VIDEO_TRACK.width(), PLAYER_VIDEO_TRACK.height(), PLAYER_VIDEO_TRACK.fps(), Collections.<byte[]>emptyList(), 0
-            ));
+        public void whenGettingSelectedVideoTrack_thenDelegatesTrackSelector() {
+            given(videoTrackSelector.getSelectedVideoTrack(eq(exoPlayer), any(RendererTypeRequester.class), any(ContentType.class))).willReturn(Optional.of(PLAYER_VIDEO_TRACK));
 
-            Optional<PlayerVideoTrack> videoTrack = facade.getSelectedVideoTrack();
+            Optional<PlayerVideoTrack> selectedVideoTrack = facade.getSelectedVideoTrack();
 
-            assertThat(videoTrack).isEqualTo(Optional.of(PLAYER_VIDEO_TRACK));
+            assertThat(selectedVideoTrack).isEqualTo(Optional.of(PLAYER_VIDEO_TRACK));
+        }
+
+        @Test
+        public void whenSelectingVideoTrack_thenDelegatesToTrackSelector() {
+            given(videoTrackSelector.selectVideoTrack(eq(PLAYER_VIDEO_TRACK), any(RendererTypeRequester.class))).willReturn(SELECTED);
+
+            boolean selectedVideoTrack = facade.selectVideoTrack(PLAYER_VIDEO_TRACK);
+
+            assertThat(selectedVideoTrack).isTrue();
         }
 
         @Test

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/mediasource/ExoPlayerVideoTrackSelectorTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/mediasource/ExoPlayerVideoTrackSelectorTest.java
@@ -1,31 +1,63 @@
 package com.novoda.noplayer.internal.exoplayer.mediasource;
 
 import com.google.android.exoplayer2.Format;
+import com.google.android.exoplayer2.SimpleExoPlayer;
 import com.google.android.exoplayer2.source.TrackGroup;
 import com.google.android.exoplayer2.source.TrackGroupArray;
+import com.google.android.exoplayer2.trackselection.MappingTrackSelector;
 import com.google.android.exoplayer2.trackselection.TrackSelection;
 import com.novoda.noplayer.ContentType;
 import com.novoda.noplayer.internal.exoplayer.RendererTypeRequester;
 import com.novoda.noplayer.model.PlayerVideoTrack;
+import com.novoda.utils.Optional;
 
-import java.util.Collections;
+import java.util.Arrays;
 import java.util.List;
 
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
 import static com.novoda.noplayer.internal.exoplayer.mediasource.VideoFormatFixture.aVideoFormat;
 import static org.fest.assertions.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 
 public class ExoPlayerVideoTrackSelectorTest {
 
-    private static final String ANY_TRACK_ID = "id1";
-    private static final Format VIDEO_FORMAT = aVideoFormat().withId(ANY_TRACK_ID).build();
+    private static final Format VIDEO_FORMAT = aVideoFormat().withId("id1").build();
+    private static final PlayerVideoTrack PLAYER_VIDEO_TRACK = new PlayerVideoTrack(
+            0,
+            0,
+            VIDEO_FORMAT.id,
+            ContentType.HLS,
+            VIDEO_FORMAT.width,
+            VIDEO_FORMAT.height,
+            (int) VIDEO_FORMAT.frameRate,
+            VIDEO_FORMAT.bitrate
+    );
+
+    private static final Format ADDITIONAL_VIDEO_FORMAT = aVideoFormat().withId("id2").build();
+    private static final int FIRST_GROUP = 0;
+    private static final int SECOND_TRACK = 1;
+    private static final PlayerVideoTrack ADDITIONAL_PLAYER_VIDEO_TRACK = new PlayerVideoTrack(
+            FIRST_GROUP,
+            SECOND_TRACK,
+            ADDITIONAL_VIDEO_FORMAT.id,
+            ContentType.HLS,
+            ADDITIONAL_VIDEO_FORMAT.width,
+            ADDITIONAL_VIDEO_FORMAT.height,
+            (int) ADDITIONAL_VIDEO_FORMAT.frameRate,
+            ADDITIONAL_VIDEO_FORMAT.bitrate
+    );
+
+    private static final List<PlayerVideoTrack> EXPECTED_TRACKS = Arrays.asList(PLAYER_VIDEO_TRACK, ADDITIONAL_PLAYER_VIDEO_TRACK);
 
     @Rule
     public MockitoRule mockitoRule = MockitoJUnit.rule();
@@ -36,6 +68,8 @@ public class ExoPlayerVideoTrackSelectorTest {
     private TrackSelection.Factory trackSelectionFactory;
     @Mock
     private RendererTypeRequester rendererTypeRequester;
+    @Mock
+    private SimpleExoPlayer exoPlayer;
 
     private ExoPlayerVideoTrackSelector exoPlayerVideoTrackSelector;
 
@@ -45,33 +79,58 @@ public class ExoPlayerVideoTrackSelectorTest {
     }
 
     @Test
-    public void givenTrackSelectorContainsUnsupportedTracks_whenGettingVideoTracks_thenReturnsSupportedTracks() {
+    public void givenTrackSelectorContainsTracks_whenSelectingVideoTrack_thenSelectsTrack() {
+        givenTrackSelectorContainsTracks();
+
+        ArgumentCaptor<MappingTrackSelector.SelectionOverride> argumentCaptor = whenSelectingVideoTrack(ADDITIONAL_PLAYER_VIDEO_TRACK);
+
+        MappingTrackSelector.SelectionOverride selectionOverride = argumentCaptor.getValue();
+        assertThat(selectionOverride.factory).isEqualTo(trackSelectionFactory);
+        assertThat(selectionOverride.groupIndex).isEqualTo(FIRST_GROUP);
+        assertThat(selectionOverride.tracks).contains(SECOND_TRACK);
+    }
+
+    @Test
+    public void givenTrackSelector_whenGettingVideoTracks_thenReturnsSupportedTracks() {
         givenTrackSelectorContainsTracks();
 
         List<PlayerVideoTrack> actualVideoTracks = exoPlayerVideoTrackSelector.getVideoTracks(rendererTypeRequester, ContentType.HLS);
 
-        assertThat(actualVideoTracks).isEqualTo(expectedSupportedVideoTracks());
+        assertThat(actualVideoTracks).isEqualTo(EXPECTED_TRACKS);
+    }
+
+    @Test
+    public void givenTrackSelector_whenGettingCurrentlySelectedVideoTrack_thenReturnsSelectedTrack() {
+        givenTrackSelectorContainsTracks();
+        given(exoPlayer.getVideoFormat()).willReturn(ADDITIONAL_VIDEO_FORMAT);
+
+        Optional<PlayerVideoTrack> selectedVideoTrack = exoPlayerVideoTrackSelector.getSelectedVideoTrack(exoPlayer, rendererTypeRequester, ContentType.HLS);
+
+        assertThat(selectedVideoTrack).isEqualTo(Optional.of(ADDITIONAL_PLAYER_VIDEO_TRACK));
+    }
+
+    @Test
+    public void givenNoCurrentlySelectedTrack_whenGettingCurrentlySelectedVideoTrack_thenReturnsAbsent() {
+        givenTrackSelectorContainsTracks();
+        given(exoPlayer.getVideoFormat()).willReturn(null);
+
+        Optional<PlayerVideoTrack> selectedVideoTrack = exoPlayerVideoTrackSelector.getSelectedVideoTrack(exoPlayer, rendererTypeRequester, ContentType.HLS);
+
+        assertThat(selectedVideoTrack).isEqualTo(Optional.<PlayerVideoTrack>absent());
     }
 
     private void givenTrackSelectorContainsTracks() {
         TrackGroupArray trackGroups = new TrackGroupArray(
-                new TrackGroup(VIDEO_FORMAT)
+                new TrackGroup(VIDEO_FORMAT, ADDITIONAL_VIDEO_FORMAT)
         );
         given(trackSelector.trackGroups(TrackType.VIDEO, rendererTypeRequester)).willReturn(trackGroups);
     }
 
-    private List<PlayerVideoTrack> expectedSupportedVideoTracks() {
-        return Collections.singletonList(
-                new PlayerVideoTrack(
-                        0,
-                        0,
-                        VIDEO_FORMAT.id,
-                        ContentType.HLS,
-                        VIDEO_FORMAT.width,
-                        VIDEO_FORMAT.height,
-                        (int) VIDEO_FORMAT.frameRate,
-                        VIDEO_FORMAT.bitrate
-                )
-        );
+    private ArgumentCaptor<MappingTrackSelector.SelectionOverride> whenSelectingVideoTrack(PlayerVideoTrack videoTrack) {
+        exoPlayerVideoTrackSelector.selectVideoTrack(videoTrack, rendererTypeRequester);
+
+        ArgumentCaptor<MappingTrackSelector.SelectionOverride> argumentCaptor = ArgumentCaptor.forClass(MappingTrackSelector.SelectionOverride.class);
+        verify(trackSelector).setSelectionOverride(eq(TrackType.VIDEO), any(RendererTypeRequester.class), any(TrackGroupArray.class), argumentCaptor.capture());
+        return argumentCaptor;
     }
 }

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/mediasource/ExoPlayerVideoTrackSelectorTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/mediasource/ExoPlayerVideoTrackSelectorTest.java
@@ -41,7 +41,7 @@ public class ExoPlayerVideoTrackSelectorTest {
 
     @Before
     public void setUp() {
-        exoPlayerVideoTrackSelector = new ExoPlayerVideoTrackSelector(trackSelector);
+        exoPlayerVideoTrackSelector = new ExoPlayerVideoTrackSelector(trackSelector, trackSelectionFactory);
     }
 
     @Test
@@ -63,6 +63,8 @@ public class ExoPlayerVideoTrackSelectorTest {
     private List<PlayerVideoTrack> expectedSupportedVideoTracks() {
         return Collections.singletonList(
                 new PlayerVideoTrack(
+                        0,
+                        0,
                         VIDEO_FORMAT.id,
                         ContentType.HLS,
                         VIDEO_FORMAT.width,

--- a/core/src/test/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerFacadeTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerFacadeTest.java
@@ -6,7 +6,6 @@ import android.media.MediaPlayer;
 import android.net.Uri;
 import android.view.SurfaceHolder;
 
-import com.novoda.noplayer.ContentType;
 import com.novoda.noplayer.SurfaceHolderRequester;
 import com.novoda.noplayer.internal.mediaplayer.forwarder.MediaPlayerForwarder;
 import com.novoda.noplayer.model.AudioTracks;
@@ -140,8 +139,8 @@ public class AndroidMediaPlayerFacadeTest {
 
     @Test
     public void whenPreparingMultipleTimes_thenReleasesMediaPlayer() {
-        facade.prepareVideo(ANY_URI, surfaceHolder, ContentType.HLS);
-        facade.prepareVideo(ANY_URI, surfaceHolder, ContentType.HLS);
+        facade.prepareVideo(ANY_URI, surfaceHolder);
+        facade.prepareVideo(ANY_URI, surfaceHolder);
 
         verify(mediaPlayer).reset();
         verify(mediaPlayer).release();
@@ -199,7 +198,7 @@ public class AndroidMediaPlayerFacadeTest {
 
     @Test
     public void givenBoundPreparedListener_andMediaPlayerIsPrepared_whenPrepared_thenForwardsOnPrepared() {
-        facade.prepareVideo(ANY_URI, surfaceHolder, ContentType.HLS);
+        facade.prepareVideo(ANY_URI, surfaceHolder);
         ArgumentCaptor<MediaPlayer.OnPreparedListener> argumentCaptor = ArgumentCaptor.forClass(MediaPlayer.OnPreparedListener.class);
         verify(mediaPlayer).setOnPreparedListener(argumentCaptor.capture());
         argumentCaptor.getValue().onPrepared(mediaPlayer);
@@ -562,7 +561,7 @@ public class AndroidMediaPlayerFacadeTest {
     }
 
     private void givenMediaPlayerIsPrepared() {
-        facade.prepareVideo(ANY_URI, surfaceHolder, ContentType.HLS);
+        facade.prepareVideo(ANY_URI, surfaceHolder);
         ArgumentCaptor<MediaPlayer.OnPreparedListener> argumentCaptor = ArgumentCaptor.forClass(MediaPlayer.OnPreparedListener.class);
         verify(mediaPlayer).setOnPreparedListener(argumentCaptor.capture());
         argumentCaptor.getValue().onPrepared(mediaPlayer);

--- a/core/src/test/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImplTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImplTest.java
@@ -433,7 +433,7 @@ public class AndroidMediaPlayerImplTest {
         public void whenLoadingVideo_thenPreparesVideo() {
             player.loadVideo(URI, ContentType.HLS);
 
-            verify(mediaPlayer).prepareVideo(URI, surfaceHolder, ContentType.HLS);
+            verify(mediaPlayer).prepareVideo(URI, surfaceHolder);
         }
 
         @Test
@@ -447,7 +447,7 @@ public class AndroidMediaPlayerImplTest {
         public void whenLoadingVideoWithTimeout_thenPreparesVideo() {
             player.loadVideoWithTimeout(URI, ContentType.HLS, ANY_TIMEOUT, ANY_LOAD_TIMEOUT_CALLBACK);
 
-            verify(mediaPlayer).prepareVideo(URI, surfaceHolder, ContentType.HLS);
+            verify(mediaPlayer).prepareVideo(URI, surfaceHolder);
         }
 
         @Test

--- a/core/src/test/java/com/novoda/noplayer/model/PlayerVideoTrackFixture.java
+++ b/core/src/test/java/com/novoda/noplayer/model/PlayerVideoTrackFixture.java
@@ -4,6 +4,8 @@ import com.novoda.noplayer.ContentType;
 
 public class PlayerVideoTrackFixture {
 
+    private int groupIndex = 0;
+    private int formatIndex = 0;
     private String id = "id";
     private ContentType contentType = ContentType.DASH;
     private int width = 1920;
@@ -17,6 +19,16 @@ public class PlayerVideoTrackFixture {
 
     private PlayerVideoTrackFixture() {
         // Uses static factory method.
+    }
+
+    public PlayerVideoTrackFixture withGroupIndex(int groupIndex) {
+        this.groupIndex = groupIndex;
+        return this;
+    }
+
+    public PlayerVideoTrackFixture withFormatIndex(int formatIndex) {
+        this.formatIndex = formatIndex;
+        return this;
     }
 
     public PlayerVideoTrackFixture withId(String id) {
@@ -50,6 +62,6 @@ public class PlayerVideoTrackFixture {
     }
 
     public PlayerVideoTrack build() {
-        return new PlayerVideoTrack(id, contentType, width, height, fps, bitrate);
+        return new PlayerVideoTrack(groupIndex, formatIndex, id, contentType, width, height, fps, bitrate);
     }
 }

--- a/demo/src/main/java/com/novoda/demo/MainActivity.java
+++ b/demo/src/main/java/com/novoda/demo/MainActivity.java
@@ -17,6 +17,7 @@ import com.novoda.noplayer.PlayerView;
 import com.novoda.noplayer.model.AudioTracks;
 import com.novoda.noplayer.model.PlayerAudioTrack;
 import com.novoda.noplayer.model.PlayerSubtitleTrack;
+import com.novoda.noplayer.model.PlayerVideoTrack;
 import com.novoda.utils.NoPlayerLog;
 
 import java.util.ArrayList;
@@ -39,9 +40,11 @@ public class MainActivity extends Activity {
         NoPlayerLog.setLoggingEnabled(true);
         setContentView(R.layout.activity_main);
         PlayerView playerView = (PlayerView) findViewById(R.id.player_view);
+        View videoSelectionButton = findViewById(R.id.button_video_selection);
         View audioSelectionButton = findViewById(R.id.button_audio_selection);
         View subtitleSelectionButton = findViewById(R.id.button_subtitle_selection);
 
+        videoSelectionButton.setOnClickListener(showVideoSelectionDialog);
         audioSelectionButton.setOnClickListener(showAudioSelectionDialog);
         subtitleSelectionButton.setOnClickListener(showSubtitleSelectionDialog);
 
@@ -69,6 +72,41 @@ public class MainActivity extends Activity {
         Uri uri = Uri.parse(URI_VIDEO_WIDEVINE_EXAMPLE_MODULAR_MPD);
         player.loadVideo(uri, ContentType.DASH);
     }
+
+    private final View.OnClickListener showVideoSelectionDialog = new View.OnClickListener() {
+        @Override
+        public void onClick(View v) {
+            if (player.getVideoTracks().isEmpty()) {
+                Toast.makeText(MainActivity.this, "no additional video tracks available!", Toast.LENGTH_LONG).show();
+            } else {
+                showVideoSelectionDialog();
+            }
+        }
+
+        private void showVideoSelectionDialog() {
+            final List<PlayerVideoTrack> videoTracks = player.getVideoTracks();
+            ArrayAdapter<String> adapter = new ArrayAdapter<>(MainActivity.this, R.layout.list_item);
+            adapter.addAll(mapVideoTrackToLabel(videoTracks));
+            AlertDialog videoTrackSelectionDialog = new AlertDialog.Builder(MainActivity.this)
+                    .setTitle("Select Video track")
+                    .setAdapter(adapter, new DialogInterface.OnClickListener() {
+                        @Override
+                        public void onClick(DialogInterface dialog, int position) {
+                            PlayerVideoTrack videoTrack = videoTracks.get(position);
+                            player.selectVideoTrack(videoTrack);
+                        }
+                    }).create();
+            videoTrackSelectionDialog.show();
+        }
+
+        private List<String> mapVideoTrackToLabel(List<PlayerVideoTrack> videoTracks) {
+            List<String> labels = new ArrayList<>();
+            for (PlayerVideoTrack videoTrack : videoTracks) {
+                labels.add("Quality " + videoTrack.height());
+            }
+            return labels;
+        }
+    };
 
     private final View.OnClickListener showAudioSelectionDialog = new View.OnClickListener() {
 

--- a/demo/src/main/res/layout/activity_main.xml
+++ b/demo/src/main/res/layout/activity_main.xml
@@ -12,6 +12,12 @@
       android:orientation="horizontal">
 
       <Button
+        android:id="@+id/button_video_selection"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Video" />
+
+      <Button
         android:id="@+id/button_audio_selection"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"


### PR DESCRIPTION
## Problem
We can get a list of the currently supported as well as the currently selected video track but we cannot select any of them on the fly 😱 

## Solution
Add a dialog for selecting the desired video track.

### Test(s) added 
Yes, updated the underlying facade tests as well as creating tests for the newly created selectors.

### Screenshots
![video](https://user-images.githubusercontent.com/3380092/32194918-a6cdb166-bdb3-11e7-892d-29c845702239.gif)


### Paired with 
Nobody.
