### PR TITLE
Add missing throws declaration from volume api

### DIFF
--- a/core/src/main/java/com/novoda/noplayer/NoPlayer.java
+++ b/core/src/main/java/com/novoda/noplayer/NoPlayer.java
@@ -1,8 +1,8 @@
 package com.novoda.noplayer;
 
 import android.net.Uri;
-
 import android.support.annotation.FloatRange;
+
 import com.novoda.noplayer.internal.utils.Optional;
 import com.novoda.noplayer.model.AudioTracks;
 import com.novoda.noplayer.model.Bitrate;
@@ -212,7 +212,7 @@ public interface NoPlayer extends PlayerState {
      * @param volume The audio volume.
      * @throws IllegalStateException - if called before {@link NoPlayer#loadVideo(Uri, ContentType)}.
      */
-    void setVolume(@FloatRange(from = 0.0f, to = 1.0f) float volume);
+    void setVolume(@FloatRange(from = 0.0f, to = 1.0f) float volume) throws IllegalStateException;
 
     /**
      * Return the audio volume, with 0 being silence and 1 being unity gain.
@@ -220,7 +220,7 @@ public interface NoPlayer extends PlayerState {
      * @throws IllegalStateException - if called before {@link NoPlayer#loadVideo(Uri, ContentType)}.
      */
     @FloatRange(from = 0.0f, to = 1.0f)
-    float getVolume();
+    float getVolume() throws IllegalStateException;
 
     interface PlayerError {
 

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacadeTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacadeTest.java
@@ -45,13 +45,15 @@ import static org.fest.assertions.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(Enclosed.class)
 public class ExoPlayerFacadeTest {
 
     private static final boolean SELECTED = true;
-    private static final PlayerVideoTrack PLAYER_VIDEO_TRACK = PlayerVideoTrackFixture.aPlayerVideoTrack().build();
 
     private static final long TWO_MINUTES_IN_MILLIS = 120000;
     private static final long TEN_MINUTES_IN_MILLIS = 600000;
@@ -206,6 +208,20 @@ public class ExoPlayerFacadeTest {
 
             facade.selectSubtitleTrack(subtitleTrack);
         }
+
+        @Test
+        public void whenSetVolume_thenThrowsIllegalStateException() {
+            thrown.expect(ExceptionMatcher.matches("Video must be loaded before trying to interact with the player", IllegalStateException.class));
+
+            facade.setVolume(ANY_VOLUME);
+        }
+
+        @Test
+        public void whenGetVolume_thenthenThrowsIllegalStateException() {
+            thrown.expect(ExceptionMatcher.matches("Video must be loaded before trying to interact with the player", IllegalStateException.class));
+
+            facade.getVolume();
+        }
     }
 
     public static class GivenVideoIsLoaded extends Base {
@@ -214,7 +230,6 @@ public class ExoPlayerFacadeTest {
         private static final AudioTracks AUDIO_TRACKS = AudioTracks.from(Collections.singletonList(PLAYER_AUDIO_TRACK));
         private static final PlayerVideoTrack PLAYER_VIDEO_TRACK = PlayerVideoTrackFixture.aPlayerVideoTrack().build();
         private static final List<PlayerVideoTrack> VIDEO_TRACKS = Collections.singletonList(PLAYER_VIDEO_TRACK);
-        private static final float ANY_VOLUME = 0.5f;
 
         @Override
         public void setUp() {
@@ -436,6 +451,8 @@ public class ExoPlayerFacadeTest {
     }
 
     public abstract static class Base {
+
+        static final float ANY_VOLUME = 0.5f;
 
         @Rule
         public MockitoRule mockitoRule = MockitoJUnit.rule();

--- a/core/src/test/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerFacadeTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerFacadeTest.java
@@ -8,11 +8,11 @@ import android.view.SurfaceHolder;
 
 import com.novoda.noplayer.SurfaceHolderRequester;
 import com.novoda.noplayer.internal.mediaplayer.forwarder.MediaPlayerForwarder;
+import com.novoda.noplayer.internal.utils.NoPlayerLog;
 import com.novoda.noplayer.model.AudioTracks;
 import com.novoda.noplayer.model.PlayerAudioTrack;
 import com.novoda.noplayer.model.PlayerAudioTrackFixture;
 import com.novoda.noplayer.model.PlayerSubtitleTrack;
-import com.novoda.noplayer.internal.utils.NoPlayerLog;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -562,6 +562,13 @@ public class AndroidMediaPlayerFacadeTest {
     }
 
     @Test
+    public void givenMediaPlayerIsNotInPlaybackState_whenSettingVolume_thenThrowsIllegalStateException() {
+        thrown.expect(ExceptionMatcher.matches(ERROR_MESSAGE, IllegalStateException.class));
+
+        facade.setVolume(ANY_VOLUME);
+    }
+
+    @Test
     public void whenSettingVolume_thenSetsLeftAndRightVolumeScalars() {
         givenMediaPlayerIsPrepared();
 
@@ -571,9 +578,16 @@ public class AndroidMediaPlayerFacadeTest {
     }
 
     @Test
+    public void givenMediaPlayerIsNotInPlaybackState_whenGettingVolume_thenThrowsIllegalStateException() {
+        thrown.expect(ExceptionMatcher.matches(ERROR_MESSAGE, IllegalStateException.class));
+
+        facade.getVolume();
+    }
+
+    @Test
     public void givenNoVolumeWasSet_whenGettingVolume_theReturnsOne() {
         givenMediaPlayerIsPrepared();
-        
+
         float currentVolume = facade.getVolume();
 
         assertThat(currentVolume).isEqualTo(1f);


### PR DESCRIPTION
## Problem
I noticed when implementing some changes on a client application that we are missing the `throws` declaration on the volume api.

## Solution
Add the `throws` declaration.

### Paired with 
Nobody.
