### PR TITLE
Options to influence default track selection

### DIFF
--- a/core/src/main/java/com/novoda/noplayer/NoPlayer.java
+++ b/core/src/main/java/com/novoda/noplayer/NoPlayer.java
@@ -72,22 +72,22 @@ public interface NoPlayer extends PlayerState {
     /**
      * Loads the video content and triggers the {@link NoPlayer.PreparedListener}.
      *
-     * @param uri         link to the content.
-     * @param contentType format of the content.
+     * @param uri     link to the content.
+     * @param options to be passed to the underlying player.
      * @throws IllegalStateException - if called before {@link NoPlayer#attach(PlayerView)}.
      */
-    void loadVideo(Uri uri, ContentType contentType) throws IllegalStateException;
+    void loadVideo(Uri uri, Options options) throws IllegalStateException;
 
     /**
      * Loads the video content and triggers the {@link NoPlayer.PreparedListener}.
      *
      * @param uri                 link to the content.
-     * @param contentType         format of the content.
+     * @param options             to be passed to the underlying player.
      * @param timeout             amount of time to wait before triggering {@link LoadTimeoutCallback}.
      * @param loadTimeoutCallback callback when loading has hit the timeout.
      * @throws IllegalStateException - if called before {@link NoPlayer#attach(PlayerView)}.
      */
-    void loadVideoWithTimeout(Uri uri, ContentType contentType, Timeout timeout, LoadTimeoutCallback loadTimeoutCallback);
+    void loadVideoWithTimeout(Uri uri, Options options, Timeout timeout, LoadTimeoutCallback loadTimeoutCallback);
 
     /**
      * Supplies information about the underlying player.

--- a/core/src/main/java/com/novoda/noplayer/NoPlayer.java
+++ b/core/src/main/java/com/novoda/noplayer/NoPlayer.java
@@ -26,7 +26,7 @@ public interface NoPlayer extends PlayerState {
     /**
      * Plays content of a prepared Player.
      *
-     * @throws IllegalStateException - if called before {@link NoPlayer#loadVideo(Uri, ContentType)}.
+     * @throws IllegalStateException - if called before {@link NoPlayer#loadVideo(Uri, Options)}.
      * @see NoPlayer.PreparedListener
      */
     void play() throws IllegalStateException;
@@ -35,7 +35,7 @@ public interface NoPlayer extends PlayerState {
      * Plays content of a prepared Player at a given position.
      *
      * @param positionInMillis to start playing content from.
-     * @throws IllegalStateException - if called before {@link NoPlayer#loadVideo(Uri, ContentType)}.
+     * @throws IllegalStateException - if called before {@link NoPlayer#loadVideo(Uri, Options)}.
      * @see NoPlayer.PreparedListener
      */
     void playAt(long positionInMillis) throws IllegalStateException;
@@ -43,7 +43,7 @@ public interface NoPlayer extends PlayerState {
     /**
      * Pauses content of a prepared Player.
      *
-     * @throws IllegalStateException - if called before {@link NoPlayer#loadVideo(Uri, ContentType)}.
+     * @throws IllegalStateException - if called before {@link NoPlayer#loadVideo(Uri, Options)}.
      * @see NoPlayer.PreparedListener
      */
     void pause() throws IllegalStateException;
@@ -53,13 +53,13 @@ public interface NoPlayer extends PlayerState {
      * Will not cause content to play if not already playing.
      *
      * @param positionInMillis to seek content to.
-     * @throws IllegalStateException - if called before {@link NoPlayer#loadVideo(Uri, ContentType)}.
+     * @throws IllegalStateException - if called before {@link NoPlayer#loadVideo(Uri, Options)}.
      * @see NoPlayer.PreparedListener
      */
     void seekTo(long positionInMillis) throws IllegalStateException;
 
     /**
-     * Stops playback of content and then requires call to {@link NoPlayer#loadVideo(Uri, ContentType)} to continue playback.
+     * Stops playback of content and then requires call to {@link NoPlayer#loadVideo(Uri, Options)} to continue playback.
      */
     void stop();
 
@@ -114,7 +114,7 @@ public interface NoPlayer extends PlayerState {
      * Retrieves all of the available {@link PlayerVideoTrack} of a prepared Player.
      *
      * @return a list of available {@link PlayerVideoTrack} of a prepared Player.
-     * @throws IllegalStateException - if called before {@link NoPlayer#loadVideo(Uri, ContentType)}.
+     * @throws IllegalStateException - if called before {@link NoPlayer#loadVideo(Uri, Options)}.
      * @see NoPlayer.PreparedListener
      */
     List<PlayerVideoTrack> getVideoTracks() throws IllegalStateException;
@@ -124,7 +124,7 @@ public interface NoPlayer extends PlayerState {
      *
      * @param videoTrack the video track to select.
      * @return whether the selection was successful.
-     * @throws IllegalStateException - if called before {@link NoPlayer#loadVideo(Uri, ContentType)}.
+     * @throws IllegalStateException - if called before {@link NoPlayer#loadVideo(Uri, Options)}.
      */
     boolean selectVideoTrack(PlayerVideoTrack videoTrack) throws IllegalStateException;
 
@@ -133,7 +133,7 @@ public interface NoPlayer extends PlayerState {
      * as an {@link Optional} or {@link Optional#absent()} if unavailable.
      *
      * @return {@link PlayerVideoTrack}.
-     * @throws IllegalStateException - if called before {@link NoPlayer#loadVideo(Uri, ContentType)}.
+     * @throws IllegalStateException - if called before {@link NoPlayer#loadVideo(Uri, Options)}.
      * @see NoPlayer.PreparedListener
      */
     Optional<PlayerVideoTrack> getSelectedVideoTrack() throws IllegalStateException;
@@ -142,7 +142,7 @@ public interface NoPlayer extends PlayerState {
      * Clears the {@link PlayerVideoTrack} selection made in {@link NoPlayer#selectVideoTrack(PlayerVideoTrack)}.
      *
      * @return whether the clear was successful.
-     * @throws IllegalStateException - if called before {@link NoPlayer#loadVideo(Uri, ContentType)}.
+     * @throws IllegalStateException - if called before {@link NoPlayer#loadVideo(Uri, Options)}.
      */
     boolean clearVideoTrackSelection() throws IllegalStateException;
 
@@ -150,7 +150,7 @@ public interface NoPlayer extends PlayerState {
      * Retrieves all of the available {@link PlayerAudioTrack} of a prepared Player.
      *
      * @return {@link AudioTracks} that contains a list of available {@link PlayerAudioTrack}.
-     * @throws IllegalStateException - if called before {@link NoPlayer#loadVideo(Uri, ContentType)}.
+     * @throws IllegalStateException - if called before {@link NoPlayer#loadVideo(Uri, Options)}.
      * @see NoPlayer.PreparedListener
      */
     AudioTracks getAudioTracks() throws IllegalStateException;
@@ -160,7 +160,7 @@ public interface NoPlayer extends PlayerState {
      *
      * @param audioTrack the audio track to select.
      * @return whether the selection was successful.
-     * @throws IllegalStateException - if called before {@link NoPlayer#loadVideo(Uri, ContentType)}.
+     * @throws IllegalStateException - if called before {@link NoPlayer#loadVideo(Uri, Options)}.
      */
     boolean selectAudioTrack(PlayerAudioTrack audioTrack) throws IllegalStateException;
 
@@ -168,7 +168,7 @@ public interface NoPlayer extends PlayerState {
      * Clears the {@link PlayerAudioTrack} selection made in {@link NoPlayer#selectAudioTrack(PlayerAudioTrack)}.
      *
      * @return whether the clear was successful.
-     * @throws IllegalStateException - if called before {@link NoPlayer#loadVideo(Uri, ContentType)}.
+     * @throws IllegalStateException - if called before {@link NoPlayer#loadVideo(Uri, Options)}.
      */
     boolean clearAudioTrackSelection() throws IllegalStateException;
 
@@ -176,7 +176,7 @@ public interface NoPlayer extends PlayerState {
      * Retrieves all of the available {@link PlayerSubtitleTrack} of a prepared Player.
      *
      * @return A list of available {@link PlayerSubtitleTrack}.
-     * @throws IllegalStateException - if called before {@link NoPlayer#loadVideo(Uri, ContentType)}.
+     * @throws IllegalStateException - if called before {@link NoPlayer#loadVideo(Uri, Options)}.
      * @see NoPlayer.PreparedListener
      */
     List<PlayerSubtitleTrack> getSubtitleTracks() throws IllegalStateException;
@@ -186,7 +186,7 @@ public interface NoPlayer extends PlayerState {
      *
      * @param subtitleTrack the subtitle track to select.
      * @return whether the selection was successful.
-     * @throws IllegalStateException - if called before {@link NoPlayer#loadVideo(Uri, ContentType)}.
+     * @throws IllegalStateException - if called before {@link NoPlayer#loadVideo(Uri, Options)}.
      */
     boolean showSubtitleTrack(PlayerSubtitleTrack subtitleTrack) throws IllegalStateException;
 
@@ -194,7 +194,7 @@ public interface NoPlayer extends PlayerState {
      * Clear and hide the subtitles on an attached PlayerView.
      *
      * @return whether the hide was successful.
-     * @throws IllegalStateException - if called before {@link NoPlayer#loadVideo(Uri, ContentType)}.
+     * @throws IllegalStateException - if called before {@link NoPlayer#loadVideo(Uri, Options)}.
      */
     boolean hideSubtitleTrack() throws IllegalStateException;
 
@@ -202,7 +202,7 @@ public interface NoPlayer extends PlayerState {
      * Set the Player to repeat the content.
      *
      * @param repeating true to set repeating, false to disable.
-     * @throws IllegalStateException - if called before {@link NoPlayer#loadVideo(Uri, ContentType)}.
+     * @throws IllegalStateException - if called before {@link NoPlayer#loadVideo(Uri, Options)}.
      */
     void setRepeating(boolean repeating) throws IllegalStateException;
 
@@ -210,14 +210,15 @@ public interface NoPlayer extends PlayerState {
      * Set the audio volume, with 0 being silence and 1 being unity gain.
      *
      * @param volume The audio volume.
-     * @throws IllegalStateException - if called before {@link NoPlayer#loadVideo(Uri, ContentType)}.
+     * @throws IllegalStateException - if called before {@link NoPlayer#loadVideo(Uri, Options)}.
      */
     void setVolume(@FloatRange(from = 0.0f, to = 1.0f) float volume) throws IllegalStateException;
 
     /**
      * Return the audio volume, with 0 being silence and 1 being unity gain.
      *
-     * @throws IllegalStateException - if called before {@link NoPlayer#loadVideo(Uri, ContentType)}.
+     * @return audio volume.
+     * @throws IllegalStateException - if called before {@link NoPlayer#loadVideo(Uri, Options)}.
      */
     @FloatRange(from = 0.0f, to = 1.0f)
     float getVolume() throws IllegalStateException;

--- a/core/src/main/java/com/novoda/noplayer/Options.java
+++ b/core/src/main/java/com/novoda/noplayer/Options.java
@@ -1,0 +1,20 @@
+package com.novoda.noplayer;
+
+public class Options {
+
+    private final ContentType contentType;
+    private final int minDurationBeforeQualityIncreaseInMillis;
+
+    Options(ContentType contentType, int minDurationBeforeQualityIncreaseInMillis) {
+        this.contentType = contentType;
+        this.minDurationBeforeQualityIncreaseInMillis = minDurationBeforeQualityIncreaseInMillis;
+    }
+
+    public ContentType contentType() {
+        return contentType;
+    }
+
+    public int minDurationBeforeQualityIncreaseInMillis() {
+        return minDurationBeforeQualityIncreaseInMillis;
+    }
+}

--- a/core/src/main/java/com/novoda/noplayer/Options.java
+++ b/core/src/main/java/com/novoda/noplayer/Options.java
@@ -4,10 +4,12 @@ public class Options {
 
     private final ContentType contentType;
     private final int minDurationBeforeQualityIncreaseInMillis;
+    private final int maxInitialBitrate;
 
-    Options(ContentType contentType, int minDurationBeforeQualityIncreaseInMillis) {
+    Options(ContentType contentType, int minDurationBeforeQualityIncreaseInMillis, int maxInitialBitrate) {
         this.contentType = contentType;
         this.minDurationBeforeQualityIncreaseInMillis = minDurationBeforeQualityIncreaseInMillis;
+        this.maxInitialBitrate = maxInitialBitrate;
     }
 
     public ContentType contentType() {
@@ -16,5 +18,9 @@ public class Options {
 
     public int minDurationBeforeQualityIncreaseInMillis() {
         return minDurationBeforeQualityIncreaseInMillis;
+    }
+
+    public int maxInitialBitrate() {
+        return maxInitialBitrate;
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/OptionsBuilder.java
+++ b/core/src/main/java/com/novoda/noplayer/OptionsBuilder.java
@@ -1,0 +1,48 @@
+package com.novoda.noplayer;
+
+import android.net.Uri;
+
+/**
+ * Builds instances of {@link Options} for {@link NoPlayer#loadVideo(Uri, Options)}.
+ */
+public class OptionsBuilder {
+
+    private static final int DEFAULT_MIN_DURATION_FOR_QUALITY_INCREASE_MS = 10000;
+
+    private ContentType contentType = ContentType.H264;
+    private int minDurationBeforeQualityIncreaseInMillis = DEFAULT_MIN_DURATION_FOR_QUALITY_INCREASE_MS;
+
+    /**
+     * Sets {@link OptionsBuilder} to build {@link Options} with a given {@link ContentType}.
+     * This content type is passed to the underlying Player.
+     *
+     * @param contentType format of the content.
+     * @return {@link OptionsBuilder}.
+     */
+    public OptionsBuilder withContentType(ContentType contentType) {
+        this.contentType = contentType;
+        return this;
+    }
+
+    /**
+     * Sets {@link OptionsBuilder} to build {@link Options} so that the {@link NoPlayer}
+     * switches to a higher quality video track after {@param minDurationInMillis}.
+     *
+     * @param minDurationInMillis before switching to a higher quality video track.
+     * @return {@link OptionsBuilder}.
+     */
+    public OptionsBuilder withMinDurationBeforeQualityIncreaseInMillis(int minDurationInMillis) {
+        this.minDurationBeforeQualityIncreaseInMillis = minDurationInMillis;
+        return this;
+    }
+
+    /**
+     * Builds a new {@link Options} instance.
+     *
+     * @return a {@link Options} instance.
+     */
+    public Options build() {
+        return new Options(contentType, minDurationBeforeQualityIncreaseInMillis);
+    }
+
+}

--- a/core/src/main/java/com/novoda/noplayer/OptionsBuilder.java
+++ b/core/src/main/java/com/novoda/noplayer/OptionsBuilder.java
@@ -8,9 +8,11 @@ import android.net.Uri;
 public class OptionsBuilder {
 
     private static final int DEFAULT_MIN_DURATION_FOR_QUALITY_INCREASE_MS = 10000;
+    private static final int DEFAULT_MAX_INITIAL_BITRATE = 800000;
 
     private ContentType contentType = ContentType.H264;
     private int minDurationBeforeQualityIncreaseInMillis = DEFAULT_MIN_DURATION_FOR_QUALITY_INCREASE_MS;
+    private int maxInitialBitrate = DEFAULT_MAX_INITIAL_BITRATE;
 
     /**
      * Sets {@link OptionsBuilder} to build {@link Options} with a given {@link ContentType}.
@@ -37,12 +39,25 @@ public class OptionsBuilder {
     }
 
     /**
+     * Sets {@link OptionsBuilder} to build {@link Options} with given maximum initial bitrate in order to
+     * control what is the quality with which {@link NoPlayer} starts the playback. Setting a higher value
+     * allows the player to choose a higher quality video track at the beginning.
+     *
+     * @param maxInitialBitrate maximum bitrate that limits the initial track selection.
+     * @return {@link OptionsBuilder}
+     */
+    public OptionsBuilder withMaxInitialBitrate(int maxInitialBitrate) {
+        this.maxInitialBitrate = maxInitialBitrate;
+        return this;
+    }
+
+    /**
      * Builds a new {@link Options} instance.
      *
      * @return a {@link Options} instance.
      */
     public Options build() {
-        return new Options(contentType, minDurationBeforeQualityIncreaseInMillis);
+        return new Options(contentType, minDurationBeforeQualityIncreaseInMillis, maxInitialBitrate);
     }
 
 }

--- a/core/src/main/java/com/novoda/noplayer/OptionsBuilder.java
+++ b/core/src/main/java/com/novoda/noplayer/OptionsBuilder.java
@@ -26,9 +26,9 @@ public class OptionsBuilder {
 
     /**
      * Sets {@link OptionsBuilder} to build {@link Options} so that the {@link NoPlayer}
-     * switches to a higher quality video track after {@param minDurationInMillis}.
+     * switches to a higher quality video track after given time.
      *
-     * @param minDurationInMillis before switching to a higher quality video track.
+     * @param minDurationInMillis time elapsed before switching to a higher quality video track.
      * @return {@link OptionsBuilder}.
      */
     public OptionsBuilder withMinDurationBeforeQualityIncreaseInMillis(int minDurationInMillis) {

--- a/core/src/main/java/com/novoda/noplayer/PlayerBuilder.java
+++ b/core/src/main/java/com/novoda/noplayer/PlayerBuilder.java
@@ -78,7 +78,8 @@ public class PlayerBuilder {
      * Sets {@link PlayerBuilder} to build a {@link NoPlayer} which will prioritise the underlying player when
      * multiple underlying players share the same features.
      *
-     * @param playerTypes Priority order of {@link PlayerType} with the first being the highest.
+     * @param playerType First {@link PlayerType} with the highest priority.
+     * @param playerTypes Remaining {@link PlayerType} in order of priority.
      * @return {@link PlayerBuilder}
      * @see NoPlayer
      */
@@ -104,7 +105,7 @@ public class PlayerBuilder {
     /**
      * Builds a new {@link NoPlayer} instance.
      *
-     * @param context
+     * @param context The {@link Context} associated with the player.
      * @return a {@link NoPlayer} instance.
      * @throws UnableToCreatePlayerException thrown when the configuration is not supported and there is no way to recover.
      * @see NoPlayer

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/CompositeTrackSelector.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/CompositeTrackSelector.java
@@ -1,0 +1,90 @@
+package com.novoda.noplayer.internal.exoplayer;
+
+import com.google.android.exoplayer2.ExoPlaybackException;
+import com.google.android.exoplayer2.RendererCapabilities;
+import com.google.android.exoplayer2.SimpleExoPlayer;
+import com.google.android.exoplayer2.source.TrackGroupArray;
+import com.google.android.exoplayer2.trackselection.DefaultTrackSelector;
+import com.google.android.exoplayer2.trackselection.TrackSelector;
+import com.google.android.exoplayer2.trackselection.TrackSelectorResult;
+import com.novoda.noplayer.ContentType;
+import com.novoda.noplayer.internal.exoplayer.mediasource.ExoPlayerAudioTrackSelector;
+import com.novoda.noplayer.internal.exoplayer.mediasource.ExoPlayerSubtitleTrackSelector;
+import com.novoda.noplayer.internal.exoplayer.mediasource.ExoPlayerVideoTrackSelector;
+import com.novoda.noplayer.internal.utils.Optional;
+import com.novoda.noplayer.model.AudioTracks;
+import com.novoda.noplayer.model.PlayerAudioTrack;
+import com.novoda.noplayer.model.PlayerSubtitleTrack;
+import com.novoda.noplayer.model.PlayerVideoTrack;
+
+import java.util.List;
+
+class CompositeTrackSelector extends TrackSelector {
+
+    private final DefaultTrackSelector defaultTrackSelector;
+    private final ExoPlayerAudioTrackSelector audioTrackSelector;
+    private final ExoPlayerVideoTrackSelector videoTrackSelector;
+    private final ExoPlayerSubtitleTrackSelector subtitleTrackSelector;
+
+    CompositeTrackSelector(DefaultTrackSelector defaultTrackSelector,
+                           ExoPlayerAudioTrackSelector audioTrackSelector,
+                           ExoPlayerVideoTrackSelector videoTrackSelector,
+                           ExoPlayerSubtitleTrackSelector subtitleTrackSelector) {
+        this.defaultTrackSelector = defaultTrackSelector;
+        this.audioTrackSelector = audioTrackSelector;
+        this.videoTrackSelector = videoTrackSelector;
+        this.subtitleTrackSelector = subtitleTrackSelector;
+    }
+
+    boolean selectAudioTrack(PlayerAudioTrack audioTrack, RendererTypeRequester rendererTypeRequester) {
+        return audioTrackSelector.selectAudioTrack(audioTrack, rendererTypeRequester);
+    }
+
+    AudioTracks getAudioTracks(RendererTypeRequester rendererTypeRequester) {
+        return audioTrackSelector.getAudioTracks(rendererTypeRequester);
+    }
+
+    boolean clearAudioTrack(RendererTypeRequester rendererTypeRequester) {
+        return audioTrackSelector.clearAudioTrack(rendererTypeRequester);
+    }
+
+    boolean selectVideoTrack(PlayerVideoTrack videoTrack, RendererTypeRequester rendererTypeRequester) {
+        return videoTrackSelector.selectVideoTrack(videoTrack, rendererTypeRequester);
+    }
+
+    List<PlayerVideoTrack> getVideoTracks(RendererTypeRequester rendererTypeRequester, ContentType contentType) {
+        return videoTrackSelector.getVideoTracks(rendererTypeRequester, contentType);
+    }
+
+    Optional<PlayerVideoTrack> getSelectedVideoTrack(SimpleExoPlayer exoPlayer,
+                                                     RendererTypeRequester rendererTypeRequester,
+                                                     ContentType contentType) {
+        return videoTrackSelector.getSelectedVideoTrack(exoPlayer, rendererTypeRequester, contentType);
+    }
+
+    boolean clearVideoTrack(RendererTypeRequester rendererTypeRequester) {
+        return videoTrackSelector.clearVideoTrack(rendererTypeRequester);
+    }
+
+    boolean selectTextTrack(PlayerSubtitleTrack subtitleTrack, RendererTypeRequester rendererTypeRequester) {
+        return subtitleTrackSelector.selectTextTrack(subtitleTrack, rendererTypeRequester);
+    }
+
+    List<PlayerSubtitleTrack> getSubtitleTracks(RendererTypeRequester rendererTypeRequester) {
+        return subtitleTrackSelector.getSubtitleTracks(rendererTypeRequester);
+    }
+
+    boolean clearSubtitleTrack(RendererTypeRequester rendererTypeRequester) {
+        return subtitleTrackSelector.clearSubtitleTrack(rendererTypeRequester);
+    }
+
+    @Override
+    public TrackSelectorResult selectTracks(RendererCapabilities[] rendererCapabilities, TrackGroupArray trackGroups) throws ExoPlaybackException {
+        return defaultTrackSelector.selectTracks(rendererCapabilities, trackGroups);
+    }
+
+    @Override
+    public void onSelectionActivated(Object info) {
+        defaultTrackSelector.onSelectionActivated(info);
+    }
+}

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/CompositeTrackSelectorCreator.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/CompositeTrackSelectorCreator.java
@@ -5,6 +5,8 @@ import com.google.android.exoplayer2.trackselection.DefaultTrackSelector;
 import com.google.android.exoplayer2.trackselection.FixedTrackSelection;
 import com.google.android.exoplayer2.trackselection.TrackSelection;
 import com.google.android.exoplayer2.upstream.DefaultBandwidthMeter;
+import com.google.android.exoplayer2.util.Clock;
+import com.novoda.noplayer.Options;
 import com.novoda.noplayer.internal.exoplayer.mediasource.ExoPlayerAudioTrackSelector;
 import com.novoda.noplayer.internal.exoplayer.mediasource.ExoPlayerSubtitleTrackSelector;
 import com.novoda.noplayer.internal.exoplayer.mediasource.ExoPlayerTrackSelector;
@@ -18,8 +20,18 @@ class CompositeTrackSelectorCreator {
         this.bandwidthMeter = bandwidthMeter;
     }
 
-    CompositeTrackSelector create() {
-        TrackSelection.Factory adaptiveTrackSelectionFactory = new AdaptiveTrackSelection.Factory(bandwidthMeter);
+    CompositeTrackSelector create(Options options) {
+        TrackSelection.Factory adaptiveTrackSelectionFactory = new AdaptiveTrackSelection.Factory(
+                bandwidthMeter,
+                AdaptiveTrackSelection.DEFAULT_MAX_INITIAL_BITRATE,
+                options.minDurationBeforeQualityIncreaseInMillis(),
+                AdaptiveTrackSelection.DEFAULT_MAX_DURATION_FOR_QUALITY_DECREASE_MS,
+                AdaptiveTrackSelection.DEFAULT_MIN_DURATION_TO_RETAIN_AFTER_DISCARD_MS,
+                AdaptiveTrackSelection.DEFAULT_BANDWIDTH_FRACTION,
+                AdaptiveTrackSelection.DEFAULT_BUFFERED_FRACTION_TO_LIVE_EDGE_FOR_QUALITY_INCREASE,
+                AdaptiveTrackSelection.DEFAULT_MIN_TIME_BETWEEN_BUFFER_REEVALUTATION_MS,
+                Clock.DEFAULT
+        );
         DefaultTrackSelector trackSelector = new DefaultTrackSelector(adaptiveTrackSelectionFactory);
 
         ExoPlayerTrackSelector exoPlayerTrackSelector = ExoPlayerTrackSelector.newInstance(trackSelector);

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/CompositeTrackSelectorCreator.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/CompositeTrackSelectorCreator.java
@@ -1,0 +1,36 @@
+package com.novoda.noplayer.internal.exoplayer;
+
+import com.google.android.exoplayer2.trackselection.AdaptiveTrackSelection;
+import com.google.android.exoplayer2.trackselection.DefaultTrackSelector;
+import com.google.android.exoplayer2.trackselection.FixedTrackSelection;
+import com.google.android.exoplayer2.trackselection.TrackSelection;
+import com.google.android.exoplayer2.upstream.DefaultBandwidthMeter;
+import com.novoda.noplayer.internal.exoplayer.mediasource.ExoPlayerAudioTrackSelector;
+import com.novoda.noplayer.internal.exoplayer.mediasource.ExoPlayerSubtitleTrackSelector;
+import com.novoda.noplayer.internal.exoplayer.mediasource.ExoPlayerTrackSelector;
+import com.novoda.noplayer.internal.exoplayer.mediasource.ExoPlayerVideoTrackSelector;
+
+class CompositeTrackSelectorCreator {
+
+    private final DefaultBandwidthMeter bandwidthMeter;
+
+    CompositeTrackSelectorCreator(DefaultBandwidthMeter bandwidthMeter) {
+        this.bandwidthMeter = bandwidthMeter;
+    }
+
+    CompositeTrackSelector create() {
+        TrackSelection.Factory adaptiveTrackSelectionFactory = new AdaptiveTrackSelection.Factory(bandwidthMeter);
+        DefaultTrackSelector trackSelector = new DefaultTrackSelector(adaptiveTrackSelectionFactory);
+
+        ExoPlayerTrackSelector exoPlayerTrackSelector = ExoPlayerTrackSelector.newInstance(trackSelector);
+        FixedTrackSelection.Factory trackSelectionFactory = new FixedTrackSelection.Factory();
+        ExoPlayerAudioTrackSelector audioTrackSelector = new ExoPlayerAudioTrackSelector(exoPlayerTrackSelector, trackSelectionFactory);
+        ExoPlayerVideoTrackSelector videoTrackSelector = new ExoPlayerVideoTrackSelector(exoPlayerTrackSelector, trackSelectionFactory);
+        ExoPlayerSubtitleTrackSelector subtitleTrackSelector = new ExoPlayerSubtitleTrackSelector(
+                exoPlayerTrackSelector,
+                trackSelectionFactory
+        );
+        return new CompositeTrackSelector(trackSelector, audioTrackSelector, videoTrackSelector, subtitleTrackSelector);
+    }
+
+}

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/CompositeTrackSelectorCreator.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/CompositeTrackSelectorCreator.java
@@ -23,7 +23,7 @@ class CompositeTrackSelectorCreator {
     CompositeTrackSelector create(Options options) {
         TrackSelection.Factory adaptiveTrackSelectionFactory = new AdaptiveTrackSelection.Factory(
                 bandwidthMeter,
-                AdaptiveTrackSelection.DEFAULT_MAX_INITIAL_BITRATE,
+                options.maxInitialBitrate(),
                 options.minDurationBeforeQualityIncreaseInMillis(),
                 AdaptiveTrackSelection.DEFAULT_MAX_DURATION_FOR_QUALITY_DECREASE_MS,
                 AdaptiveTrackSelection.DEFAULT_MIN_DURATION_TO_RETAIN_AFTER_DISCARD_MS,

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerCreator.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerCreator.java
@@ -12,7 +12,7 @@ import com.google.android.exoplayer2.drm.DrmSessionManager;
 import com.google.android.exoplayer2.drm.FrameworkMediaCrypto;
 import com.google.android.exoplayer2.mediacodec.MediaCodecSelector;
 import com.google.android.exoplayer2.text.SubtitleDecoderFactory;
-import com.google.android.exoplayer2.trackselection.DefaultTrackSelector;
+import com.google.android.exoplayer2.trackselection.TrackSelector;
 import com.novoda.noplayer.internal.exoplayer.drm.DrmSessionCreator;
 import com.novoda.noplayer.text.NoPlayerSubtitleDecoderFactory;
 
@@ -23,17 +23,16 @@ class ExoPlayerCreator {
     private static final long DEFAULT_ALLOWED_VIDEO_JOINING_TIME_MS = 5000;
 
     private final Context context;
-    private final DefaultTrackSelector trackSelector;
 
-    ExoPlayerCreator(Context context, DefaultTrackSelector trackSelector) {
+    ExoPlayerCreator(Context context) {
         this.context = context;
-        this.trackSelector = trackSelector;
     }
 
     @NonNull
     public SimpleExoPlayer create(DrmSessionCreator drmSessionCreator,
                                   DefaultDrmSessionManager.EventListener drmSessionEventListener,
-                                  MediaCodecSelector mediaCodecSelector) {
+                                  MediaCodecSelector mediaCodecSelector,
+                                  TrackSelector trackSelector) {
         DrmSessionManager<FrameworkMediaCrypto> drmSessionManager = drmSessionCreator.create(drmSessionEventListener);
         SubtitleDecoderFactory subtitleDecoderFactory = new NoPlayerSubtitleDecoderFactory();
         RenderersFactory renderersFactory = new SimpleRenderersFactory(

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
@@ -9,7 +9,7 @@ import com.google.android.exoplayer2.SimpleExoPlayer;
 import com.google.android.exoplayer2.audio.AudioAttributes;
 import com.google.android.exoplayer2.mediacodec.MediaCodecSelector;
 import com.google.android.exoplayer2.source.MediaSource;
-import com.novoda.noplayer.ContentType;
+import com.novoda.noplayer.Options;
 import com.novoda.noplayer.internal.exoplayer.drm.DrmSessionCreator;
 import com.novoda.noplayer.internal.exoplayer.forwarder.ExoPlayerForwarder;
 import com.novoda.noplayer.internal.exoplayer.mediasource.MediaSourceFactory;
@@ -40,7 +40,7 @@ class ExoPlayerFacade {
     @Nullable
     private RendererTypeRequester rendererTypeRequester;
     @Nullable
-    private ContentType contentType;
+    private Options options;
 
     ExoPlayerFacade(AndroidDeviceVersion androidDeviceVersion,
                     MediaSourceFactory mediaSourceFactory,
@@ -103,11 +103,11 @@ class ExoPlayerFacade {
     void loadVideo(SurfaceHolder surfaceHolder,
                    DrmSessionCreator drmSessionCreator,
                    Uri uri,
-                   ContentType contentType,
+                   Options options,
                    ExoPlayerForwarder forwarder,
                    MediaCodecSelector mediaCodecSelector) {
-        this.contentType = contentType;
-        trackSelector = trackSelectorCreator.create();
+        this.options = options;
+        trackSelector = trackSelectorCreator.create(options);
         exoPlayer = exoPlayerCreator.create(drmSessionCreator, forwarder.drmSessionEventListener(), mediaCodecSelector, trackSelector);
         rendererTypeRequester = rendererTypeRequesterCreator.createfrom(exoPlayer);
         exoPlayer.addListener(forwarder.exoPlayerEventListener());
@@ -116,7 +116,7 @@ class ExoPlayerFacade {
         setMovieAudioAttributes(exoPlayer);
 
         MediaSource mediaSource = mediaSourceFactory.create(
-                contentType,
+                options.contentType(),
                 uri,
                 forwarder.extractorMediaSourceListener(),
                 forwarder.mediaSourceEventListener()
@@ -160,12 +160,12 @@ class ExoPlayerFacade {
 
     Optional<PlayerVideoTrack> getSelectedVideoTrack() {
         assertVideoLoaded();
-        return trackSelector.getSelectedVideoTrack(exoPlayer, rendererTypeRequester, contentType);
+        return trackSelector.getSelectedVideoTrack(exoPlayer, rendererTypeRequester, options.contentType());
     }
 
     List<PlayerVideoTrack> getVideoTracks() {
         assertVideoLoaded();
-        return trackSelector.getVideoTracks(rendererTypeRequester, contentType);
+        return trackSelector.getVideoTracks(rendererTypeRequester, options.contentType());
     }
 
     boolean clearVideoTrackSelection() {

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImpl.java
@@ -6,9 +6,9 @@ import android.view.SurfaceHolder;
 import android.view.View;
 
 import com.google.android.exoplayer2.mediacodec.MediaCodecSelector;
-import com.novoda.noplayer.ContentType;
 import com.novoda.noplayer.Listeners;
 import com.novoda.noplayer.NoPlayer;
+import com.novoda.noplayer.Options;
 import com.novoda.noplayer.PlayerInformation;
 import com.novoda.noplayer.PlayerState;
 import com.novoda.noplayer.PlayerView;
@@ -17,17 +17,18 @@ import com.novoda.noplayer.internal.Heart;
 import com.novoda.noplayer.internal.exoplayer.drm.DrmSessionCreator;
 import com.novoda.noplayer.internal.exoplayer.forwarder.ExoPlayerForwarder;
 import com.novoda.noplayer.internal.listeners.PlayerListenersHolder;
+import com.novoda.noplayer.internal.utils.Optional;
 import com.novoda.noplayer.model.AudioTracks;
 import com.novoda.noplayer.model.LoadTimeout;
 import com.novoda.noplayer.model.PlayerAudioTrack;
 import com.novoda.noplayer.model.PlayerSubtitleTrack;
 import com.novoda.noplayer.model.PlayerVideoTrack;
 import com.novoda.noplayer.model.Timeout;
-import com.novoda.noplayer.internal.utils.Optional;
 
 import java.util.List;
 
-@SuppressWarnings("PMD.GodClass") // Not much we can do, wrapping ExoPlayer is a lot of work
+@SuppressWarnings("PMD.GodClass")
+        // Not much we can do, wrapping ExoPlayer is a lot of work
 class ExoPlayerTwoImpl implements NoPlayer {
 
     private final ExoPlayerFacade exoPlayer;
@@ -199,7 +200,7 @@ class ExoPlayerTwoImpl implements NoPlayer {
     }
 
     @Override
-    public void loadVideo(final Uri uri, final ContentType contentType) {
+    public void loadVideo(final Uri uri, final Options options) {
         if (exoPlayer.hasPlayedContent()) {
             stop();
         }
@@ -207,7 +208,7 @@ class ExoPlayerTwoImpl implements NoPlayer {
         onSurfaceReadyCallback = new SurfaceHolderRequester.Callback() {
             @Override
             public void onSurfaceHolderReady(SurfaceHolder surfaceHolder) {
-                exoPlayer.loadVideo(surfaceHolder, drmSessionCreator, uri, contentType, forwarder, mediaCodecSelector);
+                exoPlayer.loadVideo(surfaceHolder, drmSessionCreator, uri, options, forwarder, mediaCodecSelector);
             }
         };
 
@@ -227,9 +228,9 @@ class ExoPlayerTwoImpl implements NoPlayer {
     }
 
     @Override
-    public void loadVideoWithTimeout(Uri uri, ContentType contentType, Timeout timeout, LoadTimeoutCallback loadTimeoutCallback) {
+    public void loadVideoWithTimeout(Uri uri, Options options, Timeout timeout, LoadTimeoutCallback loadTimeoutCallback) {
         loadTimeout.start(timeout, loadTimeoutCallback);
-        loadVideo(uri, contentType);
+        loadVideo(uri, options);
     }
 
     @Override

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerExoPlayerCreator.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerExoPlayerCreator.java
@@ -4,10 +4,6 @@ import android.content.Context;
 import android.os.Handler;
 
 import com.google.android.exoplayer2.mediacodec.MediaCodecSelector;
-import com.google.android.exoplayer2.trackselection.AdaptiveTrackSelection;
-import com.google.android.exoplayer2.trackselection.DefaultTrackSelector;
-import com.google.android.exoplayer2.trackselection.FixedTrackSelection;
-import com.google.android.exoplayer2.trackselection.TrackSelection;
 import com.google.android.exoplayer2.upstream.DefaultBandwidthMeter;
 import com.google.android.exoplayer2.upstream.DefaultDataSourceFactory;
 import com.novoda.noplayer.NoPlayer;
@@ -15,10 +11,6 @@ import com.novoda.noplayer.internal.Heart;
 import com.novoda.noplayer.internal.SystemClock;
 import com.novoda.noplayer.internal.exoplayer.drm.DrmSessionCreator;
 import com.novoda.noplayer.internal.exoplayer.forwarder.ExoPlayerForwarder;
-import com.novoda.noplayer.internal.exoplayer.mediasource.ExoPlayerAudioTrackSelector;
-import com.novoda.noplayer.internal.exoplayer.mediasource.ExoPlayerSubtitleTrackSelector;
-import com.novoda.noplayer.internal.exoplayer.mediasource.ExoPlayerTrackSelector;
-import com.novoda.noplayer.internal.exoplayer.mediasource.ExoPlayerVideoTrackSelector;
 import com.novoda.noplayer.internal.exoplayer.mediasource.MediaSourceFactory;
 import com.novoda.noplayer.internal.listeners.PlayerListenersHolder;
 import com.novoda.noplayer.internal.utils.AndroidDeviceVersion;
@@ -56,33 +48,22 @@ public class NoPlayerExoPlayerCreator {
             DefaultDataSourceFactory defaultDataSourceFactory = new DefaultDataSourceFactory(context, "user-agent", bandwidthMeter);
             MediaSourceFactory mediaSourceFactory = new MediaSourceFactory(defaultDataSourceFactory, handler);
 
-            TrackSelection.Factory adaptiveTrackSelectionFactory = new AdaptiveTrackSelection.Factory(bandwidthMeter);
-            DefaultTrackSelector trackSelector = new DefaultTrackSelector(adaptiveTrackSelectionFactory);
-
             MediaCodecSelector mediaCodecSelector = downgradeSecureDecoder
                     ? SecurityDowngradingCodecSelector.newInstance()
                     : MediaCodecSelector.DEFAULT;
 
-            ExoPlayerTrackSelector exoPlayerTrackSelector = ExoPlayerTrackSelector.newInstance(trackSelector);
-            FixedTrackSelection.Factory trackSelectionFactory = new FixedTrackSelection.Factory();
-            ExoPlayerAudioTrackSelector exoPlayerAudioTrackSelector = new ExoPlayerAudioTrackSelector(exoPlayerTrackSelector, trackSelectionFactory);
-            ExoPlayerVideoTrackSelector exoPlayerVideoTrackSelector = new ExoPlayerVideoTrackSelector(exoPlayerTrackSelector, trackSelectionFactory);
-            ExoPlayerSubtitleTrackSelector exoPlayerSubtitleTrackSelector = new ExoPlayerSubtitleTrackSelector(
-                    exoPlayerTrackSelector,
-                    trackSelectionFactory
-            );
+            CompositeTrackSelectorCreator trackSelectorCreator = new CompositeTrackSelectorCreator(bandwidthMeter);
 
-            ExoPlayerCreator exoPlayerCreator = new ExoPlayerCreator(context, trackSelector);
+            ExoPlayerCreator exoPlayerCreator = new ExoPlayerCreator(context);
             RendererTypeRequesterCreator rendererTypeRequesterCreator = new RendererTypeRequesterCreator();
             AndroidDeviceVersion androidDeviceVersion = AndroidDeviceVersion.newInstance();
             ExoPlayerFacade exoPlayerFacade = new ExoPlayerFacade(
                     androidDeviceVersion,
                     mediaSourceFactory,
-                    exoPlayerAudioTrackSelector,
-                    exoPlayerSubtitleTrackSelector,
-                    exoPlayerVideoTrackSelector,
+                    trackSelectorCreator,
                     exoPlayerCreator,
-                    rendererTypeRequesterCreator);
+                    rendererTypeRequesterCreator
+            );
 
             PlayerListenersHolder listenersHolder = new PlayerListenersHolder();
             ExoPlayerForwarder exoPlayerForwarder = new ExoPlayerForwarder();

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImpl.java
@@ -5,9 +5,9 @@ import android.net.Uri;
 import android.view.SurfaceHolder;
 import android.view.View;
 
-import com.novoda.noplayer.ContentType;
 import com.novoda.noplayer.Listeners;
 import com.novoda.noplayer.NoPlayer;
+import com.novoda.noplayer.Options;
 import com.novoda.noplayer.PlayerInformation;
 import com.novoda.noplayer.PlayerState;
 import com.novoda.noplayer.PlayerView;
@@ -15,18 +15,19 @@ import com.novoda.noplayer.SurfaceHolderRequester;
 import com.novoda.noplayer.internal.Heart;
 import com.novoda.noplayer.internal.listeners.PlayerListenersHolder;
 import com.novoda.noplayer.internal.mediaplayer.forwarder.MediaPlayerForwarder;
+import com.novoda.noplayer.internal.utils.Optional;
 import com.novoda.noplayer.model.AudioTracks;
 import com.novoda.noplayer.model.LoadTimeout;
 import com.novoda.noplayer.model.PlayerAudioTrack;
 import com.novoda.noplayer.model.PlayerSubtitleTrack;
 import com.novoda.noplayer.model.PlayerVideoTrack;
 import com.novoda.noplayer.model.Timeout;
-import com.novoda.noplayer.internal.utils.Optional;
 
 import java.util.ArrayList;
 import java.util.List;
 
-@SuppressWarnings("PMD.GodClass")   // Not much we can do, wrapping MediaPlayer is a lot of work
+@SuppressWarnings("PMD.GodClass")
+        // Not much we can do, wrapping MediaPlayer is a lot of work
 class AndroidMediaPlayerImpl implements NoPlayer {
 
     private static final long NO_SEEK_TO_POSITION = -1;
@@ -52,7 +53,8 @@ class AndroidMediaPlayerImpl implements NoPlayer {
     private SurfaceHolderRequester surfaceHolderRequester;
     private View containerView;
 
-    @SuppressWarnings("checkstyle:ParameterNumber")     // We cannot really group these any further
+    @SuppressWarnings("checkstyle:ParameterNumber")
+        // We cannot really group these any further
     AndroidMediaPlayerImpl(MediaPlayerInformation mediaPlayerInformation,
                            AndroidMediaPlayerFacade mediaPlayer,
                            MediaPlayerForwarder forwarder,
@@ -220,7 +222,7 @@ class AndroidMediaPlayerImpl implements NoPlayer {
     }
 
     @Override
-    public void loadVideo(final Uri uri, final ContentType contentType) {
+    public void loadVideo(final Uri uri, final Options options) {
         if (mediaPlayer.hasPlayedContent()) {
             stop();
         }
@@ -246,9 +248,9 @@ class AndroidMediaPlayerImpl implements NoPlayer {
     }
 
     @Override
-    public void loadVideoWithTimeout(Uri uri, ContentType contentType, Timeout timeout, LoadTimeoutCallback loadTimeoutCallback) {
+    public void loadVideoWithTimeout(Uri uri, Options options, Timeout timeout, LoadTimeoutCallback loadTimeoutCallback) {
         loadTimeout.start(timeout, loadTimeoutCallback);
-        loadVideo(uri, contentType);
+        loadVideo(uri, options);
     }
 
     @Override

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacadeTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacadeTest.java
@@ -11,6 +11,8 @@ import com.google.android.exoplayer2.drm.DefaultDrmSessionManager;
 import com.google.android.exoplayer2.mediacodec.MediaCodecSelector;
 import com.google.android.exoplayer2.source.MediaSource;
 import com.novoda.noplayer.ContentType;
+import com.novoda.noplayer.Options;
+import com.novoda.noplayer.OptionsBuilder;
 import com.novoda.noplayer.internal.exoplayer.drm.DrmSessionCreator;
 import com.novoda.noplayer.internal.exoplayer.forwarder.ExoPlayerForwarder;
 import com.novoda.noplayer.internal.exoplayer.mediasource.MediaSourceFactory;
@@ -62,7 +64,7 @@ public class ExoPlayerFacadeTest {
     private static final boolean RESET_POSITION = true;
     private static final boolean DO_NOT_RESET_STATE = false;
 
-    private static final ContentType ANY_CONTENT_TYPE = ContentType.DASH;
+    private static final Options OPTIONS = new OptionsBuilder().withContentType(ContentType.DASH).build();
 
     public static class GivenVideoNotLoaded extends Base {
 
@@ -84,7 +86,7 @@ public class ExoPlayerFacadeTest {
         @Test
         public void whenLoadingVideo_thenAddsPlayerEventListener() {
 
-            facade.loadVideo(surfaceHolder, drmSessionCreator, uri, ANY_CONTENT_TYPE, exoPlayerForwarder, mediaCodecSelector);
+            facade.loadVideo(surfaceHolder, drmSessionCreator, uri, OPTIONS, exoPlayerForwarder, mediaCodecSelector);
 
             verify(exoPlayer).addListener(exoPlayerForwarder.exoPlayerEventListener());
         }
@@ -92,7 +94,7 @@ public class ExoPlayerFacadeTest {
         @Test
         public void whenLoadingVideo_thenSetsVideoDebugListener() {
 
-            facade.loadVideo(surfaceHolder, drmSessionCreator, uri, ANY_CONTENT_TYPE, exoPlayerForwarder, mediaCodecSelector);
+            facade.loadVideo(surfaceHolder, drmSessionCreator, uri, OPTIONS, exoPlayerForwarder, mediaCodecSelector);
 
             verify(exoPlayer).setVideoDebugListener(exoPlayerForwarder.videoRendererEventListener());
         }
@@ -100,7 +102,7 @@ public class ExoPlayerFacadeTest {
         @Test
         public void whenLoadingVideo_thenSetsSurfaceHolderOnExoPlayer() {
 
-            facade.loadVideo(surfaceHolder, drmSessionCreator, uri, ANY_CONTENT_TYPE, exoPlayerForwarder, mediaCodecSelector);
+            facade.loadVideo(surfaceHolder, drmSessionCreator, uri, OPTIONS, exoPlayerForwarder, mediaCodecSelector);
 
             verify(exoPlayer).setVideoSurfaceHolder(surfaceHolder);
         }
@@ -109,7 +111,7 @@ public class ExoPlayerFacadeTest {
         public void givenLollipopDevice_whenLoadingVideo_thenSetsMovieAudioAttributesOnExoPlayer() {
             given(androidDeviceVersion.isLollipopTwentyOneOrAbove()).willReturn(true);
 
-            facade.loadVideo(surfaceHolder, drmSessionCreator, uri, ANY_CONTENT_TYPE, exoPlayerForwarder, mediaCodecSelector);
+            facade.loadVideo(surfaceHolder, drmSessionCreator, uri, OPTIONS, exoPlayerForwarder, mediaCodecSelector);
 
             AudioAttributes expectedMovieAudioAttributes = new AudioAttributes.Builder()
                     .setContentType(C.CONTENT_TYPE_MOVIE)
@@ -121,7 +123,7 @@ public class ExoPlayerFacadeTest {
         public void givenNonLollipopDevice_whenLoadingVideo_thenDoesNotSetAudioAttributesOnExoPlayer() {
             given(androidDeviceVersion.isLollipopTwentyOneOrAbove()).willReturn(false);
 
-            facade.loadVideo(surfaceHolder, drmSessionCreator, uri, ANY_CONTENT_TYPE, exoPlayerForwarder, mediaCodecSelector);
+            facade.loadVideo(surfaceHolder, drmSessionCreator, uri, OPTIONS, exoPlayerForwarder, mediaCodecSelector);
 
             verify(exoPlayer, never()).setAudioAttributes(any(AudioAttributes.class));
         }
@@ -130,7 +132,7 @@ public class ExoPlayerFacadeTest {
         public void givenMediaSource_whenLoadingVideo_thenPreparesInternalExoPlayer() {
             MediaSource mediaSource = givenMediaSource();
 
-            facade.loadVideo(surfaceHolder, drmSessionCreator, uri, ANY_CONTENT_TYPE, exoPlayerForwarder, mediaCodecSelector);
+            facade.loadVideo(surfaceHolder, drmSessionCreator, uri, OPTIONS, exoPlayerForwarder, mediaCodecSelector);
 
             verify(exoPlayer).prepare(mediaSource, RESET_POSITION, DO_NOT_RESET_STATE);
         }
@@ -235,7 +237,7 @@ public class ExoPlayerFacadeTest {
 
         private void givenPlayerIsLoaded() {
             givenMediaSource();
-            facade.loadVideo(surfaceHolder, drmSessionCreator, uri, ANY_CONTENT_TYPE, exoPlayerForwarder, mediaCodecSelector);
+            facade.loadVideo(surfaceHolder, drmSessionCreator, uri, OPTIONS, exoPlayerForwarder, mediaCodecSelector);
         }
 
         @Test
@@ -486,7 +488,7 @@ public class ExoPlayerFacadeTest {
         public void setUp() {
             ExoPlayerCreator exoPlayerCreator = mock(ExoPlayerCreator.class);
             given(exoPlayerForwarder.drmSessionEventListener()).willReturn(drmSessionEventListener);
-            given(trackSelectorCreator.create()).willReturn(trackSelector);
+            given(trackSelectorCreator.create(OPTIONS)).willReturn(trackSelector);
             given(exoPlayerCreator.create(drmSessionCreator, drmSessionEventListener, mediaCodecSelector, trackSelector)).willReturn(exoPlayer);
             given(rendererTypeRequesterCreator.createfrom(exoPlayer)).willReturn(rendererTypeRequester);
             facade = new ExoPlayerFacade(
@@ -502,7 +504,7 @@ public class ExoPlayerFacadeTest {
             MediaSource mediaSource = mock(MediaSource.class);
             given(
                     mediaSourceFactory.create(
-                            ANY_CONTENT_TYPE,
+                            OPTIONS.contentType(),
                             uri,
                             exoPlayerForwarder.extractorMediaSourceListener(),
                             exoPlayerForwarder.mediaSourceEventListener()

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacadeTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacadeTest.java
@@ -13,9 +13,6 @@ import com.google.android.exoplayer2.source.MediaSource;
 import com.novoda.noplayer.ContentType;
 import com.novoda.noplayer.internal.exoplayer.drm.DrmSessionCreator;
 import com.novoda.noplayer.internal.exoplayer.forwarder.ExoPlayerForwarder;
-import com.novoda.noplayer.internal.exoplayer.mediasource.ExoPlayerAudioTrackSelector;
-import com.novoda.noplayer.internal.exoplayer.mediasource.ExoPlayerSubtitleTrackSelector;
-import com.novoda.noplayer.internal.exoplayer.mediasource.ExoPlayerVideoTrackSelector;
 import com.novoda.noplayer.internal.exoplayer.mediasource.MediaSourceFactory;
 import com.novoda.noplayer.internal.utils.AndroidDeviceVersion;
 import com.novoda.noplayer.internal.utils.Optional;
@@ -48,7 +45,6 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @RunWith(Enclosed.class)
 public class ExoPlayerFacadeTest {
@@ -195,7 +191,7 @@ public class ExoPlayerFacadeTest {
         public void whenGettingAudioTracks_thenThrowsIllegalStateException() {
             thrown.expect(ExceptionMatcher.matches("Video must be loaded before trying to interact with the player", IllegalStateException.class));
 
-            given(audioTrackSelector.getAudioTracks(any(RendererTypeRequester.class))).willReturn(AUDIO_TRACKS);
+            given(trackSelector.getAudioTracks(any(RendererTypeRequester.class))).willReturn(AUDIO_TRACKS);
 
             facade.getAudioTracks();
         }
@@ -330,13 +326,13 @@ public class ExoPlayerFacadeTest {
 
             facade.selectAudioTrack(audioTrack);
 
-            verify(audioTrackSelector).selectAudioTrack(audioTrack, rendererTypeRequester);
+            verify(trackSelector).selectAudioTrack(audioTrack, rendererTypeRequester);
         }
 
         @Test
         public void givenSelectingAudioTrackSuceeds_whenSelectingAudioTrack_thenReturnsTrue() {
             PlayerAudioTrack audioTrack = mock(PlayerAudioTrack.class);
-            given(audioTrackSelector.selectAudioTrack(audioTrack, rendererTypeRequester)).willReturn(true);
+            given(trackSelector.selectAudioTrack(audioTrack, rendererTypeRequester)).willReturn(true);
 
             boolean success = facade.selectAudioTrack(audioTrack);
 
@@ -346,7 +342,7 @@ public class ExoPlayerFacadeTest {
         @Test
         public void givenSelectingAudioTrackFails_whenSelectingAudioTrack_thenReturnsFalse() {
             PlayerAudioTrack audioTrack = mock(PlayerAudioTrack.class);
-            given(audioTrackSelector.selectAudioTrack(audioTrack, rendererTypeRequester)).willReturn(false);
+            given(trackSelector.selectAudioTrack(audioTrack, rendererTypeRequester)).willReturn(false);
 
             boolean success = facade.selectAudioTrack(audioTrack);
 
@@ -359,13 +355,13 @@ public class ExoPlayerFacadeTest {
 
             facade.selectSubtitleTrack(subtitleTrack);
 
-            verify(subtitleTrackSelector).selectTextTrack(subtitleTrack, rendererTypeRequester);
+            verify(trackSelector).selectTextTrack(subtitleTrack, rendererTypeRequester);
         }
 
         @Test
         public void givenSelectingTextTrackSuceeds_whenSelectingSubtitlesTrack_thenReturnsTrue() {
             PlayerSubtitleTrack subtitleTrack = mock(PlayerSubtitleTrack.class);
-            given(subtitleTrackSelector.selectTextTrack(subtitleTrack, rendererTypeRequester)).willReturn(true);
+            given(trackSelector.selectTextTrack(subtitleTrack, rendererTypeRequester)).willReturn(true);
 
             boolean success = facade.selectSubtitleTrack(subtitleTrack);
 
@@ -375,7 +371,7 @@ public class ExoPlayerFacadeTest {
         @Test
         public void givenSelectingTextTrackFails_whenSelectingSubtitlesTrack_thenReturnsFalse() {
             PlayerSubtitleTrack subtitleTrack = mock(PlayerSubtitleTrack.class);
-            given(subtitleTrackSelector.selectTextTrack(subtitleTrack, rendererTypeRequester)).willReturn(false);
+            given(trackSelector.selectTextTrack(subtitleTrack, rendererTypeRequester)).willReturn(false);
 
             boolean success = facade.selectSubtitleTrack(subtitleTrack);
 
@@ -384,7 +380,7 @@ public class ExoPlayerFacadeTest {
 
         @Test
         public void whenGettingAudioTracks_thenDelegatesToTrackSelector() {
-            given(audioTrackSelector.getAudioTracks(any(RendererTypeRequester.class))).willReturn(AUDIO_TRACKS);
+            given(trackSelector.getAudioTracks(any(RendererTypeRequester.class))).willReturn(AUDIO_TRACKS);
 
             AudioTracks audioTracks = facade.getAudioTracks();
 
@@ -393,7 +389,7 @@ public class ExoPlayerFacadeTest {
 
         @Test
         public void whenGettingSelectedVideoTrack_thenDelegatesTrackSelector() {
-            given(videoTrackSelector.getSelectedVideoTrack(eq(exoPlayer), any(RendererTypeRequester.class), any(ContentType.class))).willReturn(Optional.of(PLAYER_VIDEO_TRACK));
+            given(trackSelector.getSelectedVideoTrack(eq(exoPlayer), any(RendererTypeRequester.class), any(ContentType.class))).willReturn(Optional.of(PLAYER_VIDEO_TRACK));
 
             Optional<PlayerVideoTrack> selectedVideoTrack = facade.getSelectedVideoTrack();
 
@@ -402,7 +398,7 @@ public class ExoPlayerFacadeTest {
 
         @Test
         public void whenSelectingVideoTrack_thenDelegatesToTrackSelector() {
-            given(videoTrackSelector.selectVideoTrack(eq(PLAYER_VIDEO_TRACK), any(RendererTypeRequester.class))).willReturn(SELECTED);
+            given(trackSelector.selectVideoTrack(eq(PLAYER_VIDEO_TRACK), any(RendererTypeRequester.class))).willReturn(SELECTED);
 
             boolean selectedVideoTrack = facade.selectVideoTrack(PLAYER_VIDEO_TRACK);
 
@@ -411,7 +407,7 @@ public class ExoPlayerFacadeTest {
 
         @Test
         public void whenGettingVideoTracks_thenDelegatesToTrackSelector() {
-            given(videoTrackSelector.getVideoTracks(any(RendererTypeRequester.class), any(ContentType.class))).willReturn(VIDEO_TRACKS);
+            given(trackSelector.getVideoTracks(any(RendererTypeRequester.class), any(ContentType.class))).willReturn(VIDEO_TRACKS);
 
             List<PlayerVideoTrack> videoTracks = facade.getVideoTracks();
 
@@ -466,11 +462,9 @@ public class ExoPlayerFacadeTest {
         @Mock
         ExoPlayerForwarder exoPlayerForwarder;
         @Mock
-        ExoPlayerAudioTrackSelector audioTrackSelector;
+        CompositeTrackSelectorCreator trackSelectorCreator;
         @Mock
-        ExoPlayerSubtitleTrackSelector subtitleTrackSelector;
-        @Mock
-        ExoPlayerVideoTrackSelector videoTrackSelector;
+        CompositeTrackSelector trackSelector;
         @Mock
         Uri uri;
         @Mock
@@ -492,14 +486,13 @@ public class ExoPlayerFacadeTest {
         public void setUp() {
             ExoPlayerCreator exoPlayerCreator = mock(ExoPlayerCreator.class);
             given(exoPlayerForwarder.drmSessionEventListener()).willReturn(drmSessionEventListener);
-            given(exoPlayerCreator.create(drmSessionCreator, drmSessionEventListener, mediaCodecSelector)).willReturn(exoPlayer);
-            when(rendererTypeRequesterCreator.createfrom(exoPlayer)).thenReturn(rendererTypeRequester);
+            given(trackSelectorCreator.create()).willReturn(trackSelector);
+            given(exoPlayerCreator.create(drmSessionCreator, drmSessionEventListener, mediaCodecSelector, trackSelector)).willReturn(exoPlayer);
+            given(rendererTypeRequesterCreator.createfrom(exoPlayer)).willReturn(rendererTypeRequester);
             facade = new ExoPlayerFacade(
                     androidDeviceVersion,
                     mediaSourceFactory,
-                    audioTrackSelector,
-                    subtitleTrackSelector,
-                    videoTrackSelector,
+                    trackSelectorCreator,
                     exoPlayerCreator,
                     rendererTypeRequesterCreator
             );

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImplTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImplTest.java
@@ -10,6 +10,8 @@ import com.google.android.exoplayer2.text.Cue;
 import com.novoda.noplayer.ContentType;
 import com.novoda.noplayer.NoPlayer;
 import com.novoda.noplayer.NoPlayer.StateChangedListener;
+import com.novoda.noplayer.Options;
+import com.novoda.noplayer.OptionsBuilder;
 import com.novoda.noplayer.PlayerInformation;
 import com.novoda.noplayer.PlayerType;
 import com.novoda.noplayer.PlayerView;
@@ -23,6 +25,9 @@ import com.novoda.noplayer.model.PlayerSubtitleTrack;
 import com.novoda.noplayer.model.TextCues;
 import com.novoda.noplayer.model.Timeout;
 
+import java.util.Arrays;
+import java.util.List;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -35,9 +40,6 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import org.mockito.stubbing.Answer;
-
-import java.util.Arrays;
-import java.util.List;
 
 import static android.provider.CalendarContract.CalendarCache.URI;
 import static org.fest.assertions.api.Assertions.assertThat;
@@ -63,7 +65,7 @@ public class ExoPlayerTwoImplTest {
     private static final boolean IS_BEATING = true;
     private static final boolean IS_NOT_BEATING = false;
 
-    private static final ContentType ANY_CONTENT_TYPE = ContentType.DASH;
+    private static final Options OPTIONS = new OptionsBuilder().withContentType(ContentType.DASH).build();
     private static final Timeout ANY_TIMEOUT = Timeout.fromSeconds(TEN_SECONDS);
     private static final NoPlayer.LoadTimeoutCallback ANY_LOAD_TIMEOUT_CALLBACK = new NoPlayer.LoadTimeoutCallback() {
         @Override
@@ -218,25 +220,25 @@ public class ExoPlayerTwoImplTest {
         public void whenLoadingVideo_thenDelegatesLoadingToFacade() {
             player.attach(playerView);
 
-            player.loadVideo(uri, ANY_CONTENT_TYPE);
+            player.loadVideo(uri, OPTIONS);
 
-            verify(exoPlayerFacade).loadVideo(surfaceHolder, drmSessionCreator, uri, ANY_CONTENT_TYPE, forwarder, mediaCodecSelector);
+            verify(exoPlayerFacade).loadVideo(surfaceHolder, drmSessionCreator, uri, OPTIONS, forwarder, mediaCodecSelector);
         }
 
         @Test
         public void whenLoadingVideoWithTimeout_thenDelegatesLoadingToFacade() {
             player.attach(playerView);
 
-            player.loadVideoWithTimeout(uri, ANY_CONTENT_TYPE, ANY_TIMEOUT, ANY_LOAD_TIMEOUT_CALLBACK);
+            player.loadVideoWithTimeout(uri, OPTIONS, ANY_TIMEOUT, ANY_LOAD_TIMEOUT_CALLBACK);
 
-            verify(exoPlayerFacade).loadVideo(surfaceHolder, drmSessionCreator, uri, ANY_CONTENT_TYPE, forwarder, mediaCodecSelector);
+            verify(exoPlayerFacade).loadVideo(surfaceHolder, drmSessionCreator, uri, OPTIONS, forwarder, mediaCodecSelector);
         }
 
         @Test
         public void whenLoadingVideoWithTimeout_thenStartsLoadTimeout() {
             player.attach(playerView);
 
-            player.loadVideoWithTimeout(uri, ANY_CONTENT_TYPE, ANY_TIMEOUT, ANY_LOAD_TIMEOUT_CALLBACK);
+            player.loadVideoWithTimeout(uri, OPTIONS, ANY_TIMEOUT, ANY_LOAD_TIMEOUT_CALLBACK);
 
             verify(loadTimeout).start(ANY_TIMEOUT, ANY_LOAD_TIMEOUT_CALLBACK);
         }
@@ -295,7 +297,7 @@ public class ExoPlayerTwoImplTest {
         public void givenAttachedPlayerView_whenLoadingVideo_thenMakesContainerVisible() {
             player.attach(playerView);
 
-            player.loadVideo(uri, ANY_CONTENT_TYPE);
+            player.loadVideo(uri, OPTIONS);
 
             verify(containerView).setVisibility(View.VISIBLE);
         }
@@ -305,7 +307,7 @@ public class ExoPlayerTwoImplTest {
             given(exoPlayerFacade.hasPlayedContent()).willReturn(true);
             player.attach(playerView);
 
-            player.loadVideo(URI, ContentType.HLS);
+            player.loadVideo(URI, OPTIONS);
 
             verify(stateChangedListener).onVideoStopped();
             verify(loadTimeout).cancel();
@@ -319,7 +321,7 @@ public class ExoPlayerTwoImplTest {
             given(exoPlayerFacade.hasPlayedContent()).willReturn(true);
             player.attach(playerView);
 
-            player.loadVideoWithTimeout(URI, ContentType.HLS, ANY_TIMEOUT, ANY_LOAD_TIMEOUT_CALLBACK);
+            player.loadVideoWithTimeout(URI, OPTIONS, ANY_TIMEOUT, ANY_LOAD_TIMEOUT_CALLBACK);
 
             verify(stateChangedListener).onVideoStopped();
             verify(loadTimeout).cancel();
@@ -333,7 +335,7 @@ public class ExoPlayerTwoImplTest {
             given(exoPlayerFacade.hasPlayedContent()).willReturn(false);
             player.attach(playerView);
 
-            player.loadVideo(URI, ContentType.HLS);
+            player.loadVideo(URI, OPTIONS);
 
             verify(stateChangedListener, never()).onVideoStopped();
             verify(loadTimeout, never()).cancel();
@@ -346,7 +348,7 @@ public class ExoPlayerTwoImplTest {
             given(exoPlayerFacade.hasPlayedContent()).willReturn(false);
             player.attach(playerView);
 
-            player.loadVideoWithTimeout(URI, ContentType.HLS, ANY_TIMEOUT, ANY_LOAD_TIMEOUT_CALLBACK);
+            player.loadVideoWithTimeout(URI, OPTIONS, ANY_TIMEOUT, ANY_LOAD_TIMEOUT_CALLBACK);
 
             verify(stateChangedListener, never()).onVideoStopped();
             verify(loadTimeout, never()).cancel();
@@ -363,13 +365,13 @@ public class ExoPlayerTwoImplTest {
         public void setUp() {
             super.setUp();
             player.attach(playerView);
-            player.loadVideo(uri, ANY_CONTENT_TYPE);
+            player.loadVideo(uri, OPTIONS);
         }
 
         @Test
         public void whenLoadingVideo_thenAddsStateChangedListenerToListenersHolder() {
 
-            player.loadVideo(uri, ANY_CONTENT_TYPE);
+            player.loadVideo(uri, OPTIONS);
 
             verify(listenersHolder).addStateChangedListener(playerView.getStateChangedListener());
         }
@@ -377,7 +379,7 @@ public class ExoPlayerTwoImplTest {
         @Test
         public void whenLoadingVideo_thenAddsVideoSizeChangedListenerToListenersHolder() {
 
-            player.loadVideo(uri, ANY_CONTENT_TYPE);
+            player.loadVideo(uri, OPTIONS);
 
             verify(listenersHolder).addVideoSizeChangedListener(playerView.getVideoSizeChangedListener());
         }
@@ -529,7 +531,7 @@ public class ExoPlayerTwoImplTest {
             final List<Cue> cueList = Arrays.asList(new Cue("first cue"), new Cue("secondCue"));
             doAnswer(new Answer() {
                 @Override
-                public Object answer(InvocationOnMock invocation) throws Throwable {
+                public Object answer(InvocationOnMock invocation) {
                     TextRendererOutput output = invocation.getArgument(0);
                     output.output().onCues(cueList);
                     return null;
@@ -627,7 +629,7 @@ public class ExoPlayerTwoImplTest {
             given(playerView.getContainerView()).willReturn(containerView);
             doAnswer(new Answer<Void>() {
                 @Override
-                public Void answer(InvocationOnMock invocation) throws Throwable {
+                public Void answer(InvocationOnMock invocation) {
                     SurfaceHolderRequester.Callback callback = invocation.getArgument(0);
                     callback.onSurfaceHolderReady(surfaceHolder);
                     return null;

--- a/core/src/test/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImplTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImplTest.java
@@ -7,18 +7,20 @@ import android.view.View;
 
 import com.novoda.noplayer.ContentType;
 import com.novoda.noplayer.NoPlayer;
+import com.novoda.noplayer.Options;
+import com.novoda.noplayer.OptionsBuilder;
 import com.novoda.noplayer.PlayerInformation;
 import com.novoda.noplayer.PlayerView;
 import com.novoda.noplayer.SurfaceHolderRequester;
 import com.novoda.noplayer.internal.Heart;
 import com.novoda.noplayer.internal.listeners.PlayerListenersHolder;
 import com.novoda.noplayer.internal.mediaplayer.forwarder.MediaPlayerForwarder;
+import com.novoda.noplayer.internal.utils.NoPlayerLog;
 import com.novoda.noplayer.model.AudioTracks;
 import com.novoda.noplayer.model.LoadTimeout;
 import com.novoda.noplayer.model.PlayerAudioTrack;
 import com.novoda.noplayer.model.PlayerAudioTrackFixture;
 import com.novoda.noplayer.model.Timeout;
-import com.novoda.noplayer.internal.utils.NoPlayerLog;
 
 import java.util.Collections;
 
@@ -423,42 +425,42 @@ public class AndroidMediaPlayerImplTest {
 
         @Test
         public void whenLoadingVideo_thenNotifiesBufferStateListenersThatBufferStarted() {
-            player.loadVideo(URI, ContentType.HLS);
+            player.loadVideo(URI, OPTIONS);
 
             verify(bufferStateListener).onBufferStarted();
         }
 
         @Test
         public void whenLoadingVideo_thenPreparesVideo() {
-            player.loadVideo(URI, ContentType.HLS);
+            player.loadVideo(URI, OPTIONS);
 
             verify(mediaPlayer).prepareVideo(URI, surfaceHolder);
         }
 
         @Test
         public void whenLoadingVideoWithTimeout_thenNotifiesBufferStateListenersThatBufferStarted() {
-            player.loadVideoWithTimeout(URI, ContentType.HLS, ANY_TIMEOUT, ANY_LOAD_TIMEOUT_CALLBACK);
+            player.loadVideoWithTimeout(URI, OPTIONS, ANY_TIMEOUT, ANY_LOAD_TIMEOUT_CALLBACK);
 
             verify(bufferStateListener).onBufferStarted();
         }
 
         @Test
         public void whenLoadingVideoWithTimeout_thenPreparesVideo() {
-            player.loadVideoWithTimeout(URI, ContentType.HLS, ANY_TIMEOUT, ANY_LOAD_TIMEOUT_CALLBACK);
+            player.loadVideoWithTimeout(URI, OPTIONS, ANY_TIMEOUT, ANY_LOAD_TIMEOUT_CALLBACK);
 
             verify(mediaPlayer).prepareVideo(URI, surfaceHolder);
         }
 
         @Test
         public void whenLoadingVideoWithTimeout_thenStartsTimeout() {
-            player.loadVideoWithTimeout(URI, ContentType.HLS, ANY_TIMEOUT, ANY_LOAD_TIMEOUT_CALLBACK);
+            player.loadVideoWithTimeout(URI, OPTIONS, ANY_TIMEOUT, ANY_LOAD_TIMEOUT_CALLBACK);
 
             verify(loadTimeout).start(ANY_TIMEOUT, ANY_LOAD_TIMEOUT_CALLBACK);
         }
 
         @Test
         public void whenLoadingVideo_thenShowsContainerView() {
-            player.loadVideo(URI, ContentType.HLS);
+            player.loadVideo(URI, OPTIONS);
 
             verify(containerView).setVisibility(View.VISIBLE);
         }
@@ -515,7 +517,7 @@ public class AndroidMediaPlayerImplTest {
         public void givenPlayerHasPlayedVideo_whenLoadingVideo_thenPlayerIsReleased_andNotListeners() {
             given(mediaPlayer.hasPlayedContent()).willReturn(true);
 
-            player.loadVideo(URI, ContentType.HLS);
+            player.loadVideo(URI, OPTIONS);
 
             verify(stateChangedListener).onVideoStopped();
             verify(loadTimeout).cancel();
@@ -528,7 +530,7 @@ public class AndroidMediaPlayerImplTest {
         public void givenPlayerHasPlayedVideo_whenLoadingVideoWithTimeout_thenPlayerResourcesAreReleased_andNotListeners() {
             given(mediaPlayer.hasPlayedContent()).willReturn(true);
 
-            player.loadVideoWithTimeout(URI, ContentType.HLS, ANY_TIMEOUT, ANY_LOAD_TIMEOUT_CALLBACK);
+            player.loadVideoWithTimeout(URI, OPTIONS, ANY_TIMEOUT, ANY_LOAD_TIMEOUT_CALLBACK);
 
             verify(stateChangedListener).onVideoStopped();
             verify(loadTimeout).cancel();
@@ -541,7 +543,7 @@ public class AndroidMediaPlayerImplTest {
         public void givenPlayerHasNotPlayedVideo_whenLoadingVideo_thenPlayerResourcesAreNotReleased() {
             given(mediaPlayer.hasPlayedContent()).willReturn(false);
 
-            player.loadVideo(URI, ContentType.HLS);
+            player.loadVideo(URI, OPTIONS);
 
             verify(stateChangedListener, never()).onVideoStopped();
             verify(loadTimeout, never()).cancel();
@@ -553,7 +555,7 @@ public class AndroidMediaPlayerImplTest {
         public void givenPlayerHasNotPlayedVideo_whenLoadingVideoWithTimeout_thenPlayerResourcesAreNotReleased() {
             given(mediaPlayer.hasPlayedContent()).willReturn(false);
 
-            player.loadVideoWithTimeout(URI, ContentType.HLS, ANY_TIMEOUT, ANY_LOAD_TIMEOUT_CALLBACK);
+            player.loadVideoWithTimeout(URI, OPTIONS, ANY_TIMEOUT, ANY_LOAD_TIMEOUT_CALLBACK);
 
             verify(stateChangedListener, never()).onVideoStopped();
             verify(loadTimeout, never()).cancel();
@@ -637,8 +639,9 @@ public class AndroidMediaPlayerImplTest {
         }
     }
 
-    public static abstract class Base {
+    public abstract static class Base {
 
+        static final Options OPTIONS = new OptionsBuilder().withContentType(ContentType.H264).build();
         static final long BEGINNING_POSITION = 0;
         static final Uri URI = Mockito.mock(Uri.class);
         static final int TEN_SECONDS = 10;

--- a/demo/src/main/java/com/novoda/demo/DemoPresenter.java
+++ b/demo/src/main/java/com/novoda/demo/DemoPresenter.java
@@ -2,9 +2,9 @@ package com.novoda.demo;
 
 import android.net.Uri;
 
-import com.novoda.noplayer.ContentType;
 import com.novoda.noplayer.Listeners;
 import com.novoda.noplayer.NoPlayer;
+import com.novoda.noplayer.Options;
 import com.novoda.noplayer.PlayerState;
 import com.novoda.noplayer.PlayerView;
 
@@ -22,7 +22,7 @@ class DemoPresenter {
         this.playerView = playerView;
     }
 
-    void startPresenting(Uri uri, ContentType contentType) {
+    void startPresenting(Uri uri, Options options) {
         listeners.addPreparedListener(playOnPrepared);
         listeners.addStateChangedListener(updatePlayPause);
         listeners.addHeartbeatCallback(updateProgress);
@@ -32,7 +32,7 @@ class DemoPresenter {
         controllerView.setToggleVolumeOnOffAction(onToggleVolume);
 
         noPlayer.attach(playerView);
-        noPlayer.loadVideo(uri, contentType);
+        noPlayer.loadVideo(uri, options);
     }
 
     private final NoPlayer.PreparedListener playOnPrepared = new NoPlayer.PreparedListener() {

--- a/demo/src/main/java/com/novoda/demo/MainActivity.java
+++ b/demo/src/main/java/com/novoda/demo/MainActivity.java
@@ -8,6 +8,8 @@ import android.widget.Toast;
 
 import com.novoda.noplayer.ContentType;
 import com.novoda.noplayer.NoPlayer;
+import com.novoda.noplayer.Options;
+import com.novoda.noplayer.OptionsBuilder;
 import com.novoda.noplayer.PlayerBuilder;
 import com.novoda.noplayer.PlayerView;
 import com.novoda.noplayer.internal.utils.NoPlayerLog;
@@ -16,6 +18,7 @@ public class MainActivity extends Activity {
 
     private static final String URI_VIDEO_WIDEVINE_EXAMPLE_MODULAR_MPD = "https://storage.googleapis.com/wvmedia/cenc/h264/tears/tears.mpd";
     private static final String EXAMPLE_MODULAR_LICENSE_SERVER_PROXY = "https://proxy.uat.widevine.com/proxy?provider=widevine_test";
+    private static final int HALF_A_SECOND_IN_MILLIS = 500;
 
     private NoPlayer player;
     private DemoPresenter demoPresenter;
@@ -51,7 +54,11 @@ public class MainActivity extends Activity {
     protected void onStart() {
         super.onStart();
         Uri uri = Uri.parse(URI_VIDEO_WIDEVINE_EXAMPLE_MODULAR_MPD);
-        demoPresenter.startPresenting(uri, ContentType.DASH);
+        Options options = new OptionsBuilder()
+                .withContentType(ContentType.DASH)
+                .withMinDurationBeforeQualityIncreaseInMillis(HALF_A_SECOND_IN_MILLIS)
+                .build();
+        demoPresenter.startPresenting(uri, options);
     }
 
     private final View.OnClickListener showVideoSelectionDialog = new View.OnClickListener() {

--- a/demo/src/main/java/com/novoda/demo/MainActivity.java
+++ b/demo/src/main/java/com/novoda/demo/MainActivity.java
@@ -19,6 +19,7 @@ public class MainActivity extends Activity {
     private static final String URI_VIDEO_WIDEVINE_EXAMPLE_MODULAR_MPD = "https://storage.googleapis.com/wvmedia/cenc/h264/tears/tears.mpd";
     private static final String EXAMPLE_MODULAR_LICENSE_SERVER_PROXY = "https://proxy.uat.widevine.com/proxy?provider=widevine_test";
     private static final int HALF_A_SECOND_IN_MILLIS = 500;
+    private static final int TWO_MEGABITS = 2000000;
 
     private NoPlayer player;
     private DemoPresenter demoPresenter;
@@ -57,6 +58,7 @@ public class MainActivity extends Activity {
         Options options = new OptionsBuilder()
                 .withContentType(ContentType.DASH)
                 .withMinDurationBeforeQualityIncreaseInMillis(HALF_A_SECOND_IN_MILLIS)
+                .withMaxInitialBitrate(TWO_MEGABITS)
                 .build();
         demoPresenter.startPresenting(uri, options);
     }


### PR DESCRIPTION
## Problem

We would like to have the ability to influence the default track selection when a video is loaded.

## Solution

The `loadVideo()` method has been refactored and now it allows to pass in different `Options` that influence initial track selection. This changes the API of `NoPlayer` interface.

At the moment 2 properties have been added to `Options`.

This feature consists of the following PRs:
#144 Track selectors create at loadVideo
#145 Add Options to loadVideo
#146 Fix javadoc errors
#147 Add max initial bitrate to options
