### PR TITLE
Add Options to loadVideo

### DIFF
--- a/core/src/main/java/com/novoda/noplayer/NoPlayer.java
+++ b/core/src/main/java/com/novoda/noplayer/NoPlayer.java
@@ -72,22 +72,22 @@ public interface NoPlayer extends PlayerState {
     /**
      * Loads the video content and triggers the {@link NoPlayer.PreparedListener}.
      *
-     * @param uri         link to the content.
-     * @param contentType format of the content.
+     * @param uri     link to the content.
+     * @param options to be passed to the underlying player.
      * @throws IllegalStateException - if called before {@link NoPlayer#attach(PlayerView)}.
      */
-    void loadVideo(Uri uri, ContentType contentType) throws IllegalStateException;
+    void loadVideo(Uri uri, Options options) throws IllegalStateException;
 
     /**
      * Loads the video content and triggers the {@link NoPlayer.PreparedListener}.
      *
      * @param uri                 link to the content.
-     * @param contentType         format of the content.
+     * @param options             to be passed to the underlying player.
      * @param timeout             amount of time to wait before triggering {@link LoadTimeoutCallback}.
      * @param loadTimeoutCallback callback when loading has hit the timeout.
      * @throws IllegalStateException - if called before {@link NoPlayer#attach(PlayerView)}.
      */
-    void loadVideoWithTimeout(Uri uri, ContentType contentType, Timeout timeout, LoadTimeoutCallback loadTimeoutCallback);
+    void loadVideoWithTimeout(Uri uri, Options options, Timeout timeout, LoadTimeoutCallback loadTimeoutCallback);
 
     /**
      * Supplies information about the underlying player.

--- a/core/src/main/java/com/novoda/noplayer/Options.java
+++ b/core/src/main/java/com/novoda/noplayer/Options.java
@@ -3,9 +3,9 @@ package com.novoda.noplayer;
 public class Options {
 
     private final ContentType contentType;
-    private final long minDurationBeforeQualityIncreaseInMillis;
+    private final int minDurationBeforeQualityIncreaseInMillis;
 
-    Options(ContentType contentType, long minDurationBeforeQualityIncreaseInMillis) {
+    Options(ContentType contentType, int minDurationBeforeQualityIncreaseInMillis) {
         this.contentType = contentType;
         this.minDurationBeforeQualityIncreaseInMillis = minDurationBeforeQualityIncreaseInMillis;
     }
@@ -14,7 +14,7 @@ public class Options {
         return contentType;
     }
 
-    public long minDurationBeforeQualityIncreaseInMillis() {
+    public int minDurationBeforeQualityIncreaseInMillis() {
         return minDurationBeforeQualityIncreaseInMillis;
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/Options.java
+++ b/core/src/main/java/com/novoda/noplayer/Options.java
@@ -3,12 +3,18 @@ package com.novoda.noplayer;
 public class Options {
 
     private final ContentType contentType;
+    private final long minDurationBeforeQualityIncreaseInMillis;
 
-    Options(ContentType contentType) {
+    Options(ContentType contentType, long minDurationBeforeQualityIncreaseInMillis) {
         this.contentType = contentType;
+        this.minDurationBeforeQualityIncreaseInMillis = minDurationBeforeQualityIncreaseInMillis;
     }
 
     public ContentType contentType() {
         return contentType;
+    }
+
+    public long minDurationBeforeQualityIncreaseInMillis() {
+        return minDurationBeforeQualityIncreaseInMillis;
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/Options.java
+++ b/core/src/main/java/com/novoda/noplayer/Options.java
@@ -1,0 +1,14 @@
+package com.novoda.noplayer;
+
+public class Options {
+
+    private final ContentType contentType;
+
+    Options(ContentType contentType) {
+        this.contentType = contentType;
+    }
+
+    public ContentType contentType() {
+        return contentType;
+    }
+}

--- a/core/src/main/java/com/novoda/noplayer/OptionsBuilder.java
+++ b/core/src/main/java/com/novoda/noplayer/OptionsBuilder.java
@@ -7,10 +7,10 @@ import android.net.Uri;
  */
 public class OptionsBuilder {
 
-    private static final long DEFAULT_MIN_DURATION_FOR_QUALITY_INCREASE_MS = 10000;
+    private static final int DEFAULT_MIN_DURATION_FOR_QUALITY_INCREASE_MS = 10000;
 
     private ContentType contentType = ContentType.H264;
-    private long minDurationBeforeQualityIncreaseInMillis = DEFAULT_MIN_DURATION_FOR_QUALITY_INCREASE_MS;
+    private int minDurationBeforeQualityIncreaseInMillis = DEFAULT_MIN_DURATION_FOR_QUALITY_INCREASE_MS;
 
     /**
      * Sets {@link OptionsBuilder} to build {@link Options} with a given {@link ContentType}.
@@ -31,7 +31,7 @@ public class OptionsBuilder {
      * @param minDurationInMillis before switching to a higher quality video track.
      * @return {@link OptionsBuilder}.
      */
-    public OptionsBuilder withMinDurationBeforeQualityIncreaseInMillis(long minDurationInMillis) {
+    public OptionsBuilder withMinDurationBeforeQualityIncreaseInMillis(int minDurationInMillis) {
         this.minDurationBeforeQualityIncreaseInMillis = minDurationInMillis;
         return this;
     }

--- a/core/src/main/java/com/novoda/noplayer/OptionsBuilder.java
+++ b/core/src/main/java/com/novoda/noplayer/OptionsBuilder.java
@@ -1,0 +1,28 @@
+package com.novoda.noplayer;
+
+import android.net.Uri;
+
+/**
+ * Builds instances of {@link Options} for {@link NoPlayer#loadVideo(Uri, ContentType)}.
+ */
+public class OptionsBuilder {
+
+    private ContentType contentType = ContentType.H264;
+
+    /**
+     * Sets {@link OptionsBuilder} to build {@link Options} with a given {@link ContentType}.
+     * This content type is passed to the underlying Player.
+     *
+     * @param contentType of the video being played.
+     * @return {@link OptionsBuilder}.
+     */
+    public OptionsBuilder withContentType(ContentType contentType) {
+        this.contentType = contentType;
+        return this;
+    }
+
+    public Options build() {
+        return new Options(contentType);
+    }
+
+}

--- a/core/src/main/java/com/novoda/noplayer/OptionsBuilder.java
+++ b/core/src/main/java/com/novoda/noplayer/OptionsBuilder.java
@@ -13,7 +13,7 @@ public class OptionsBuilder {
      * Sets {@link OptionsBuilder} to build {@link Options} with a given {@link ContentType}.
      * This content type is passed to the underlying Player.
      *
-     * @param contentType of the video being played.
+     * @param contentType format of the content.
      * @return {@link OptionsBuilder}.
      */
     public OptionsBuilder withContentType(ContentType contentType) {

--- a/core/src/main/java/com/novoda/noplayer/OptionsBuilder.java
+++ b/core/src/main/java/com/novoda/noplayer/OptionsBuilder.java
@@ -3,11 +3,14 @@ package com.novoda.noplayer;
 import android.net.Uri;
 
 /**
- * Builds instances of {@link Options} for {@link NoPlayer#loadVideo(Uri, ContentType)}.
+ * Builds instances of {@link Options} for {@link NoPlayer#loadVideo(Uri, Options)}.
  */
 public class OptionsBuilder {
 
+    private static final long DEFAULT_MIN_DURATION_FOR_QUALITY_INCREASE_MS = 10000;
+
     private ContentType contentType = ContentType.H264;
+    private long minDurationBeforeQualityIncreaseInMillis = DEFAULT_MIN_DURATION_FOR_QUALITY_INCREASE_MS;
 
     /**
      * Sets {@link OptionsBuilder} to build {@link Options} with a given {@link ContentType}.
@@ -21,8 +24,25 @@ public class OptionsBuilder {
         return this;
     }
 
+    /**
+     * Sets {@link OptionsBuilder} to build {@link Options} so that the {@link NoPlayer}
+     * switches to a higher quality video track after {@param minDurationInMillis}.
+     *
+     * @param minDurationInMillis before switching to a higher quality video track.
+     * @return {@link OptionsBuilder}.
+     */
+    public OptionsBuilder withMinDurationBeforeQualityIncreaseInMillis(long minDurationInMillis) {
+        this.minDurationBeforeQualityIncreaseInMillis = minDurationInMillis;
+        return this;
+    }
+
+    /**
+     * Builds a new {@link Options} instance.
+     *
+     * @return a {@link Options} instance.
+     */
     public Options build() {
-        return new Options(contentType);
+        return new Options(contentType, minDurationBeforeQualityIncreaseInMillis);
     }
 
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/CompositeTrackSelectorCreator.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/CompositeTrackSelectorCreator.java
@@ -5,6 +5,8 @@ import com.google.android.exoplayer2.trackselection.DefaultTrackSelector;
 import com.google.android.exoplayer2.trackselection.FixedTrackSelection;
 import com.google.android.exoplayer2.trackselection.TrackSelection;
 import com.google.android.exoplayer2.upstream.DefaultBandwidthMeter;
+import com.google.android.exoplayer2.util.Clock;
+import com.novoda.noplayer.Options;
 import com.novoda.noplayer.internal.exoplayer.mediasource.ExoPlayerAudioTrackSelector;
 import com.novoda.noplayer.internal.exoplayer.mediasource.ExoPlayerSubtitleTrackSelector;
 import com.novoda.noplayer.internal.exoplayer.mediasource.ExoPlayerTrackSelector;
@@ -18,8 +20,18 @@ class CompositeTrackSelectorCreator {
         this.bandwidthMeter = bandwidthMeter;
     }
 
-    CompositeTrackSelector create() {
-        TrackSelection.Factory adaptiveTrackSelectionFactory = new AdaptiveTrackSelection.Factory(bandwidthMeter);
+    CompositeTrackSelector create(Options options) {
+        TrackSelection.Factory adaptiveTrackSelectionFactory = new AdaptiveTrackSelection.Factory(
+                bandwidthMeter,
+                AdaptiveTrackSelection.DEFAULT_MAX_INITIAL_BITRATE,
+                options.minDurationBeforeQualityIncreaseInMillis(),
+                AdaptiveTrackSelection.DEFAULT_MAX_DURATION_FOR_QUALITY_DECREASE_MS,
+                AdaptiveTrackSelection.DEFAULT_MIN_DURATION_TO_RETAIN_AFTER_DISCARD_MS,
+                AdaptiveTrackSelection.DEFAULT_BANDWIDTH_FRACTION,
+                AdaptiveTrackSelection.DEFAULT_BUFFERED_FRACTION_TO_LIVE_EDGE_FOR_QUALITY_INCREASE,
+                AdaptiveTrackSelection.DEFAULT_MIN_TIME_BETWEEN_BUFFER_REEVALUTATION_MS,
+                Clock.DEFAULT
+        );
         DefaultTrackSelector trackSelector = new DefaultTrackSelector(adaptiveTrackSelectionFactory);
 
         ExoPlayerTrackSelector exoPlayerTrackSelector = ExoPlayerTrackSelector.newInstance(trackSelector);

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
@@ -107,7 +107,7 @@ class ExoPlayerFacade {
                    ExoPlayerForwarder forwarder,
                    MediaCodecSelector mediaCodecSelector) {
         this.options = options;
-        trackSelector = trackSelectorCreator.create();
+        trackSelector = trackSelectorCreator.create(options);
         exoPlayer = exoPlayerCreator.create(drmSessionCreator, forwarder.drmSessionEventListener(), mediaCodecSelector, trackSelector);
         rendererTypeRequester = rendererTypeRequesterCreator.createfrom(exoPlayer);
         exoPlayer.addListener(forwarder.exoPlayerEventListener());

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
@@ -9,7 +9,7 @@ import com.google.android.exoplayer2.SimpleExoPlayer;
 import com.google.android.exoplayer2.audio.AudioAttributes;
 import com.google.android.exoplayer2.mediacodec.MediaCodecSelector;
 import com.google.android.exoplayer2.source.MediaSource;
-import com.novoda.noplayer.ContentType;
+import com.novoda.noplayer.Options;
 import com.novoda.noplayer.internal.exoplayer.drm.DrmSessionCreator;
 import com.novoda.noplayer.internal.exoplayer.forwarder.ExoPlayerForwarder;
 import com.novoda.noplayer.internal.exoplayer.mediasource.MediaSourceFactory;
@@ -40,7 +40,7 @@ class ExoPlayerFacade {
     @Nullable
     private RendererTypeRequester rendererTypeRequester;
     @Nullable
-    private ContentType contentType;
+    private Options options;
 
     ExoPlayerFacade(AndroidDeviceVersion androidDeviceVersion,
                     MediaSourceFactory mediaSourceFactory,
@@ -103,10 +103,10 @@ class ExoPlayerFacade {
     void loadVideo(SurfaceHolder surfaceHolder,
                    DrmSessionCreator drmSessionCreator,
                    Uri uri,
-                   ContentType contentType,
+                   Options options,
                    ExoPlayerForwarder forwarder,
                    MediaCodecSelector mediaCodecSelector) {
-        this.contentType = contentType;
+        this.options = options;
         trackSelector = trackSelectorCreator.create();
         exoPlayer = exoPlayerCreator.create(drmSessionCreator, forwarder.drmSessionEventListener(), mediaCodecSelector, trackSelector);
         rendererTypeRequester = rendererTypeRequesterCreator.createfrom(exoPlayer);
@@ -116,7 +116,7 @@ class ExoPlayerFacade {
         setMovieAudioAttributes(exoPlayer);
 
         MediaSource mediaSource = mediaSourceFactory.create(
-                contentType,
+                options.contentType(),
                 uri,
                 forwarder.extractorMediaSourceListener(),
                 forwarder.mediaSourceEventListener()
@@ -160,12 +160,12 @@ class ExoPlayerFacade {
 
     Optional<PlayerVideoTrack> getSelectedVideoTrack() {
         assertVideoLoaded();
-        return trackSelector.getSelectedVideoTrack(exoPlayer, rendererTypeRequester, contentType);
+        return trackSelector.getSelectedVideoTrack(exoPlayer, rendererTypeRequester, options.contentType());
     }
 
     List<PlayerVideoTrack> getVideoTracks() {
         assertVideoLoaded();
-        return trackSelector.getVideoTracks(rendererTypeRequester, contentType);
+        return trackSelector.getVideoTracks(rendererTypeRequester, options.contentType());
     }
 
     boolean clearVideoTrackSelection() {

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImpl.java
@@ -6,9 +6,9 @@ import android.view.SurfaceHolder;
 import android.view.View;
 
 import com.google.android.exoplayer2.mediacodec.MediaCodecSelector;
-import com.novoda.noplayer.ContentType;
 import com.novoda.noplayer.Listeners;
 import com.novoda.noplayer.NoPlayer;
+import com.novoda.noplayer.Options;
 import com.novoda.noplayer.PlayerInformation;
 import com.novoda.noplayer.PlayerState;
 import com.novoda.noplayer.PlayerView;
@@ -17,17 +17,18 @@ import com.novoda.noplayer.internal.Heart;
 import com.novoda.noplayer.internal.exoplayer.drm.DrmSessionCreator;
 import com.novoda.noplayer.internal.exoplayer.forwarder.ExoPlayerForwarder;
 import com.novoda.noplayer.internal.listeners.PlayerListenersHolder;
+import com.novoda.noplayer.internal.utils.Optional;
 import com.novoda.noplayer.model.AudioTracks;
 import com.novoda.noplayer.model.LoadTimeout;
 import com.novoda.noplayer.model.PlayerAudioTrack;
 import com.novoda.noplayer.model.PlayerSubtitleTrack;
 import com.novoda.noplayer.model.PlayerVideoTrack;
 import com.novoda.noplayer.model.Timeout;
-import com.novoda.noplayer.internal.utils.Optional;
 
 import java.util.List;
 
-@SuppressWarnings("PMD.GodClass") // Not much we can do, wrapping ExoPlayer is a lot of work
+@SuppressWarnings("PMD.GodClass")
+        // Not much we can do, wrapping ExoPlayer is a lot of work
 class ExoPlayerTwoImpl implements NoPlayer {
 
     private final ExoPlayerFacade exoPlayer;
@@ -199,7 +200,7 @@ class ExoPlayerTwoImpl implements NoPlayer {
     }
 
     @Override
-    public void loadVideo(final Uri uri, final ContentType contentType) {
+    public void loadVideo(final Uri uri, final Options options) {
         if (exoPlayer.hasPlayedContent()) {
             stop();
         }
@@ -207,7 +208,7 @@ class ExoPlayerTwoImpl implements NoPlayer {
         onSurfaceReadyCallback = new SurfaceHolderRequester.Callback() {
             @Override
             public void onSurfaceHolderReady(SurfaceHolder surfaceHolder) {
-                exoPlayer.loadVideo(surfaceHolder, drmSessionCreator, uri, contentType, forwarder, mediaCodecSelector);
+                exoPlayer.loadVideo(surfaceHolder, drmSessionCreator, uri, options, forwarder, mediaCodecSelector);
             }
         };
 
@@ -227,9 +228,9 @@ class ExoPlayerTwoImpl implements NoPlayer {
     }
 
     @Override
-    public void loadVideoWithTimeout(Uri uri, ContentType contentType, Timeout timeout, LoadTimeoutCallback loadTimeoutCallback) {
+    public void loadVideoWithTimeout(Uri uri, Options options, Timeout timeout, LoadTimeoutCallback loadTimeoutCallback) {
         loadTimeout.start(timeout, loadTimeoutCallback);
-        loadVideo(uri, contentType);
+        loadVideo(uri, options);
     }
 
     @Override

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImpl.java
@@ -5,9 +5,9 @@ import android.net.Uri;
 import android.view.SurfaceHolder;
 import android.view.View;
 
-import com.novoda.noplayer.ContentType;
 import com.novoda.noplayer.Listeners;
 import com.novoda.noplayer.NoPlayer;
+import com.novoda.noplayer.Options;
 import com.novoda.noplayer.PlayerInformation;
 import com.novoda.noplayer.PlayerState;
 import com.novoda.noplayer.PlayerView;
@@ -15,18 +15,19 @@ import com.novoda.noplayer.SurfaceHolderRequester;
 import com.novoda.noplayer.internal.Heart;
 import com.novoda.noplayer.internal.listeners.PlayerListenersHolder;
 import com.novoda.noplayer.internal.mediaplayer.forwarder.MediaPlayerForwarder;
+import com.novoda.noplayer.internal.utils.Optional;
 import com.novoda.noplayer.model.AudioTracks;
 import com.novoda.noplayer.model.LoadTimeout;
 import com.novoda.noplayer.model.PlayerAudioTrack;
 import com.novoda.noplayer.model.PlayerSubtitleTrack;
 import com.novoda.noplayer.model.PlayerVideoTrack;
 import com.novoda.noplayer.model.Timeout;
-import com.novoda.noplayer.internal.utils.Optional;
 
 import java.util.ArrayList;
 import java.util.List;
 
-@SuppressWarnings("PMD.GodClass")   // Not much we can do, wrapping MediaPlayer is a lot of work
+@SuppressWarnings("PMD.GodClass")
+        // Not much we can do, wrapping MediaPlayer is a lot of work
 class AndroidMediaPlayerImpl implements NoPlayer {
 
     private static final long NO_SEEK_TO_POSITION = -1;
@@ -52,7 +53,8 @@ class AndroidMediaPlayerImpl implements NoPlayer {
     private SurfaceHolderRequester surfaceHolderRequester;
     private View containerView;
 
-    @SuppressWarnings("checkstyle:ParameterNumber")     // We cannot really group these any further
+    @SuppressWarnings("checkstyle:ParameterNumber")
+        // We cannot really group these any further
     AndroidMediaPlayerImpl(MediaPlayerInformation mediaPlayerInformation,
                            AndroidMediaPlayerFacade mediaPlayer,
                            MediaPlayerForwarder forwarder,
@@ -220,7 +222,7 @@ class AndroidMediaPlayerImpl implements NoPlayer {
     }
 
     @Override
-    public void loadVideo(final Uri uri, final ContentType contentType) {
+    public void loadVideo(final Uri uri, final Options options) {
         if (mediaPlayer.hasPlayedContent()) {
             stop();
         }
@@ -246,9 +248,9 @@ class AndroidMediaPlayerImpl implements NoPlayer {
     }
 
     @Override
-    public void loadVideoWithTimeout(Uri uri, ContentType contentType, Timeout timeout, LoadTimeoutCallback loadTimeoutCallback) {
+    public void loadVideoWithTimeout(Uri uri, Options options, Timeout timeout, LoadTimeoutCallback loadTimeoutCallback) {
         loadTimeout.start(timeout, loadTimeoutCallback);
-        loadVideo(uri, contentType);
+        loadVideo(uri, options);
     }
 
     @Override

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacadeTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacadeTest.java
@@ -488,7 +488,7 @@ public class ExoPlayerFacadeTest {
         public void setUp() {
             ExoPlayerCreator exoPlayerCreator = mock(ExoPlayerCreator.class);
             given(exoPlayerForwarder.drmSessionEventListener()).willReturn(drmSessionEventListener);
-            given(trackSelectorCreator.create()).willReturn(trackSelector);
+            given(trackSelectorCreator.create(OPTIONS)).willReturn(trackSelector);
             given(exoPlayerCreator.create(drmSessionCreator, drmSessionEventListener, mediaCodecSelector, trackSelector)).willReturn(exoPlayer);
             given(rendererTypeRequesterCreator.createfrom(exoPlayer)).willReturn(rendererTypeRequester);
             facade = new ExoPlayerFacade(

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacadeTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacadeTest.java
@@ -11,6 +11,8 @@ import com.google.android.exoplayer2.drm.DefaultDrmSessionManager;
 import com.google.android.exoplayer2.mediacodec.MediaCodecSelector;
 import com.google.android.exoplayer2.source.MediaSource;
 import com.novoda.noplayer.ContentType;
+import com.novoda.noplayer.Options;
+import com.novoda.noplayer.OptionsBuilder;
 import com.novoda.noplayer.internal.exoplayer.drm.DrmSessionCreator;
 import com.novoda.noplayer.internal.exoplayer.forwarder.ExoPlayerForwarder;
 import com.novoda.noplayer.internal.exoplayer.mediasource.MediaSourceFactory;
@@ -62,7 +64,7 @@ public class ExoPlayerFacadeTest {
     private static final boolean RESET_POSITION = true;
     private static final boolean DO_NOT_RESET_STATE = false;
 
-    private static final ContentType ANY_CONTENT_TYPE = ContentType.DASH;
+    private static final Options OPTIONS = new OptionsBuilder().withContentType(ContentType.DASH).build();
 
     public static class GivenVideoNotLoaded extends Base {
 
@@ -84,7 +86,7 @@ public class ExoPlayerFacadeTest {
         @Test
         public void whenLoadingVideo_thenAddsPlayerEventListener() {
 
-            facade.loadVideo(surfaceHolder, drmSessionCreator, uri, ANY_CONTENT_TYPE, exoPlayerForwarder, mediaCodecSelector);
+            facade.loadVideo(surfaceHolder, drmSessionCreator, uri, OPTIONS, exoPlayerForwarder, mediaCodecSelector);
 
             verify(exoPlayer).addListener(exoPlayerForwarder.exoPlayerEventListener());
         }
@@ -92,7 +94,7 @@ public class ExoPlayerFacadeTest {
         @Test
         public void whenLoadingVideo_thenSetsVideoDebugListener() {
 
-            facade.loadVideo(surfaceHolder, drmSessionCreator, uri, ANY_CONTENT_TYPE, exoPlayerForwarder, mediaCodecSelector);
+            facade.loadVideo(surfaceHolder, drmSessionCreator, uri, OPTIONS, exoPlayerForwarder, mediaCodecSelector);
 
             verify(exoPlayer).setVideoDebugListener(exoPlayerForwarder.videoRendererEventListener());
         }
@@ -100,7 +102,7 @@ public class ExoPlayerFacadeTest {
         @Test
         public void whenLoadingVideo_thenSetsSurfaceHolderOnExoPlayer() {
 
-            facade.loadVideo(surfaceHolder, drmSessionCreator, uri, ANY_CONTENT_TYPE, exoPlayerForwarder, mediaCodecSelector);
+            facade.loadVideo(surfaceHolder, drmSessionCreator, uri, OPTIONS, exoPlayerForwarder, mediaCodecSelector);
 
             verify(exoPlayer).setVideoSurfaceHolder(surfaceHolder);
         }
@@ -109,7 +111,7 @@ public class ExoPlayerFacadeTest {
         public void givenLollipopDevice_whenLoadingVideo_thenSetsMovieAudioAttributesOnExoPlayer() {
             given(androidDeviceVersion.isLollipopTwentyOneOrAbove()).willReturn(true);
 
-            facade.loadVideo(surfaceHolder, drmSessionCreator, uri, ANY_CONTENT_TYPE, exoPlayerForwarder, mediaCodecSelector);
+            facade.loadVideo(surfaceHolder, drmSessionCreator, uri, OPTIONS, exoPlayerForwarder, mediaCodecSelector);
 
             AudioAttributes expectedMovieAudioAttributes = new AudioAttributes.Builder()
                     .setContentType(C.CONTENT_TYPE_MOVIE)
@@ -121,7 +123,7 @@ public class ExoPlayerFacadeTest {
         public void givenNonLollipopDevice_whenLoadingVideo_thenDoesNotSetAudioAttributesOnExoPlayer() {
             given(androidDeviceVersion.isLollipopTwentyOneOrAbove()).willReturn(false);
 
-            facade.loadVideo(surfaceHolder, drmSessionCreator, uri, ANY_CONTENT_TYPE, exoPlayerForwarder, mediaCodecSelector);
+            facade.loadVideo(surfaceHolder, drmSessionCreator, uri, OPTIONS, exoPlayerForwarder, mediaCodecSelector);
 
             verify(exoPlayer, never()).setAudioAttributes(any(AudioAttributes.class));
         }
@@ -130,7 +132,7 @@ public class ExoPlayerFacadeTest {
         public void givenMediaSource_whenLoadingVideo_thenPreparesInternalExoPlayer() {
             MediaSource mediaSource = givenMediaSource();
 
-            facade.loadVideo(surfaceHolder, drmSessionCreator, uri, ANY_CONTENT_TYPE, exoPlayerForwarder, mediaCodecSelector);
+            facade.loadVideo(surfaceHolder, drmSessionCreator, uri, OPTIONS, exoPlayerForwarder, mediaCodecSelector);
 
             verify(exoPlayer).prepare(mediaSource, RESET_POSITION, DO_NOT_RESET_STATE);
         }
@@ -235,7 +237,7 @@ public class ExoPlayerFacadeTest {
 
         private void givenPlayerIsLoaded() {
             givenMediaSource();
-            facade.loadVideo(surfaceHolder, drmSessionCreator, uri, ANY_CONTENT_TYPE, exoPlayerForwarder, mediaCodecSelector);
+            facade.loadVideo(surfaceHolder, drmSessionCreator, uri, OPTIONS, exoPlayerForwarder, mediaCodecSelector);
         }
 
         @Test
@@ -502,7 +504,7 @@ public class ExoPlayerFacadeTest {
             MediaSource mediaSource = mock(MediaSource.class);
             given(
                     mediaSourceFactory.create(
-                            ANY_CONTENT_TYPE,
+                            OPTIONS.contentType(),
                             uri,
                             exoPlayerForwarder.extractorMediaSourceListener(),
                             exoPlayerForwarder.mediaSourceEventListener()

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImplTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImplTest.java
@@ -10,6 +10,8 @@ import com.google.android.exoplayer2.text.Cue;
 import com.novoda.noplayer.ContentType;
 import com.novoda.noplayer.NoPlayer;
 import com.novoda.noplayer.NoPlayer.StateChangedListener;
+import com.novoda.noplayer.Options;
+import com.novoda.noplayer.OptionsBuilder;
 import com.novoda.noplayer.PlayerInformation;
 import com.novoda.noplayer.PlayerType;
 import com.novoda.noplayer.PlayerView;
@@ -23,6 +25,9 @@ import com.novoda.noplayer.model.PlayerSubtitleTrack;
 import com.novoda.noplayer.model.TextCues;
 import com.novoda.noplayer.model.Timeout;
 
+import java.util.Arrays;
+import java.util.List;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -35,9 +40,6 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import org.mockito.stubbing.Answer;
-
-import java.util.Arrays;
-import java.util.List;
 
 import static android.provider.CalendarContract.CalendarCache.URI;
 import static org.fest.assertions.api.Assertions.assertThat;
@@ -63,7 +65,7 @@ public class ExoPlayerTwoImplTest {
     private static final boolean IS_BEATING = true;
     private static final boolean IS_NOT_BEATING = false;
 
-    private static final ContentType ANY_CONTENT_TYPE = ContentType.DASH;
+    private static final Options OPTIONS = new OptionsBuilder().withContentType(ContentType.DASH).build();
     private static final Timeout ANY_TIMEOUT = Timeout.fromSeconds(TEN_SECONDS);
     private static final NoPlayer.LoadTimeoutCallback ANY_LOAD_TIMEOUT_CALLBACK = new NoPlayer.LoadTimeoutCallback() {
         @Override
@@ -218,25 +220,25 @@ public class ExoPlayerTwoImplTest {
         public void whenLoadingVideo_thenDelegatesLoadingToFacade() {
             player.attach(playerView);
 
-            player.loadVideo(uri, ANY_CONTENT_TYPE);
+            player.loadVideo(uri, OPTIONS);
 
-            verify(exoPlayerFacade).loadVideo(surfaceHolder, drmSessionCreator, uri, ANY_CONTENT_TYPE, forwarder, mediaCodecSelector);
+            verify(exoPlayerFacade).loadVideo(surfaceHolder, drmSessionCreator, uri, OPTIONS, forwarder, mediaCodecSelector);
         }
 
         @Test
         public void whenLoadingVideoWithTimeout_thenDelegatesLoadingToFacade() {
             player.attach(playerView);
 
-            player.loadVideoWithTimeout(uri, ANY_CONTENT_TYPE, ANY_TIMEOUT, ANY_LOAD_TIMEOUT_CALLBACK);
+            player.loadVideoWithTimeout(uri, OPTIONS, ANY_TIMEOUT, ANY_LOAD_TIMEOUT_CALLBACK);
 
-            verify(exoPlayerFacade).loadVideo(surfaceHolder, drmSessionCreator, uri, ANY_CONTENT_TYPE, forwarder, mediaCodecSelector);
+            verify(exoPlayerFacade).loadVideo(surfaceHolder, drmSessionCreator, uri, OPTIONS, forwarder, mediaCodecSelector);
         }
 
         @Test
         public void whenLoadingVideoWithTimeout_thenStartsLoadTimeout() {
             player.attach(playerView);
 
-            player.loadVideoWithTimeout(uri, ANY_CONTENT_TYPE, ANY_TIMEOUT, ANY_LOAD_TIMEOUT_CALLBACK);
+            player.loadVideoWithTimeout(uri, OPTIONS, ANY_TIMEOUT, ANY_LOAD_TIMEOUT_CALLBACK);
 
             verify(loadTimeout).start(ANY_TIMEOUT, ANY_LOAD_TIMEOUT_CALLBACK);
         }
@@ -295,7 +297,7 @@ public class ExoPlayerTwoImplTest {
         public void givenAttachedPlayerView_whenLoadingVideo_thenMakesContainerVisible() {
             player.attach(playerView);
 
-            player.loadVideo(uri, ANY_CONTENT_TYPE);
+            player.loadVideo(uri, OPTIONS);
 
             verify(containerView).setVisibility(View.VISIBLE);
         }
@@ -305,7 +307,7 @@ public class ExoPlayerTwoImplTest {
             given(exoPlayerFacade.hasPlayedContent()).willReturn(true);
             player.attach(playerView);
 
-            player.loadVideo(URI, ContentType.HLS);
+            player.loadVideo(URI, OPTIONS);
 
             verify(stateChangedListener).onVideoStopped();
             verify(loadTimeout).cancel();
@@ -319,7 +321,7 @@ public class ExoPlayerTwoImplTest {
             given(exoPlayerFacade.hasPlayedContent()).willReturn(true);
             player.attach(playerView);
 
-            player.loadVideoWithTimeout(URI, ContentType.HLS, ANY_TIMEOUT, ANY_LOAD_TIMEOUT_CALLBACK);
+            player.loadVideoWithTimeout(URI, OPTIONS, ANY_TIMEOUT, ANY_LOAD_TIMEOUT_CALLBACK);
 
             verify(stateChangedListener).onVideoStopped();
             verify(loadTimeout).cancel();
@@ -333,7 +335,7 @@ public class ExoPlayerTwoImplTest {
             given(exoPlayerFacade.hasPlayedContent()).willReturn(false);
             player.attach(playerView);
 
-            player.loadVideo(URI, ContentType.HLS);
+            player.loadVideo(URI, OPTIONS);
 
             verify(stateChangedListener, never()).onVideoStopped();
             verify(loadTimeout, never()).cancel();
@@ -346,7 +348,7 @@ public class ExoPlayerTwoImplTest {
             given(exoPlayerFacade.hasPlayedContent()).willReturn(false);
             player.attach(playerView);
 
-            player.loadVideoWithTimeout(URI, ContentType.HLS, ANY_TIMEOUT, ANY_LOAD_TIMEOUT_CALLBACK);
+            player.loadVideoWithTimeout(URI, OPTIONS, ANY_TIMEOUT, ANY_LOAD_TIMEOUT_CALLBACK);
 
             verify(stateChangedListener, never()).onVideoStopped();
             verify(loadTimeout, never()).cancel();
@@ -363,13 +365,13 @@ public class ExoPlayerTwoImplTest {
         public void setUp() {
             super.setUp();
             player.attach(playerView);
-            player.loadVideo(uri, ANY_CONTENT_TYPE);
+            player.loadVideo(uri, OPTIONS);
         }
 
         @Test
         public void whenLoadingVideo_thenAddsStateChangedListenerToListenersHolder() {
 
-            player.loadVideo(uri, ANY_CONTENT_TYPE);
+            player.loadVideo(uri, OPTIONS);
 
             verify(listenersHolder).addStateChangedListener(playerView.getStateChangedListener());
         }
@@ -377,7 +379,7 @@ public class ExoPlayerTwoImplTest {
         @Test
         public void whenLoadingVideo_thenAddsVideoSizeChangedListenerToListenersHolder() {
 
-            player.loadVideo(uri, ANY_CONTENT_TYPE);
+            player.loadVideo(uri, OPTIONS);
 
             verify(listenersHolder).addVideoSizeChangedListener(playerView.getVideoSizeChangedListener());
         }
@@ -529,7 +531,7 @@ public class ExoPlayerTwoImplTest {
             final List<Cue> cueList = Arrays.asList(new Cue("first cue"), new Cue("secondCue"));
             doAnswer(new Answer() {
                 @Override
-                public Object answer(InvocationOnMock invocation) throws Throwable {
+                public Object answer(InvocationOnMock invocation) {
                     TextRendererOutput output = invocation.getArgument(0);
                     output.output().onCues(cueList);
                     return null;
@@ -627,7 +629,7 @@ public class ExoPlayerTwoImplTest {
             given(playerView.getContainerView()).willReturn(containerView);
             doAnswer(new Answer<Void>() {
                 @Override
-                public Void answer(InvocationOnMock invocation) throws Throwable {
+                public Void answer(InvocationOnMock invocation) {
                     SurfaceHolderRequester.Callback callback = invocation.getArgument(0);
                     callback.onSurfaceHolderReady(surfaceHolder);
                     return null;

--- a/core/src/test/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImplTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImplTest.java
@@ -7,18 +7,20 @@ import android.view.View;
 
 import com.novoda.noplayer.ContentType;
 import com.novoda.noplayer.NoPlayer;
+import com.novoda.noplayer.Options;
+import com.novoda.noplayer.OptionsBuilder;
 import com.novoda.noplayer.PlayerInformation;
 import com.novoda.noplayer.PlayerView;
 import com.novoda.noplayer.SurfaceHolderRequester;
 import com.novoda.noplayer.internal.Heart;
 import com.novoda.noplayer.internal.listeners.PlayerListenersHolder;
 import com.novoda.noplayer.internal.mediaplayer.forwarder.MediaPlayerForwarder;
+import com.novoda.noplayer.internal.utils.NoPlayerLog;
 import com.novoda.noplayer.model.AudioTracks;
 import com.novoda.noplayer.model.LoadTimeout;
 import com.novoda.noplayer.model.PlayerAudioTrack;
 import com.novoda.noplayer.model.PlayerAudioTrackFixture;
 import com.novoda.noplayer.model.Timeout;
-import com.novoda.noplayer.internal.utils.NoPlayerLog;
 
 import java.util.Collections;
 
@@ -423,42 +425,42 @@ public class AndroidMediaPlayerImplTest {
 
         @Test
         public void whenLoadingVideo_thenNotifiesBufferStateListenersThatBufferStarted() {
-            player.loadVideo(URI, ContentType.HLS);
+            player.loadVideo(URI, OPTIONS);
 
             verify(bufferStateListener).onBufferStarted();
         }
 
         @Test
         public void whenLoadingVideo_thenPreparesVideo() {
-            player.loadVideo(URI, ContentType.HLS);
+            player.loadVideo(URI, OPTIONS);
 
             verify(mediaPlayer).prepareVideo(URI, surfaceHolder);
         }
 
         @Test
         public void whenLoadingVideoWithTimeout_thenNotifiesBufferStateListenersThatBufferStarted() {
-            player.loadVideoWithTimeout(URI, ContentType.HLS, ANY_TIMEOUT, ANY_LOAD_TIMEOUT_CALLBACK);
+            player.loadVideoWithTimeout(URI, OPTIONS, ANY_TIMEOUT, ANY_LOAD_TIMEOUT_CALLBACK);
 
             verify(bufferStateListener).onBufferStarted();
         }
 
         @Test
         public void whenLoadingVideoWithTimeout_thenPreparesVideo() {
-            player.loadVideoWithTimeout(URI, ContentType.HLS, ANY_TIMEOUT, ANY_LOAD_TIMEOUT_CALLBACK);
+            player.loadVideoWithTimeout(URI, OPTIONS, ANY_TIMEOUT, ANY_LOAD_TIMEOUT_CALLBACK);
 
             verify(mediaPlayer).prepareVideo(URI, surfaceHolder);
         }
 
         @Test
         public void whenLoadingVideoWithTimeout_thenStartsTimeout() {
-            player.loadVideoWithTimeout(URI, ContentType.HLS, ANY_TIMEOUT, ANY_LOAD_TIMEOUT_CALLBACK);
+            player.loadVideoWithTimeout(URI, OPTIONS, ANY_TIMEOUT, ANY_LOAD_TIMEOUT_CALLBACK);
 
             verify(loadTimeout).start(ANY_TIMEOUT, ANY_LOAD_TIMEOUT_CALLBACK);
         }
 
         @Test
         public void whenLoadingVideo_thenShowsContainerView() {
-            player.loadVideo(URI, ContentType.HLS);
+            player.loadVideo(URI, OPTIONS);
 
             verify(containerView).setVisibility(View.VISIBLE);
         }
@@ -515,7 +517,7 @@ public class AndroidMediaPlayerImplTest {
         public void givenPlayerHasPlayedVideo_whenLoadingVideo_thenPlayerIsReleased_andNotListeners() {
             given(mediaPlayer.hasPlayedContent()).willReturn(true);
 
-            player.loadVideo(URI, ContentType.HLS);
+            player.loadVideo(URI, OPTIONS);
 
             verify(stateChangedListener).onVideoStopped();
             verify(loadTimeout).cancel();
@@ -528,7 +530,7 @@ public class AndroidMediaPlayerImplTest {
         public void givenPlayerHasPlayedVideo_whenLoadingVideoWithTimeout_thenPlayerResourcesAreReleased_andNotListeners() {
             given(mediaPlayer.hasPlayedContent()).willReturn(true);
 
-            player.loadVideoWithTimeout(URI, ContentType.HLS, ANY_TIMEOUT, ANY_LOAD_TIMEOUT_CALLBACK);
+            player.loadVideoWithTimeout(URI, OPTIONS, ANY_TIMEOUT, ANY_LOAD_TIMEOUT_CALLBACK);
 
             verify(stateChangedListener).onVideoStopped();
             verify(loadTimeout).cancel();
@@ -541,7 +543,7 @@ public class AndroidMediaPlayerImplTest {
         public void givenPlayerHasNotPlayedVideo_whenLoadingVideo_thenPlayerResourcesAreNotReleased() {
             given(mediaPlayer.hasPlayedContent()).willReturn(false);
 
-            player.loadVideo(URI, ContentType.HLS);
+            player.loadVideo(URI, OPTIONS);
 
             verify(stateChangedListener, never()).onVideoStopped();
             verify(loadTimeout, never()).cancel();
@@ -553,7 +555,7 @@ public class AndroidMediaPlayerImplTest {
         public void givenPlayerHasNotPlayedVideo_whenLoadingVideoWithTimeout_thenPlayerResourcesAreNotReleased() {
             given(mediaPlayer.hasPlayedContent()).willReturn(false);
 
-            player.loadVideoWithTimeout(URI, ContentType.HLS, ANY_TIMEOUT, ANY_LOAD_TIMEOUT_CALLBACK);
+            player.loadVideoWithTimeout(URI, OPTIONS, ANY_TIMEOUT, ANY_LOAD_TIMEOUT_CALLBACK);
 
             verify(stateChangedListener, never()).onVideoStopped();
             verify(loadTimeout, never()).cancel();
@@ -637,8 +639,9 @@ public class AndroidMediaPlayerImplTest {
         }
     }
 
-    public static abstract class Base {
+    public abstract static class Base {
 
+        static final Options OPTIONS = new OptionsBuilder().withContentType(ContentType.H264).build();
         static final long BEGINNING_POSITION = 0;
         static final Uri URI = Mockito.mock(Uri.class);
         static final int TEN_SECONDS = 10;

--- a/demo/src/main/java/com/novoda/demo/DemoPresenter.java
+++ b/demo/src/main/java/com/novoda/demo/DemoPresenter.java
@@ -2,9 +2,9 @@ package com.novoda.demo;
 
 import android.net.Uri;
 
-import com.novoda.noplayer.ContentType;
 import com.novoda.noplayer.Listeners;
 import com.novoda.noplayer.NoPlayer;
+import com.novoda.noplayer.Options;
 import com.novoda.noplayer.PlayerState;
 import com.novoda.noplayer.PlayerView;
 
@@ -22,7 +22,7 @@ class DemoPresenter {
         this.playerView = playerView;
     }
 
-    void startPresenting(Uri uri, ContentType contentType) {
+    void startPresenting(Uri uri, Options options) {
         listeners.addPreparedListener(playOnPrepared);
         listeners.addStateChangedListener(updatePlayPause);
         listeners.addHeartbeatCallback(updateProgress);
@@ -32,7 +32,7 @@ class DemoPresenter {
         controllerView.setToggleVolumeOnOffAction(onToggleVolume);
 
         noPlayer.attach(playerView);
-        noPlayer.loadVideo(uri, contentType);
+        noPlayer.loadVideo(uri, options);
     }
 
     private final NoPlayer.PreparedListener playOnPrepared = new NoPlayer.PreparedListener() {

--- a/demo/src/main/java/com/novoda/demo/MainActivity.java
+++ b/demo/src/main/java/com/novoda/demo/MainActivity.java
@@ -18,6 +18,7 @@ public class MainActivity extends Activity {
 
     private static final String URI_VIDEO_WIDEVINE_EXAMPLE_MODULAR_MPD = "https://storage.googleapis.com/wvmedia/cenc/h264/tears/tears.mpd";
     private static final String EXAMPLE_MODULAR_LICENSE_SERVER_PROXY = "https://proxy.uat.widevine.com/proxy?provider=widevine_test";
+    private static final int HALF_A_SECOND_IN_MILLIS = 500;
 
     private NoPlayer player;
     private DemoPresenter demoPresenter;
@@ -53,7 +54,10 @@ public class MainActivity extends Activity {
     protected void onStart() {
         super.onStart();
         Uri uri = Uri.parse(URI_VIDEO_WIDEVINE_EXAMPLE_MODULAR_MPD);
-        Options options = new OptionsBuilder().withContentType(ContentType.DASH).build();
+        Options options = new OptionsBuilder()
+                .withContentType(ContentType.DASH)
+                .withMinDurationBeforeQualityIncreaseInMillis(HALF_A_SECOND_IN_MILLIS)
+                .build();
         demoPresenter.startPresenting(uri, options);
     }
 

--- a/demo/src/main/java/com/novoda/demo/MainActivity.java
+++ b/demo/src/main/java/com/novoda/demo/MainActivity.java
@@ -8,6 +8,8 @@ import android.widget.Toast;
 
 import com.novoda.noplayer.ContentType;
 import com.novoda.noplayer.NoPlayer;
+import com.novoda.noplayer.Options;
+import com.novoda.noplayer.OptionsBuilder;
 import com.novoda.noplayer.PlayerBuilder;
 import com.novoda.noplayer.PlayerView;
 import com.novoda.noplayer.internal.utils.NoPlayerLog;
@@ -51,7 +53,8 @@ public class MainActivity extends Activity {
     protected void onStart() {
         super.onStart();
         Uri uri = Uri.parse(URI_VIDEO_WIDEVINE_EXAMPLE_MODULAR_MPD);
-        demoPresenter.startPresenting(uri, ContentType.DASH);
+        Options options = new OptionsBuilder().withContentType(ContentType.DASH).build();
+        demoPresenter.startPresenting(uri, options);
     }
 
     private final View.OnClickListener showVideoSelectionDialog = new View.OnClickListener() {


### PR DESCRIPTION
## Problem
We want to be able to change the duration between track changes on the `exo-player`. The duration needs to be able to change per `loadVideo` but atm we pass `Uri` and `ContentType`, adding an additional param to this may be overkill and we will most likely continue to add params as we need more customisation.

## Solution
This PR builds on #144 by creating an `Options` and an associated `OptionsBuilder`. Client applications can now create an `Options` with a `ContentType` and `minDurationBeforeQualityChanges`, this `Options` is then passed to the `loadVideo` which is then passed to the necessary `Player`/`TrackSelector`.

### Test(s) added 
Updated existing tests that broke on changing the `NoPlayer` api.

### Paired with 
Nobody.
