### PR TITLE
Add max initial bitrate to options

### DIFF
--- a/core/src/main/java/com/novoda/noplayer/Options.java
+++ b/core/src/main/java/com/novoda/noplayer/Options.java
@@ -4,10 +4,12 @@ public class Options {
 
     private final ContentType contentType;
     private final int minDurationBeforeQualityIncreaseInMillis;
+    private final int maxInitialBitrate;
 
-    Options(ContentType contentType, int minDurationBeforeQualityIncreaseInMillis) {
+    Options(ContentType contentType, int minDurationBeforeQualityIncreaseInMillis, int maxInitialBitrate) {
         this.contentType = contentType;
         this.minDurationBeforeQualityIncreaseInMillis = minDurationBeforeQualityIncreaseInMillis;
+        this.maxInitialBitrate = maxInitialBitrate;
     }
 
     public ContentType contentType() {
@@ -16,5 +18,9 @@ public class Options {
 
     public int minDurationBeforeQualityIncreaseInMillis() {
         return minDurationBeforeQualityIncreaseInMillis;
+    }
+
+    public int maxInitialBitrate() {
+        return maxInitialBitrate;
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/OptionsBuilder.java
+++ b/core/src/main/java/com/novoda/noplayer/OptionsBuilder.java
@@ -8,9 +8,11 @@ import android.net.Uri;
 public class OptionsBuilder {
 
     private static final int DEFAULT_MIN_DURATION_FOR_QUALITY_INCREASE_MS = 10000;
+    private static final int DEFAULT_MAX_INITIAL_BITRATE = 800000;
 
     private ContentType contentType = ContentType.H264;
     private int minDurationBeforeQualityIncreaseInMillis = DEFAULT_MIN_DURATION_FOR_QUALITY_INCREASE_MS;
+    private int maxInitialBitrate = DEFAULT_MAX_INITIAL_BITRATE;
 
     /**
      * Sets {@link OptionsBuilder} to build {@link Options} with a given {@link ContentType}.
@@ -37,12 +39,25 @@ public class OptionsBuilder {
     }
 
     /**
+     * Sets {@link OptionsBuilder} to build {@link Options} with given maximum initial bitrate in order to
+     * control what is the quality with which {@link NoPlayer} starts the playback. Setting a higher value
+     * allows the player to choose a higher quality video track at the beginning.
+     *
+     * @param maxInitialBitrate maximum bitrate that limits the initial track selection.
+     * @return {@link OptionsBuilder}
+     */
+    public OptionsBuilder withMaxInitialBitrate(int maxInitialBitrate) {
+        this.maxInitialBitrate = maxInitialBitrate;
+        return this;
+    }
+
+    /**
      * Builds a new {@link Options} instance.
      *
      * @return a {@link Options} instance.
      */
     public Options build() {
-        return new Options(contentType, minDurationBeforeQualityIncreaseInMillis);
+        return new Options(contentType, minDurationBeforeQualityIncreaseInMillis, maxInitialBitrate);
     }
 
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/CompositeTrackSelectorCreator.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/CompositeTrackSelectorCreator.java
@@ -23,7 +23,7 @@ class CompositeTrackSelectorCreator {
     CompositeTrackSelector create(Options options) {
         TrackSelection.Factory adaptiveTrackSelectionFactory = new AdaptiveTrackSelection.Factory(
                 bandwidthMeter,
-                AdaptiveTrackSelection.DEFAULT_MAX_INITIAL_BITRATE,
+                options.maxInitialBitrate(),
                 options.minDurationBeforeQualityIncreaseInMillis(),
                 AdaptiveTrackSelection.DEFAULT_MAX_DURATION_FOR_QUALITY_DECREASE_MS,
                 AdaptiveTrackSelection.DEFAULT_MIN_DURATION_TO_RETAIN_AFTER_DISCARD_MS,

--- a/demo/src/main/java/com/novoda/demo/MainActivity.java
+++ b/demo/src/main/java/com/novoda/demo/MainActivity.java
@@ -19,6 +19,7 @@ public class MainActivity extends Activity {
     private static final String URI_VIDEO_WIDEVINE_EXAMPLE_MODULAR_MPD = "https://storage.googleapis.com/wvmedia/cenc/h264/tears/tears.mpd";
     private static final String EXAMPLE_MODULAR_LICENSE_SERVER_PROXY = "https://proxy.uat.widevine.com/proxy?provider=widevine_test";
     private static final int HALF_A_SECOND_IN_MILLIS = 500;
+    private static final int TWO_MEGABITS = 2000000;
 
     private NoPlayer player;
     private DemoPresenter demoPresenter;
@@ -57,6 +58,7 @@ public class MainActivity extends Activity {
         Options options = new OptionsBuilder()
                 .withContentType(ContentType.DASH)
                 .withMinDurationBeforeQualityIncreaseInMillis(HALF_A_SECOND_IN_MILLIS)
+                .withMaxInitialBitrate(TWO_MEGABITS)
                 .build();
         demoPresenter.startPresenting(uri, options);
     }


### PR DESCRIPTION
## Problem

Track selection was a bit pessimistic with the quality of the initial track.

## Solution

Expose `maxInitialBitrate` in the `Options` in order to allow clients to set it.
This allows the player to start with a higher-quality rendition and then scale down if necessary.

### Test(s) added 

none, there were no tests to append

### Paired with 

nobody
