### PR TITLE
NO-124/Moving internal utils to the internal package

### DIFF
--- a/core/src/main/java/com/novoda/noplayer/NoPlayer.java
+++ b/core/src/main/java/com/novoda/noplayer/NoPlayer.java
@@ -8,7 +8,7 @@ import com.novoda.noplayer.model.PlayerAudioTrack;
 import com.novoda.noplayer.model.PlayerSubtitleTrack;
 import com.novoda.noplayer.model.PlayerVideoTrack;
 import com.novoda.noplayer.model.Timeout;
-import com.novoda.utils.Optional;
+import com.novoda.noplayer.internal.utils.Optional;
 
 import java.util.List;
 import java.util.Map;

--- a/core/src/main/java/com/novoda/noplayer/PlayerBuilder.java
+++ b/core/src/main/java/com/novoda/noplayer/PlayerBuilder.java
@@ -12,7 +12,7 @@ import com.novoda.noplayer.internal.drm.provision.ProvisionExecutorCreator;
 import com.novoda.noplayer.internal.exoplayer.NoPlayerExoPlayerCreator;
 import com.novoda.noplayer.internal.exoplayer.drm.DrmSessionCreatorFactory;
 import com.novoda.noplayer.internal.mediaplayer.NoPlayerMediaPlayerCreator;
-import com.novoda.utils.AndroidDeviceVersion;
+import com.novoda.noplayer.internal.utils.AndroidDeviceVersion;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/core/src/main/java/com/novoda/noplayer/UnableToCreatePlayerException.java
+++ b/core/src/main/java/com/novoda/noplayer/UnableToCreatePlayerException.java
@@ -1,7 +1,7 @@
 package com.novoda.noplayer;
 
 import com.novoda.noplayer.drm.DrmType;
