### PR TITLE
Clear track selections

### DIFF
--- a/core/src/main/java/com/novoda/noplayer/NoPlayer.java
+++ b/core/src/main/java/com/novoda/noplayer/NoPlayer.java
@@ -104,6 +104,15 @@ public interface NoPlayer extends PlayerState {
     void detach(PlayerView playerView);
 
     /**
+     * Retrieves all of the available {@link PlayerVideoTrack} of a prepared Player.
+     *
+     * @return a list of available {@link PlayerVideoTrack} of a prepared Player.
+     * @throws IllegalStateException - if called before {@link NoPlayer#loadVideo(Uri, ContentType)}.
+     * @see NoPlayer.PreparedListener
+     */
+    List<PlayerVideoTrack> getVideoTracks() throws IllegalStateException;
+
+    /**
      * Selects a given {@link PlayerVideoTrack}.
      *
      * @param videoTrack the video track to select.
@@ -123,13 +132,12 @@ public interface NoPlayer extends PlayerState {
     Optional<PlayerVideoTrack> getSelectedVideoTrack() throws IllegalStateException;
 
     /**
-     * Retrieves all of the available {@link PlayerVideoTrack} of a prepared Player.
+     * Clears the {@link PlayerVideoTrack} selection made in {@link NoPlayer#selectVideoTrack(PlayerVideoTrack)}.
      *
-     * @return a list of available {@link PlayerVideoTrack} of a prepared Player.
+     * @return whether the clear was successful.
      * @throws IllegalStateException - if called before {@link NoPlayer#loadVideo(Uri, ContentType)}.
-     * @see NoPlayer.PreparedListener
      */
-    List<PlayerVideoTrack> getVideoTracks() throws IllegalStateException;
+    boolean clearVideoTrackSelection() throws IllegalStateException;
 
     /**
      * Retrieves all of the available {@link PlayerAudioTrack} of a prepared Player.
@@ -167,7 +175,7 @@ public interface NoPlayer extends PlayerState {
     List<PlayerSubtitleTrack> getSubtitleTracks() throws IllegalStateException;
 
     /**
-     * Selects a given {@link PlayerSubtitleTrack} on an attached PlayerView.
+     * Selects and shows a given {@link PlayerSubtitleTrack} on an attached PlayerView.
      *
      * @param subtitleTrack the subtitle track to select.
      * @return whether the selection was successful.

--- a/core/src/main/java/com/novoda/noplayer/NoPlayer.java
+++ b/core/src/main/java/com/novoda/noplayer/NoPlayer.java
@@ -170,9 +170,10 @@ public interface NoPlayer extends PlayerState {
     /**
      * Clear and hide the subtitles on an attached PlayerView.
      *
+     * @return whether the hide was successful.
      * @throws IllegalStateException - if called before {@link NoPlayer#loadVideo(Uri, ContentType)}.
      */
-    void hideSubtitleTrack() throws IllegalStateException;
+    boolean hideSubtitleTrack() throws IllegalStateException;
 
     /**
      * Retrieves a holder, which allows you to add and remove listeners to on the Player.

--- a/core/src/main/java/com/novoda/noplayer/NoPlayer.java
+++ b/core/src/main/java/com/novoda/noplayer/NoPlayer.java
@@ -104,15 +104,6 @@ public interface NoPlayer extends PlayerState {
     void detach(PlayerView playerView);
 
     /**
-     * Retrieves all of the available {@link PlayerAudioTrack} of a prepared Player.
-     *
-     * @return {@link AudioTracks} that contains a list of available {@link PlayerAudioTrack}.
-     * @throws IllegalStateException - if called before {@link NoPlayer#loadVideo(Uri, ContentType)}.
-     * @see NoPlayer.PreparedListener
-     */
-    AudioTracks getAudioTracks() throws IllegalStateException;
-
-    /**
      * Selects a given {@link PlayerVideoTrack}.
      *
      * @param videoTrack the video track to select.
@@ -141,6 +132,15 @@ public interface NoPlayer extends PlayerState {
     List<PlayerVideoTrack> getVideoTracks() throws IllegalStateException;
 
     /**
+     * Retrieves all of the available {@link PlayerAudioTrack} of a prepared Player.
+     *
+     * @return {@link AudioTracks} that contains a list of available {@link PlayerAudioTrack}.
+     * @throws IllegalStateException - if called before {@link NoPlayer#loadVideo(Uri, ContentType)}.
+     * @see NoPlayer.PreparedListener
+     */
+    AudioTracks getAudioTracks() throws IllegalStateException;
+
+    /**
      * Selects a given {@link PlayerAudioTrack}.
      *
      * @param audioTrack the audio track to select.
@@ -148,6 +148,14 @@ public interface NoPlayer extends PlayerState {
      * @throws IllegalStateException - if called before {@link NoPlayer#loadVideo(Uri, ContentType)}.
      */
     boolean selectAudioTrack(PlayerAudioTrack audioTrack) throws IllegalStateException;
+
+    /**
+     * Clears the {@link PlayerAudioTrack} selection made in {@link NoPlayer#selectAudioTrack(PlayerAudioTrack)}.
+     *
+     * @return whether the clear was successful.
+     * @throws IllegalStateException - if called before {@link NoPlayer#loadVideo(Uri, ContentType)}.
+     */
+    boolean clearAudioTrackSelection() throws IllegalStateException;
 
     /**
      * Retrieves all of the available {@link PlayerSubtitleTrack} of a prepared Player.

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
@@ -128,14 +128,19 @@ class ExoPlayerFacade {
         exoPlayer.setVideoSurfaceHolder(surfaceHolder);
     }
 
+    AudioTracks getAudioTracks() throws IllegalStateException {
+        assertVideoLoaded();
+        return audioTrackSelector.getAudioTracks(rendererTypeRequester);
+    }
+
     boolean selectAudioTrack(PlayerAudioTrack audioTrack) throws IllegalStateException {
         assertVideoLoaded();
         return audioTrackSelector.selectAudioTrack(audioTrack, rendererTypeRequester);
     }
 
-    AudioTracks getAudioTracks() throws IllegalStateException {
+    boolean clearAudioTrackSelection() {
         assertVideoLoaded();
-        return audioTrackSelector.getAudioTracks(rendererTypeRequester);
+        return audioTrackSelector.clearAudioTrack(rendererTypeRequester);
     }
 
     boolean selectVideoTrack(PlayerVideoTrack playerVideoTrack) {
@@ -177,7 +182,7 @@ class ExoPlayerFacade {
         return exoPlayer != null;
     }
 
-    boolean clearSubtitleTrack() throws IllegalStateException {
+    boolean clearSubtitleTrackSelection() throws IllegalStateException {
         assertVideoLoaded();
         return subtitleTrackSelector.clearSubtitleTrack(rendererTypeRequester);
     }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
@@ -177,9 +177,9 @@ class ExoPlayerFacade {
         return exoPlayer != null;
     }
 
-    void clearSubtitleTrack() throws IllegalStateException {
+    boolean clearSubtitleTrack() throws IllegalStateException {
         assertVideoLoaded();
-        subtitleTrackSelector.clearSubtitleTrack(rendererTypeRequester);
+        return subtitleTrackSelector.clearSubtitleTrack(rendererTypeRequester);
     }
 
     private void assertVideoLoaded() {

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
@@ -158,6 +158,11 @@ class ExoPlayerFacade {
         return exoPlayerVideoTrackSelector.getVideoTracks(rendererTypeRequester, contentType);
     }
 
+    boolean clearVideoTrackSelection() {
+        assertVideoLoaded();
+        return exoPlayerVideoTrackSelector.clearVideoTrack(rendererTypeRequester);
+    }
+
     void setSubtitleRendererOutput(TextRendererOutput textRendererOutput) throws IllegalStateException {
         assertVideoLoaded();
         exoPlayer.setTextOutput(textRendererOutput.output());

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImpl.java
@@ -252,10 +252,10 @@ class ExoPlayerTwoImpl implements NoPlayer {
     }
 
     @Override
-    public void hideSubtitleTrack() throws IllegalStateException {
-        exoPlayer.clearSubtitleTrack();
+    public boolean hideSubtitleTrack() throws IllegalStateException {
         playerView.hideSubtitles();
         exoPlayer.removeSubtitleRendererOutput();
+        return exoPlayer.clearSubtitleTrack();
     }
 
     @Override

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImpl.java
@@ -240,6 +240,11 @@ class ExoPlayerTwoImpl implements NoPlayer {
     }
 
     @Override
+    public boolean clearAudioTrackSelection() throws IllegalStateException {
+        return exoPlayer.clearAudioTrackSelection();
+    }
+
+    @Override
     public boolean showSubtitleTrack(PlayerSubtitleTrack subtitleTrack) throws IllegalStateException {
         setSubtitleRendererOutput();
         playerView.showSubtitles();
@@ -255,7 +260,7 @@ class ExoPlayerTwoImpl implements NoPlayer {
     public boolean hideSubtitleTrack() throws IllegalStateException {
         playerView.hideSubtitles();
         exoPlayer.removeSubtitleRendererOutput();
-        return exoPlayer.clearSubtitleTrack();
+        return exoPlayer.clearSubtitleTrackSelection();
     }
 
     @Override

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImpl.java
@@ -279,6 +279,11 @@ class ExoPlayerTwoImpl implements NoPlayer {
     }
 
     @Override
+    public boolean clearVideoTrackSelection() throws IllegalStateException {
+        return exoPlayer.clearVideoTrackSelection();
+    }
+
+    @Override
     public List<PlayerVideoTrack> getVideoTracks() throws IllegalStateException {
         return exoPlayer.getVideoTracks();
     }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/mediasource/ExoPlayerAudioTrackSelector.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/mediasource/ExoPlayerAudioTrackSelector.java
@@ -64,4 +64,8 @@ public class ExoPlayerAudioTrackSelector {
 
         return AudioTracks.from(audioTracks);
     }
+
+    public boolean clearAudioTrack(RendererTypeRequester rendererTypeRequester) {
+        return trackSelector.clearSelectionOverrideFor(AUDIO, rendererTypeRequester);
+    }
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/mediasource/ExoPlayerSubtitleTrackSelector.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/mediasource/ExoPlayerSubtitleTrackSelector.java
@@ -5,8 +5,8 @@ import com.google.android.exoplayer2.source.TrackGroup;
 import com.google.android.exoplayer2.source.TrackGroupArray;
 import com.google.android.exoplayer2.trackselection.MappingTrackSelector;
 import com.google.android.exoplayer2.trackselection.TrackSelection;
-import com.novoda.noplayer.model.PlayerSubtitleTrack;
 import com.novoda.noplayer.internal.exoplayer.RendererTypeRequester;
+import com.novoda.noplayer.model.PlayerSubtitleTrack;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -60,7 +60,7 @@ public class ExoPlayerSubtitleTrackSelector {
         return subtitleTracks;
     }
 
-    public void clearSubtitleTrack(RendererTypeRequester rendererTypeRequester) {
-        trackSelector.clearSelectionOverrideFor(TEXT, rendererTypeRequester);
+    public boolean clearSubtitleTrack(RendererTypeRequester rendererTypeRequester) {
+        return trackSelector.clearSelectionOverrideFor(TEXT, rendererTypeRequester);
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/mediasource/ExoPlayerTrackSelector.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/mediasource/ExoPlayerTrackSelector.java
@@ -27,10 +27,14 @@ public class ExoPlayerTrackSelector {
         return audioRendererIndex.isAbsent() ? TrackGroupArray.EMPTY : trackInfo().getTrackGroups(audioRendererIndex.get());
     }
 
-    void clearSelectionOverrideFor(TrackType trackType, RendererTypeRequester rendererTypeRequester) {
-        Optional<Integer> audioRendererIndex = rendererTrackIndexExtractor.extract(trackType, mappedTrackInfoLength(), rendererTypeRequester);
-        if (audioRendererIndex.isPresent()) {
-            trackSelector.clearSelectionOverrides(audioRendererIndex.get());
+    boolean clearSelectionOverrideFor(TrackType trackType,
+                                      RendererTypeRequester rendererTypeRequester) {
+        Optional<Integer> rendererIndex = rendererTrackIndexExtractor.extract(trackType, mappedTrackInfoLength(), rendererTypeRequester);
+        if (rendererIndex.isPresent()) {
+            trackSelector.clearSelectionOverrides(rendererIndex.get());
+            return true;
+        } else {
+            return false;
         }
     }
 
@@ -51,9 +55,9 @@ public class ExoPlayerTrackSelector {
                                  RendererTypeRequester rendererTypeRequester,
                                  TrackGroupArray trackGroups,
                                  MappingTrackSelector.SelectionOverride selectionOverride) {
-        Optional<Integer> audioRendererIndex = rendererTrackIndexExtractor.extract(trackType, mappedTrackInfoLength(), rendererTypeRequester);
-        if (audioRendererIndex.isPresent()) {
-            trackSelector.setSelectionOverride(audioRendererIndex.get(), trackGroups, selectionOverride);
+        Optional<Integer> rendererIndex = rendererTrackIndexExtractor.extract(trackType, mappedTrackInfoLength(), rendererTypeRequester);
+        if (rendererIndex.isPresent()) {
+            trackSelector.setSelectionOverride(rendererIndex.get(), trackGroups, selectionOverride);
             return true;
         } else {
             return false;

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/mediasource/ExoPlayerTrackSelector.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/mediasource/ExoPlayerTrackSelector.java
@@ -27,8 +27,7 @@ public class ExoPlayerTrackSelector {
         return audioRendererIndex.isAbsent() ? TrackGroupArray.EMPTY : trackInfo().getTrackGroups(audioRendererIndex.get());
     }
 
-    boolean clearSelectionOverrideFor(TrackType trackType,
-                                      RendererTypeRequester rendererTypeRequester) {
+    boolean clearSelectionOverrideFor(TrackType trackType, RendererTypeRequester rendererTypeRequester) {
         Optional<Integer> rendererIndex = rendererTrackIndexExtractor.extract(trackType, mappedTrackInfoLength(), rendererTypeRequester);
         if (rendererIndex.isPresent()) {
             trackSelector.clearSelectionOverrides(rendererIndex.get());

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/mediasource/ExoPlayerVideoTrackSelector.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/mediasource/ExoPlayerVideoTrackSelector.java
@@ -85,4 +85,8 @@ public class ExoPlayerVideoTrackSelector {
         }
         return Optional.absent();
     }
+
+    public boolean clearVideoTrack(RendererTypeRequester rendererTypeRequester) {
+        return trackSelector.clearSelectionOverrideFor(VIDEO, rendererTypeRequester);
+    }
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerFacade.java
@@ -220,6 +220,12 @@ class AndroidMediaPlayerFacade {
         return trackSelector.selectAudioTrack(mediaPlayer, playerAudioTrack);
     }
 
+    boolean clearAudioTrackSelection() {
+        assertIsInPlaybackState();
+        NoPlayerLog.w("Tried to clear audio track selection but has not been implemented for MediaPlayer.");
+        return false;
+    }
+
     void setOnSeekCompleteListener(MediaPlayer.OnSeekCompleteListener seekToResettingSeekListener) throws IllegalStateException {
         assertIsInPlaybackState();
         mediaPlayer.setOnSeekCompleteListener(seekToResettingSeekListener);

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerFacade.java
@@ -233,9 +233,10 @@ class AndroidMediaPlayerFacade {
         return mediaPlayer != null;
     }
 
-    void clearSubtitleTrack() throws IllegalStateException {
+    boolean clearSubtitleTrack() throws IllegalStateException {
         assertIsInPlaybackState();
         NoPlayerLog.w("Tried to hide subtitle track but has not been implemented for MediaPlayer.");
+        return false;
     }
 
     boolean selectSubtitleTrack(PlayerSubtitleTrack subtitleTrack) throws IllegalStateException {

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerFacade.java
@@ -280,4 +280,10 @@ class AndroidMediaPlayerFacade {
         NoPlayerLog.w("Tried to select a video track but has not been implemented for MediaPlayer.");
         return false;
     }
+
+    boolean clearVideoTrackSelection() {
+        assertIsInPlaybackState();
+        NoPlayerLog.w("Tried to clear video track selection but has not been implemented for MediaPlayer.");
+        return false;
+    }
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImpl.java
@@ -327,6 +327,11 @@ class AndroidMediaPlayerImpl implements NoPlayer {
     }
 
     @Override
+    public boolean clearVideoTrackSelection() throws IllegalStateException {
+        return mediaPlayer.clearVideoTrackSelection();
+    }
+
+    @Override
     public List<PlayerVideoTrack> getVideoTracks() throws IllegalStateException {
         return mediaPlayer.getVideoTracks();
     }

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImpl.java
@@ -297,6 +297,11 @@ class AndroidMediaPlayerImpl implements NoPlayer {
     }
 
     @Override
+    public boolean clearAudioTrackSelection() throws IllegalStateException {
+        return mediaPlayer.clearAudioTrackSelection();
+    }
+
+    @Override
     public boolean showSubtitleTrack(PlayerSubtitleTrack subtitleTrack) throws IllegalStateException {
         return mediaPlayer.selectSubtitleTrack(subtitleTrack);
     }

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImpl.java
@@ -302,8 +302,8 @@ class AndroidMediaPlayerImpl implements NoPlayer {
     }
 
     @Override
-    public void hideSubtitleTrack() throws IllegalStateException {
-        mediaPlayer.clearSubtitleTrack();
+    public boolean hideSubtitleTrack() throws IllegalStateException {
+        return mediaPlayer.clearSubtitleTrack();
     }
 
     @Override

--- a/demo/src/main/java/com/novoda/demo/MainActivity.java
+++ b/demo/src/main/java/com/novoda/demo/MainActivity.java
@@ -96,14 +96,11 @@ public class MainActivity extends Activity {
                     .setAdapter(adapter, new DialogInterface.OnClickListener() {
                         @Override
                         public void onClick(DialogInterface dialog, int position) {
-                            switch (position) {
-                                case 0:
-                                    player.clearVideoTrackSelection();
-                                    break;
-                                default:
-                                    PlayerVideoTrack videoTrack = videoTracks.get(position - 1);
-                                    player.selectVideoTrack(videoTrack);
-                                    break;
+                            if (position == 0) {
+                                player.clearVideoTrackSelection();
+                            } else {
+                                PlayerVideoTrack videoTrack = videoTracks.get(position - 1);
+                                player.selectVideoTrack(videoTrack);
                             }
                         }
                     }).create();
@@ -137,14 +134,11 @@ public class MainActivity extends Activity {
                     .setAdapter(adapter, new DialogInterface.OnClickListener() {
                         @Override
                         public void onClick(DialogInterface dialog, int position) {
-                            switch (position) {
-                                case 0:
-                                    player.clearAudioTrackSelection();
-                                    break;
-                                default:
-                                    PlayerAudioTrack audioTrack = audioTracks.get(position - 1);
-                                    player.selectAudioTrack(audioTrack);
-                                    break;
+                            if (position == 0) {
+                                player.clearAudioTrackSelection();
+                            } else {
+                                PlayerAudioTrack audioTrack = audioTracks.get(position - 1);
+                                player.selectAudioTrack(audioTrack);
                             }
                         }
                     }).create();
@@ -186,14 +180,11 @@ public class MainActivity extends Activity {
                     .setAdapter(adapter, new DialogInterface.OnClickListener() {
                         @Override
                         public void onClick(DialogInterface dialog, int position) {
-                            switch (position) {
-                                case 0:
-                                    player.hideSubtitleTrack();
-                                    break;
-                                default:
-                                    PlayerSubtitleTrack subtitleTrack = subtitleTracks.get(position - 1);
-                                    player.showSubtitleTrack(subtitleTrack);
-                                    break;
+                            if (position == 0) {
+                                player.hideSubtitleTrack();
+                            } else {
+                                PlayerSubtitleTrack subtitleTrack = subtitleTracks.get(position - 1);
+                                player.showSubtitleTrack(subtitleTrack);
                             }
                         }
                     }).create();

--- a/demo/src/main/java/com/novoda/demo/MainActivity.java
+++ b/demo/src/main/java/com/novoda/demo/MainActivity.java
@@ -54,6 +54,7 @@ public class MainActivity extends Activity {
         DataPostingModularDrm drmHandler = new DataPostingModularDrm(EXAMPLE_MODULAR_LICENSE_SERVER_PROXY);
 
         player = new PlayerBuilder()
+                .withWidevineModularStreamingDrm(drmHandler)
                 .withDowngradedSecureDecoder()
                 .build(this);
 
@@ -71,7 +72,7 @@ public class MainActivity extends Activity {
     protected void onStart() {
         super.onStart();
         // TODO: Add switch in UI to avoid redeploy.
-        Uri uri = Uri.parse(URI_VIDEO_MPD);
+        Uri uri = Uri.parse(URI_VIDEO_WIDEVINE_EXAMPLE_MODULAR_MPD);
         player.loadVideo(uri, ContentType.DASH);
     }
 

--- a/demo/src/main/java/com/novoda/demo/MainActivity.java
+++ b/demo/src/main/java/com/novoda/demo/MainActivity.java
@@ -26,6 +26,9 @@ import java.util.Locale;
 
 public class MainActivity extends Activity {
 
+    private static final String VIDEO_TRACK_MESSAGE_FORMAT = "ID: %s Quality: %s";
+    private static final String AUDIO_TRACK_MESSAGE_FORMAT = "ID: %s Type: %s";
+
     private static final String URI_VIDEO_MP4 = "http://yt-dash-mse-test.commondatastorage.googleapis.com/media/car-20120827-85.mp4";
     private static final String URI_VIDEO_MPD = "https://storage.googleapis.com/content-samples/multi-audio/manifest.mpd";
 
@@ -51,7 +54,6 @@ public class MainActivity extends Activity {
         DataPostingModularDrm drmHandler = new DataPostingModularDrm(EXAMPLE_MODULAR_LICENSE_SERVER_PROXY);
 
         player = new PlayerBuilder()
-                .withWidevineModularStreamingDrm(drmHandler)
                 .withDowngradedSecureDecoder()
                 .build(this);
 
@@ -69,7 +71,7 @@ public class MainActivity extends Activity {
     protected void onStart() {
         super.onStart();
         // TODO: Add switch in UI to avoid redeploy.
-        Uri uri = Uri.parse(URI_VIDEO_WIDEVINE_EXAMPLE_MODULAR_MPD);
+        Uri uri = Uri.parse(URI_VIDEO_MPD);
         player.loadVideo(uri, ContentType.DASH);
     }
 
@@ -85,6 +87,7 @@ public class MainActivity extends Activity {
 
         private void showVideoSelectionDialog() {
             final List<PlayerVideoTrack> videoTracks = player.getVideoTracks();
+
             ArrayAdapter<String> adapter = new ArrayAdapter<>(MainActivity.this, R.layout.list_item);
             adapter.addAll(mapVideoTrackToLabel(videoTracks));
             AlertDialog videoTrackSelectionDialog = new AlertDialog.Builder(MainActivity.this)
@@ -92,8 +95,15 @@ public class MainActivity extends Activity {
                     .setAdapter(adapter, new DialogInterface.OnClickListener() {
                         @Override
                         public void onClick(DialogInterface dialog, int position) {
-                            PlayerVideoTrack videoTrack = videoTracks.get(position);
-                            player.selectVideoTrack(videoTrack);
+                            switch (position) {
+                                case 0:
+                                    player.clearVideoTrackSelection();
+                                    break;
+                                default:
+                                    PlayerVideoTrack videoTrack = videoTracks.get(position - 1);
+                                    player.selectVideoTrack(videoTrack);
+                                    break;
+                            }
                         }
                     }).create();
             videoTrackSelectionDialog.show();
@@ -101,8 +111,10 @@ public class MainActivity extends Activity {
 
         private List<String> mapVideoTrackToLabel(List<PlayerVideoTrack> videoTracks) {
             List<String> labels = new ArrayList<>();
+            labels.add("Auto");
             for (PlayerVideoTrack videoTrack : videoTracks) {
-                labels.add("Quality " + videoTrack.height());
+                String message = String.format(VIDEO_TRACK_MESSAGE_FORMAT, videoTrack.id(), videoTrack.height());
+                labels.add(message);
             }
             return labels;
         }
@@ -124,8 +136,15 @@ public class MainActivity extends Activity {
                     .setAdapter(adapter, new DialogInterface.OnClickListener() {
                         @Override
                         public void onClick(DialogInterface dialog, int position) {
-                            PlayerAudioTrack audioTrack = audioTracks.get(position);
-                            player.selectAudioTrack(audioTrack);
+                            switch (position) {
+                                case 0:
+                                    player.clearAudioTrackSelection();
+                                    break;
+                                default:
+                                    PlayerAudioTrack audioTrack = audioTracks.get(position - 1);
+                                    player.selectAudioTrack(audioTrack);
+                                    break;
+                            }
                         }
                     }).create();
             audioSelectionDialog.show();
@@ -133,12 +152,12 @@ public class MainActivity extends Activity {
 
         private List<String> mapAudioTrackToLabel(AudioTracks audioTracks) {
             List<String> labels = new ArrayList<>();
+            labels.add("Auto");
             for (PlayerAudioTrack audioTrack : audioTracks) {
                 String label = String.format(
                         Locale.UK,
-                        "Group: %s Format: %s Type: %s",
-                        audioTrack.groupIndex(),
-                        audioTrack.formatIndex(),
+                        AUDIO_TRACK_MESSAGE_FORMAT,
+                        audioTrack.trackId(),
                         audioTrack.audioTrackType()
                 );
                 labels.add(label);


### PR DESCRIPTION
## Problem
We want to be able to provide more debugging capabilities in our client applications that use `no-player` such as selecting a video rendition. 

## Solution
Use the same mechanism that exists for hiding `subtitles` but apply it to `audio` and `video` tracks. 

### Screenshots
The connection is too good here so if I use auto it automatically goes to the highest rendition after the set buffer time (internal) 😆 
![device-2017-11-06-122227](https://user-images.githubusercontent.com/3380092/32440948-45b35ca2-c2ed-11e7-8a90-374d7a22f3e9.gif)


### Paired with 
Nobody.
