### PR TITLE
ExoPlayer Dependency Update

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -19,7 +19,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.google.android.exoplayer:exoplayer:2.7.1'
+    implementation 'com.google.android.exoplayer:exoplayer:2.7.3'
 
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:2.16.0'

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -20,7 +20,7 @@ android {
 }
 dependencies {
     implementation project(':core')
-    implementation 'com.android.support:appcompat-v7:27.1.0'
+    implementation 'com.android.support:appcompat-v7:27.1.1'
 
     testImplementation 'junit:junit:4.12'
     testImplementation 'com.google.truth:truth:0.39'


### PR DESCRIPTION
## Problem
ExoPlayer update is currently on `2.7.1` but the latest is `2.7.3`

## Solution
Update it! Mainly made up of patches to the internals of ExoPlayer, doesn't look like `no-player` requires any work.

https://github.com/google/ExoPlayer/blob/release-v2/RELEASENOTES.md