-import com.novoda.utils.AndroidDeviceVersion;
+import com.novoda.noplayer.internal.utils.AndroidDeviceVersion;
 
 public class UnableToCreatePlayerException extends RuntimeException {
 

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
@@ -18,7 +18,7 @@ import com.novoda.noplayer.model.AudioTracks;
 import com.novoda.noplayer.model.PlayerAudioTrack;
 import com.novoda.noplayer.model.PlayerSubtitleTrack;
 import com.novoda.noplayer.model.PlayerVideoTrack;
-import com.novoda.utils.Optional;
+import com.novoda.noplayer.internal.utils.Optional;
 
 import java.util.List;
 

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImpl.java
@@ -23,7 +23,7 @@ import com.novoda.noplayer.model.PlayerAudioTrack;
 import com.novoda.noplayer.model.PlayerSubtitleTrack;
 import com.novoda.noplayer.model.PlayerVideoTrack;
 import com.novoda.noplayer.model.Timeout;
-import com.novoda.utils.Optional;
+import com.novoda.noplayer.internal.utils.Optional;
 
 import java.util.List;
 

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/drm/DrmSessionCreatorFactory.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/drm/DrmSessionCreatorFactory.java
@@ -10,7 +10,7 @@ import com.novoda.noplayer.drm.DrmType;
 import com.novoda.noplayer.drm.StreamingModularDrm;
 import com.novoda.noplayer.internal.drm.provision.ProvisionExecutor;
 import com.novoda.noplayer.internal.drm.provision.ProvisionExecutorCreator;
-import com.novoda.utils.AndroidDeviceVersion;
+import com.novoda.noplayer.internal.utils.AndroidDeviceVersion;
 
 public class DrmSessionCreatorFactory {
 

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/mediasource/ExoPlayerTrackSelector.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/mediasource/ExoPlayerTrackSelector.java
@@ -5,7 +5,7 @@ import com.google.android.exoplayer2.source.TrackGroupArray;
 import com.google.android.exoplayer2.trackselection.DefaultTrackSelector;
 import com.google.android.exoplayer2.trackselection.MappingTrackSelector;
 import com.novoda.noplayer.internal.exoplayer.RendererTypeRequester;
-import com.novoda.utils.Optional;
+import com.novoda.noplayer.internal.utils.Optional;
 
 // We cannot make it final as we need to mock it in tests
 @SuppressWarnings({"checkstyle:FinalClass", "PMD.ClassWithOnlyPrivateConstructorsShouldBeFinal"})

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/mediasource/ExoPlayerVideoTrackSelector.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/mediasource/ExoPlayerVideoTrackSelector.java
@@ -9,7 +9,7 @@ import com.google.android.exoplayer2.trackselection.TrackSelection;
 import com.novoda.noplayer.ContentType;
 import com.novoda.noplayer.internal.exoplayer.RendererTypeRequester;
 import com.novoda.noplayer.model.PlayerVideoTrack;
-import com.novoda.utils.Optional;
+import com.novoda.noplayer.internal.utils.Optional;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/mediasource/RendererTrackIndexExtractor.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/mediasource/RendererTrackIndexExtractor.java
@@ -2,7 +2,7 @@ package com.novoda.noplayer.internal.exoplayer.mediasource;
 
 import com.google.android.exoplayer2.C;
 import com.novoda.noplayer.internal.exoplayer.RendererTypeRequester;
-import com.novoda.utils.Optional;
+import com.novoda.noplayer.internal.utils.Optional;
 
 class RendererTrackIndexExtractor {
 

--- a/core/src/main/java/com/novoda/noplayer/internal/listeners/StateChangedListeners.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/listeners/StateChangedListeners.java
@@ -1,7 +1,7 @@
 package com.novoda.noplayer.internal.listeners;
 
 import com.novoda.noplayer.NoPlayer;
-import com.novoda.utils.NoPlayerLog;
+import com.novoda.noplayer.internal.utils.NoPlayerLog;
 
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerFacade.java
@@ -13,8 +13,8 @@ import com.novoda.noplayer.model.AudioTracks;
 import com.novoda.noplayer.model.PlayerAudioTrack;
 import com.novoda.noplayer.model.PlayerSubtitleTrack;
 import com.novoda.noplayer.model.PlayerVideoTrack;
-import com.novoda.utils.NoPlayerLog;
-import com.novoda.utils.Optional;
+import com.novoda.noplayer.internal.utils.NoPlayerLog;
+import com.novoda.noplayer.internal.utils.Optional;
 
 import java.io.IOException;
 import java.util.Collections;

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImpl.java
@@ -21,7 +21,7 @@ import com.novoda.noplayer.model.PlayerAudioTrack;
 import com.novoda.noplayer.model.PlayerSubtitleTrack;
 import com.novoda.noplayer.model.PlayerVideoTrack;
 import com.novoda.noplayer.model.Timeout;
-import com.novoda.utils.Optional;
+import com.novoda.noplayer.internal.utils.Optional;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/forwarder/VideoSizeChangedForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/forwarder/VideoSizeChangedForwarder.java
@@ -3,7 +3,7 @@ package com.novoda.noplayer.internal.mediaplayer.forwarder;
 import android.media.MediaPlayer;
 
 import com.novoda.noplayer.NoPlayer;
-import com.novoda.utils.NoPlayerLog;
+import com.novoda.noplayer.internal.utils.NoPlayerLog;
 
 class VideoSizeChangedForwarder implements MediaPlayer.OnVideoSizeChangedListener {
 

--- a/core/src/main/java/com/novoda/noplayer/internal/utils/AndroidDeviceVersion.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/utils/AndroidDeviceVersion.java
@@ -1,4 +1,4 @@
-package com.novoda.utils;
+package com.novoda.noplayer.internal.utils;
 
 import android.os.Build;
 

--- a/core/src/main/java/com/novoda/noplayer/internal/utils/NoPlayerLog.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/utils/NoPlayerLog.java
@@ -1,4 +1,4 @@
-package com.novoda.utils;
+package com.novoda.noplayer.internal.utils;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;

--- a/core/src/main/java/com/novoda/noplayer/internal/utils/Optional.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/utils/Optional.java
@@ -1,4 +1,4 @@
-package com.novoda.utils;
+package com.novoda.noplayer.internal.utils;
 
 public final class Optional<T> {
 

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacadeTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacadeTest.java
@@ -20,7 +20,7 @@ import com.novoda.noplayer.model.PlayerAudioTrackFixture;
 import com.novoda.noplayer.model.PlayerSubtitleTrack;
 import com.novoda.noplayer.model.PlayerVideoTrack;
 import com.novoda.noplayer.model.PlayerVideoTrackFixture;
-import com.novoda.utils.Optional;
+import com.novoda.noplayer.internal.utils.Optional;
 
 import java.util.Collections;
 import java.util.List;

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/drm/DrmSessionCreatorFactoryTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/drm/DrmSessionCreatorFactoryTest.java
@@ -8,7 +8,7 @@ import com.novoda.noplayer.drm.DrmHandler;
 import com.novoda.noplayer.drm.DrmType;
 import com.novoda.noplayer.drm.StreamingModularDrm;
 import com.novoda.noplayer.internal.drm.provision.ProvisionExecutorCreator;
-import com.novoda.utils.AndroidDeviceVersion;
+import com.novoda.noplayer.internal.utils.AndroidDeviceVersion;
 
 import org.junit.Before;
 import org.junit.Rule;

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/mediasource/ExoPlayerVideoTrackSelectorTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/mediasource/ExoPlayerVideoTrackSelectorTest.java
@@ -9,7 +9,7 @@ import com.google.android.exoplayer2.trackselection.TrackSelection;
 import com.novoda.noplayer.ContentType;
 import com.novoda.noplayer.internal.exoplayer.RendererTypeRequester;
 import com.novoda.noplayer.model.PlayerVideoTrack;
-import com.novoda.utils.Optional;
+import com.novoda.noplayer.internal.utils.Optional;
 
 import java.util.Arrays;
 import java.util.List;

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/mediasource/RendererTrackIndexExtractorTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/mediasource/RendererTrackIndexExtractorTest.java
@@ -2,7 +2,7 @@ package com.novoda.noplayer.internal.exoplayer.mediasource;
 
 import com.google.android.exoplayer2.C;
 import com.novoda.noplayer.internal.exoplayer.RendererTypeRequester;
-import com.novoda.utils.Optional;
+import com.novoda.noplayer.internal.utils.Optional;
 
 import org.junit.Before;
 import org.junit.Rule;

--- a/core/src/test/java/com/novoda/noplayer/internal/listeners/StateChangedListenersTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/listeners/StateChangedListenersTest.java
@@ -1,7 +1,7 @@
 package com.novoda.noplayer.internal.listeners;
 
 import com.novoda.noplayer.NoPlayer;
-import com.novoda.utils.NoPlayerLog;
+import com.novoda.noplayer.internal.utils.NoPlayerLog;
 
 import org.junit.Before;
 import org.junit.Rule;

--- a/core/src/test/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerFacadeTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerFacadeTest.java
@@ -12,7 +12,7 @@ import com.novoda.noplayer.model.AudioTracks;
 import com.novoda.noplayer.model.PlayerAudioTrack;
 import com.novoda.noplayer.model.PlayerAudioTrackFixture;
 import com.novoda.noplayer.model.PlayerSubtitleTrack;
-import com.novoda.utils.NoPlayerLog;
+import com.novoda.noplayer.internal.utils.NoPlayerLog;
 
 import java.io.IOException;
 import java.util.Collections;

--- a/core/src/test/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImplTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImplTest.java
@@ -18,7 +18,7 @@ import com.novoda.noplayer.model.LoadTimeout;
 import com.novoda.noplayer.model.PlayerAudioTrack;
 import com.novoda.noplayer.model.PlayerAudioTrackFixture;
 import com.novoda.noplayer.model.Timeout;
-import com.novoda.utils.NoPlayerLog;
+import com.novoda.noplayer.internal.utils.NoPlayerLog;
 
 import java.util.Collections;
 

--- a/demo/src/main/java/com/novoda/demo/MainActivity.java
+++ b/demo/src/main/java/com/novoda/demo/MainActivity.java
@@ -10,7 +10,7 @@ import com.novoda.noplayer.ContentType;
 import com.novoda.noplayer.NoPlayer;
 import com.novoda.noplayer.PlayerBuilder;
 import com.novoda.noplayer.PlayerView;
-import com.novoda.utils.NoPlayerLog;
+import com.novoda.noplayer.internal.utils.NoPlayerLog;
 
 public class MainActivity extends Activity {
 


### PR DESCRIPTION
Fixes #124 

## Problem

The internal utils are in a top level package, they should be inside the `internal` package.

## Solution

Move the classes!

### Test(s) added 

nothing to test

### Paired with 
Nobody