### PR TITLE
ALL-4473/Kindle low volume issue since 2.0.6

### DIFF
--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
@@ -1,7 +1,6 @@
 package com.novoda.noplayer.internal.exoplayer;
 
 import android.net.Uri;
-import android.os.Build;
 import android.support.annotation.Nullable;
 import android.view.SurfaceHolder;
 

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerExoPlayerCreator.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerExoPlayerCreator.java
@@ -21,6 +21,7 @@ import com.novoda.noplayer.internal.exoplayer.mediasource.ExoPlayerTrackSelector
 import com.novoda.noplayer.internal.exoplayer.mediasource.ExoPlayerVideoTrackSelector;
 import com.novoda.noplayer.internal.exoplayer.mediasource.MediaSourceFactory;
 import com.novoda.noplayer.internal.listeners.PlayerListenersHolder;
+import com.novoda.noplayer.internal.utils.AndroidDeviceVersion;
 import com.novoda.noplayer.model.LoadTimeout;
 
 public class NoPlayerExoPlayerCreator {
@@ -73,7 +74,9 @@ public class NoPlayerExoPlayerCreator {
 
             ExoPlayerCreator exoPlayerCreator = new ExoPlayerCreator(context, trackSelector);
             RendererTypeRequesterCreator rendererTypeRequesterCreator = new RendererTypeRequesterCreator();
+            AndroidDeviceVersion androidDeviceVersion = AndroidDeviceVersion.newInstance();
             ExoPlayerFacade exoPlayerFacade = new ExoPlayerFacade(
+                    androidDeviceVersion,
                     mediaSourceFactory,
                     exoPlayerAudioTrackSelector,
                     exoPlayerSubtitleTrackSelector,

--- a/core/src/main/java/com/novoda/noplayer/internal/utils/AndroidDeviceVersion.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/utils/AndroidDeviceVersion.java
@@ -18,6 +18,10 @@ public class AndroidDeviceVersion {
         return sdkInt >= Build.VERSION_CODES.JELLY_BEAN_MR2;
     }
 
+    public boolean isLollipopTwentyOneOrAbove() {
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP;
+    }
+
     public int sdkInt() {
         return sdkInt;
     }

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacadeTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacadeTest.java
@@ -15,13 +15,14 @@ import com.novoda.noplayer.internal.exoplayer.mediasource.ExoPlayerAudioTrackSel
 import com.novoda.noplayer.internal.exoplayer.mediasource.ExoPlayerSubtitleTrackSelector;
 import com.novoda.noplayer.internal.exoplayer.mediasource.ExoPlayerVideoTrackSelector;
 import com.novoda.noplayer.internal.exoplayer.mediasource.MediaSourceFactory;
+import com.novoda.noplayer.internal.utils.AndroidDeviceVersion;
+import com.novoda.noplayer.internal.utils.Optional;
 import com.novoda.noplayer.model.AudioTracks;
 import com.novoda.noplayer.model.PlayerAudioTrack;
 import com.novoda.noplayer.model.PlayerAudioTrackFixture;
 import com.novoda.noplayer.model.PlayerSubtitleTrack;
 import com.novoda.noplayer.model.PlayerVideoTrack;
 import com.novoda.noplayer.model.PlayerVideoTrackFixture;
-import com.novoda.noplayer.internal.utils.Optional;
 
 import java.util.Collections;
 import java.util.List;
@@ -42,10 +43,7 @@ import static org.fest.assertions.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @RunWith(Enclosed.class)
 public class ExoPlayerFacadeTest {
@@ -403,6 +401,8 @@ public class ExoPlayerFacadeTest {
         public MockitoRule mockitoRule = MockitoJUnit.rule();
 
         @Mock
+        AndroidDeviceVersion androidDeviceVersion;
+        @Mock
         SimpleExoPlayer exoPlayer;
         @Mock
         MediaSourceFactory mediaSourceFactory;
@@ -438,12 +438,14 @@ public class ExoPlayerFacadeTest {
             given(exoPlayerCreator.create(drmSessionCreator, drmSessionEventListener, mediaCodecSelector)).willReturn(exoPlayer);
             when(rendererTypeRequesterCreator.createfrom(exoPlayer)).thenReturn(rendererTypeRequester);
             facade = new ExoPlayerFacade(
+                    androidDeviceVersion,
                     mediaSourceFactory,
                     audioTrackSelector,
                     subtitleTrackSelector,
                     videoTrackSelector,
                     exoPlayerCreator,
-                    rendererTypeRequesterCreator);
+                    rendererTypeRequesterCreator
+            );
         }
 
         MediaSource givenMediaSource() {

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacadeTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacadeTest.java
@@ -3,8 +3,10 @@ package com.novoda.noplayer.internal.exoplayer;
 import android.net.Uri;
 import android.view.SurfaceHolder;
 
+import com.google.android.exoplayer2.C;
 import com.google.android.exoplayer2.Player;
 import com.google.android.exoplayer2.SimpleExoPlayer;
+import com.google.android.exoplayer2.audio.AudioAttributes;
 import com.google.android.exoplayer2.drm.DefaultDrmSessionManager;
 import com.google.android.exoplayer2.mediacodec.MediaCodecSelector;
 import com.google.android.exoplayer2.source.MediaSource;
@@ -103,6 +105,27 @@ public class ExoPlayerFacadeTest {
             facade.loadVideo(surfaceHolder, drmSessionCreator, uri, ANY_CONTENT_TYPE, exoPlayerForwarder, mediaCodecSelector);
 
             verify(exoPlayer).setVideoSurfaceHolder(surfaceHolder);
+        }
+
+        @Test
+        public void givenLollipopDevice_whenLoadingVideo_thenSetsMovieAudioAttributesOnExoPlayer() {
+            given(androidDeviceVersion.isLollipopTwentyOneOrAbove()).willReturn(true);
+
+            facade.loadVideo(surfaceHolder, drmSessionCreator, uri, ANY_CONTENT_TYPE, exoPlayerForwarder, mediaCodecSelector);
+
+            AudioAttributes expectedMovieAudioAttributes = new AudioAttributes.Builder()
+                    .setContentType(C.CONTENT_TYPE_MOVIE)
+                    .build();
+            verify(exoPlayer).setAudioAttributes(expectedMovieAudioAttributes);
+        }
+
+        @Test
+        public void givenNonLollipopDevice_whenLoadingVideo_thenDoesNotSetAudioAttributesOnExoPlayer() {
+            given(androidDeviceVersion.isLollipopTwentyOneOrAbove()).willReturn(false);
+
+            facade.loadVideo(surfaceHolder, drmSessionCreator, uri, ANY_CONTENT_TYPE, exoPlayerForwarder, mediaCodecSelector);
+
+            verify(exoPlayer, never()).setAudioAttributes(any(AudioAttributes.class));
         }
 
         @Test


### PR DESCRIPTION
## Problem

We're having reports from users that their Kindle devices have experienced a volume decrease after upgrading from exoplayer `r2.4.4`.

#### Reproduction

We're able to reproduce consistently by playing any content in the ExoPlayer r2.6.1 demo app and comparing the volume level against the MediaPlayer or the ExoPlayer `r2.4.4` release.

The following Amazon Kindle devices are affected:

```
KFASWI FireOS 5.6.0.0 & FireOS 5.6.0.1  
KFSAWI FireOS 5.4.0.0

Reported by users, version unknown
KFTBWI
KFMEWI 
```

#### Cause

It appears that ExoPlayer r2.5.0 introduced a separate v21+ audioTrack creation which changed the default audio contentType from [MUSIC to UNKNOWN](https://github.com/google/ExoPlayer/compare/cbffc14fa1ba2fa84379e95679f649cb8605e805...r2.5.0?diff=split&name=r2.5.0#diff-2716a5e2150b041bfac29ec067c43c0eL387).

## Solution

To manually set the `AudioAttributes` to `MOVIE` on the `ExoPlayer` instance


### Test(s) added 

Yes around applying the AudioAttributes for 21+ devices with the `MOVIE` type.

### Screenshots

N/A

### Paired with 

@Frankie-Boy 
