### PR TITLE
Update code example in the README, bump dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,12 +59,7 @@ dependencies {
  4. Play some content:
 
     ```java
-    player.addPreparedListener(new Player.PreparedListener() {
-      @Override
-      public void onPrepared(PlayerState playerState) {
-        player.play();
-      }
-    });
+    player.getListeners().addPreparedListener(playerState -> player.play());
     
     Uri uri = Uri.parse(mpdUrl);
     player.loadVideo(uri, ContentType.DASH);

--- a/build.gradle
+++ b/build.gradle
@@ -23,9 +23,9 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.1.2'
         classpath 'com.novoda:bintray-release:0.8.0'
-        classpath 'com.novoda:gradle-static-analysis-plugin:0.4.1'
+        classpath 'com.novoda:gradle-static-analysis-plugin:0.5.2'
     }
 }
 

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -23,5 +23,5 @@ dependencies {
     implementation 'com.android.support:appcompat-v7:27.1.1'
 
     testImplementation 'junit:junit:4.12'
-    testImplementation 'com.google.truth:truth:0.39'
+    testImplementation 'com.google.truth:truth:0.40'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Tue May 22 11:13:26 BST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.3.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip


### PR DESCRIPTION
## Problem
The code example in the README is out of date (and wouldn't even compile 🙀).

## Solution
Add a call to `getListeners` before adding a `PreparedListener`. Add the `PreparedListener` as a lambda.

Also updated some dependencies (Gradle version, Truth, static analysis plugin) because Hal forced me to. 

### Test(s) added 
No tests added because it's a README and a dependency bump

### Paired with 
No one