### PR TITLE
Support snapshot releases from `develop`

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ dependencies {
     compile 'com.novoda:no-player:<latest-version>'
 }
 ```
-### Sample usage
+### Simple usage
 
  1. Create a `Player`:
 
@@ -69,6 +69,20 @@ dependencies {
     Uri uri = Uri.parse(mpdUrl);
     player.loadVideo(uri, ContentType.DASH);
     ```
+
+## Snapshots
+
+Snapshot builds from `develop` are automatically deployed to a [repository](https://bintray.com/novoda/snapshots/no-player/_latestVersion) that is not synced with JCenter.
+To consume a snapshot build add an additional maven repo as follows:
+```
+repositories {
+    maven {
+        url 'https://novoda.bintray.com/snapshots'
+    }
+}
+```
+
+You can find the latest snapshot version following this [link](https://bintray.com/novoda/snapshots/no-player/_latestVersion).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ dependencies {
 
 ## Snapshots
 
-Snapshot builds from `develop` are automatically deployed to a [repository](https://bintray.com/novoda/snapshots/no-player/_latestVersion) that is not synced with JCenter.
+Snapshot builds from [`develop`](https://github.com/novoda/no-player/compare/master...develop) are automatically deployed to a [repository](https://bintray.com/novoda/snapshots/no-player/_latestVersion) that is not synced with JCenter.
 To consume a snapshot build add an additional maven repo as follows:
 ```
 repositories {

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ dependencies {
 
 ## Snapshots
 
+[![CI status](https://ci.novoda.com/buildStatus/icon?job=no-player-snapshot)](https://ci.novoda.com/job/no-player-snapshot/lastBuild/console) [![Download from Bintray](https://api.bintray.com/packages/novoda/snapshots/no-player/images/download.svg)](https://bintray.com/novoda/snapshots/no-player/_latestVersion)
+
 Snapshot builds from [`develop`](https://github.com/novoda/no-player/compare/master...develop) are automatically deployed to a [repository](https://bintray.com/novoda/snapshots/no-player/_latestVersion) that is not synced with JCenter.
 To consume a snapshot build add an additional maven repo as follows:
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ buildscript {
         classpath 'com.android.tools.build:gradle:3.0.1'
         classpath 'com.novoda:bintray-release:0.8.0'
         classpath 'com.novoda:gradle-static-analysis-plugin:0.5.2'
+        classpath 'com.novoda:gradle-build-properties-plugin:0.4.1'
     }
 }
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,6 +1,31 @@
 apply plugin: 'com.android.library'
 apply plugin: 'bintray-release'
 apply plugin: 'jacoco'
+apply plugin: 'com.novoda.build-properties'
+
+buildProperties {
+    cli {
+        using(project)
+    }
+    bintray {
+        def bintrayCredentials = {
+            boolean isDryRun = cli['dryRun'].or(true).boolean
+            return isDryRun ?
+                    ['bintrayRepo': 'n/a', 'bintrayUser': 'n/a', 'bintrayKey': 'n/a'] :
+                    new File("${System.getenv('BINTRAY_PROPERTIES')}")
+        }
+        using(cli).or(bintrayCredentials())
+        description = '''This should contain the following properties:
+                       | - bintrayRepo: name of the repo of the organisation to deploy the artifacts to
+                       | - bintrayUser: name of the account used to deploy the artifacts
+                       | - bintrayKey: API key of the account used to deploy the artifacts
+        '''.stripMargin()
+    }
+    publish {
+        using(['version': version])
+                .or(buildProperties.bintray)
+    }
+}
 
 android {
     compileSdkVersion 27
@@ -28,10 +53,10 @@ dependencies {
 
 publish {
     userOrg = 'novoda'
-    repoName = 'maven'
+    repoName = buildProperties.publish['bintrayRepo'].string
     groupId = 'com.novoda'
     artifactId = 'no-player'
-    version = project.version
+    version = buildProperties.publish['version'].string
 
     uploadName = 'no-player'
     description = 'player to wrap players'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -24,7 +24,7 @@ buildProperties {
     publish {
         def generateVersion = {
             boolean isSnapshot = cli['bintraySnapshot'].or(false).boolean
-            return isSnapshot ? System.getenv('BUILD_NUMBER')?:'SNAPSHOT' : version
+            return isSnapshot ? "SNAPSHOT-${System.getenv('BUILD_NUMBER')?:'LOCAL'}" : version
         }
         using(['version': "${generateVersion()}"])
                 .or(buildProperties.bintray)

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -24,7 +24,7 @@ buildProperties {
     publish {
         def generateVersion = {
             boolean isSnapshot = cli['bintraySnapshot'].or(false).boolean
-            return isSnapshot ? System.getenv('GIT_COMMIT')?:'SNAPSHOT' : version
+            return isSnapshot ? System.getenv('BUILD_NUMBER')?:'SNAPSHOT' : version
         }
         using(['version': "${generateVersion()}"])
                 .or(buildProperties.bintray)

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -14,7 +14,7 @@ buildProperties {
                     ['bintrayRepo': 'n/a', 'bintrayUser': 'n/a', 'bintrayKey': 'n/a'] :
                     new File("${System.getenv('BINTRAY_PROPERTIES')}")
         }
-        using(cli).or(bintrayCredentials())
+        using(bintrayCredentials()).or(cli)
         description = '''This should contain the following properties:
                        | - bintrayRepo: name of the repo of the organisation to deploy the artifacts to
                        | - bintrayUser: name of the account used to deploy the artifacts
@@ -61,6 +61,8 @@ publish {
     groupId = 'com.novoda'
     artifactId = 'no-player'
     version = buildProperties.publish['version'].string
+    bintrayUser = buildProperties.publish['bintrayUser'].string
+    bintrayKey = buildProperties.publish['bintrayKey'].string
 
     uploadName = 'no-player'
     description = 'player to wrap players'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -22,7 +22,11 @@ buildProperties {
         '''.stripMargin()
     }
     publish {
-        using(['version': version])
+        def generateVersion = {
+            boolean isSnapshot = cli['bintraySnapshot'].or(false).boolean
+            return isSnapshot ? System.getenv('GIT_COMMIT')?:'SNAPSHOT' : version
+        }
+        using(['version': "${generateVersion()}"])
                 .or(buildProperties.bintray)
     }
 }


### PR DESCRIPTION
## Problem

When we work on a new feature or a bug fix we would like to be able to use a new snapshot of the library without releasing to JCenter. 

## Solution

We have decided to use a new Bintray repo (https://bintray.com/novoda/snapshots) where to push such builds. This PR adds the necessary Gradle setup that allows us to define whether a certain build on the CI needs to land to the snapshots repo or not.

A [new CI job](https://ci.novoda.com/job/no-player-snapshot/configure) has been configured:
- it should be triggered only when `develop` changes (ie: after a feature branch is merged)
- it should always push to https://bintray.com/novoda/snapshots

### Test(s) added 

It's all Gradle stuff, so no automated test. I had to check manually whether the inputs were correctly handled in the build script.

### Screenshots

No UI changes, therefore no screenshots.

### Paired with 

Nobody
