### PR TITLE
Up version for release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ task wrapper(type: Wrapper) {
 }
 
 allprojects {
-    version = '4.0.1'
+    version = '4.0.2'
 }
 
 def teamPropsFile(propsFile) {


### PR DESCRIPTION
- Map exoplayer errors by looking at the thrown `ExoPlaybackException` type before unwrapping real exception. 
- Include new error types for better granularity and remove deprecated ones.
- Honour documentation by not prematurely invoking `Player.EventListener.onPlayerError()` for errors where the documentation says to do not so.