### PR TITLE
Update to latest version of exoplayer

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -22,7 +22,7 @@ android {
 }
 
 dependencies {
-    compile 'com.google.android.exoplayer:exoplayer:r2.5.2'
+    compile 'com.google.android.exoplayer:exoplayer:r2.5.4'
     compile 'com.novoda:notils-java:3.0.2'
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:2.7.22'


### PR DESCRIPTION
## Problem
There have been two patches made to ExoPlayer recently including:

- Workaround broken AAC decoders on Galaxy S6 
- Memory leak

## Solution
Update to the latest version of ExoPlayer. No API changes and the demo still functions as expected. 

https://github.com/google/ExoPlayer/blob/release-v2/RELEASENOTES.md

### Paired with 
Nobody
