### PR TITLE
Track selection fix

### DIFF
--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/CompositeTrackSelector.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/CompositeTrackSelector.java
@@ -1,12 +1,8 @@
 package com.novoda.noplayer.internal.exoplayer;
 
-import com.google.android.exoplayer2.ExoPlaybackException;
-import com.google.android.exoplayer2.RendererCapabilities;
 import com.google.android.exoplayer2.SimpleExoPlayer;
-import com.google.android.exoplayer2.source.TrackGroupArray;
 import com.google.android.exoplayer2.trackselection.DefaultTrackSelector;
 import com.google.android.exoplayer2.trackselection.TrackSelector;
-import com.google.android.exoplayer2.trackselection.TrackSelectorResult;
 import com.novoda.noplayer.ContentType;
 import com.novoda.noplayer.internal.exoplayer.mediasource.ExoPlayerAudioTrackSelector;
 import com.novoda.noplayer.internal.exoplayer.mediasource.ExoPlayerSubtitleTrackSelector;
@@ -19,7 +15,7 @@ import com.novoda.noplayer.model.PlayerVideoTrack;
 
 import java.util.List;
 
-class CompositeTrackSelector extends TrackSelector {
+class CompositeTrackSelector {
 
     private final DefaultTrackSelector defaultTrackSelector;
     private final ExoPlayerAudioTrackSelector audioTrackSelector;
@@ -34,6 +30,10 @@ class CompositeTrackSelector extends TrackSelector {
         this.audioTrackSelector = audioTrackSelector;
         this.videoTrackSelector = videoTrackSelector;
         this.subtitleTrackSelector = subtitleTrackSelector;
+    }
+
+    TrackSelector trackSelector() {
+        return defaultTrackSelector;
     }
 
     boolean selectAudioTrack(PlayerAudioTrack audioTrack, RendererTypeRequester rendererTypeRequester) {
@@ -76,15 +76,5 @@ class CompositeTrackSelector extends TrackSelector {
 
     boolean clearSubtitleTrack(RendererTypeRequester rendererTypeRequester) {
         return subtitleTrackSelector.clearSubtitleTrack(rendererTypeRequester);
-    }
-
-    @Override
-    public TrackSelectorResult selectTracks(RendererCapabilities[] rendererCapabilities, TrackGroupArray trackGroups) throws ExoPlaybackException {
-        return defaultTrackSelector.selectTracks(rendererCapabilities, trackGroups);
-    }
-
-    @Override
-    public void onSelectionActivated(Object info) {
-        defaultTrackSelector.onSelectionActivated(info);
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
@@ -36,7 +36,7 @@ class ExoPlayerFacade {
     @Nullable
     private SimpleExoPlayer exoPlayer;
     @Nullable
-    private CompositeTrackSelector trackSelector;
+    private CompositeTrackSelector compositeTrackSelector;
     @Nullable
     private RendererTypeRequester rendererTypeRequester;
     @Nullable
@@ -107,8 +107,13 @@ class ExoPlayerFacade {
                    ExoPlayerForwarder forwarder,
                    MediaCodecSelector mediaCodecSelector) {
         this.options = options;
-        trackSelector = trackSelectorCreator.create(options);
-        exoPlayer = exoPlayerCreator.create(drmSessionCreator, forwarder.drmSessionEventListener(), mediaCodecSelector, trackSelector);
+        compositeTrackSelector = trackSelectorCreator.create(options);
+        exoPlayer = exoPlayerCreator.create(
+                drmSessionCreator,
+                forwarder.drmSessionEventListener(),
+                mediaCodecSelector,
+                compositeTrackSelector.trackSelector()
+        );
         rendererTypeRequester = rendererTypeRequesterCreator.createfrom(exoPlayer);
         exoPlayer.addListener(forwarder.exoPlayerEventListener());
         exoPlayer.setVideoDebugListener(forwarder.videoRendererEventListener());
@@ -140,37 +145,37 @@ class ExoPlayerFacade {
 
     AudioTracks getAudioTracks() throws IllegalStateException {
         assertVideoLoaded();
-        return trackSelector.getAudioTracks(rendererTypeRequester);
+        return compositeTrackSelector.getAudioTracks(rendererTypeRequester);
     }
 
     boolean selectAudioTrack(PlayerAudioTrack audioTrack) throws IllegalStateException {
         assertVideoLoaded();
-        return trackSelector.selectAudioTrack(audioTrack, rendererTypeRequester);
+        return compositeTrackSelector.selectAudioTrack(audioTrack, rendererTypeRequester);
     }
 
     boolean clearAudioTrackSelection() {
         assertVideoLoaded();
-        return trackSelector.clearAudioTrack(rendererTypeRequester);
+        return compositeTrackSelector.clearAudioTrack(rendererTypeRequester);
     }
 
     boolean selectVideoTrack(PlayerVideoTrack playerVideoTrack) {
         assertVideoLoaded();
-        return trackSelector.selectVideoTrack(playerVideoTrack, rendererTypeRequester);
+        return compositeTrackSelector.selectVideoTrack(playerVideoTrack, rendererTypeRequester);
     }
 
     Optional<PlayerVideoTrack> getSelectedVideoTrack() {
         assertVideoLoaded();
-        return trackSelector.getSelectedVideoTrack(exoPlayer, rendererTypeRequester, options.contentType());
+        return compositeTrackSelector.getSelectedVideoTrack(exoPlayer, rendererTypeRequester, options.contentType());
     }
 
     List<PlayerVideoTrack> getVideoTracks() {
         assertVideoLoaded();
-        return trackSelector.getVideoTracks(rendererTypeRequester, options.contentType());
+        return compositeTrackSelector.getVideoTracks(rendererTypeRequester, options.contentType());
     }
 
     boolean clearVideoTrackSelection() {
         assertVideoLoaded();
-        return trackSelector.clearVideoTrack(rendererTypeRequester);
+        return compositeTrackSelector.clearVideoTrack(rendererTypeRequester);
     }
 
     void setSubtitleRendererOutput(TextRendererOutput textRendererOutput) throws IllegalStateException {
@@ -185,12 +190,12 @@ class ExoPlayerFacade {
 
     boolean selectSubtitleTrack(PlayerSubtitleTrack subtitleTrack) throws IllegalStateException {
         assertVideoLoaded();
-        return trackSelector.selectTextTrack(subtitleTrack, rendererTypeRequester);
+        return compositeTrackSelector.selectTextTrack(subtitleTrack, rendererTypeRequester);
     }
 
     List<PlayerSubtitleTrack> getSubtitleTracks() throws IllegalStateException {
         assertVideoLoaded();
-        return trackSelector.getSubtitleTracks(rendererTypeRequester);
+        return compositeTrackSelector.getSubtitleTracks(rendererTypeRequester);
     }
 
     boolean hasPlayedContent() {
@@ -199,7 +204,7 @@ class ExoPlayerFacade {
 
     boolean clearSubtitleTrackSelection() throws IllegalStateException {
         assertVideoLoaded();
-        return trackSelector.clearSubtitleTrack(rendererTypeRequester);
+        return compositeTrackSelector.clearSubtitleTrack(rendererTypeRequester);
     }
 
     void setRepeating(boolean repeating) {

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacadeTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacadeTest.java
@@ -489,7 +489,7 @@ public class ExoPlayerFacadeTest {
             ExoPlayerCreator exoPlayerCreator = mock(ExoPlayerCreator.class);
             given(exoPlayerForwarder.drmSessionEventListener()).willReturn(drmSessionEventListener);
             given(trackSelectorCreator.create(OPTIONS)).willReturn(trackSelector);
-            given(exoPlayerCreator.create(drmSessionCreator, drmSessionEventListener, mediaCodecSelector, trackSelector)).willReturn(exoPlayer);
+            given(exoPlayerCreator.create(drmSessionCreator, drmSessionEventListener, mediaCodecSelector, trackSelector.trackSelector())).willReturn(exoPlayer);
             given(rendererTypeRequesterCreator.createfrom(exoPlayer)).willReturn(rendererTypeRequester);
             facade = new ExoPlayerFacade(
                     androidDeviceVersion,

--- a/demo/src/main/java/com/novoda/demo/MainActivity.java
+++ b/demo/src/main/java/com/novoda/demo/MainActivity.java
@@ -16,7 +16,7 @@ import com.novoda.noplayer.internal.utils.NoPlayerLog;
 
 public class MainActivity extends Activity {
 
-    private static final String URI_VIDEO_WIDEVINE_EXAMPLE_MODULAR_MPD = "https://storage.googleapis.com/wvmedia/cenc/h264/tears/tears.mpd";
+    private static final String URI_VIDEO_WIDEVINE_EXAMPLE_MODULAR_MPD = "https://storage.googleapis.com/content-samples/multi-audio/manifest.mpd";
     private static final String EXAMPLE_MODULAR_LICENSE_SERVER_PROXY = "https://proxy.uat.widevine.com/proxy?provider=widevine_test";
     private static final int HALF_A_SECOND_IN_MILLIS = 500;
     private static final int TWO_MEGABITS = 2000000;


### PR DESCRIPTION
## Problem
We created a wrapper around the `TrackSelector` but we did something weird where we implemented the interface **and** used a `DefaultTrackSelector` the default was used for everything but we passed the wrapper to the `ExoPlayer`. This meant that the track selection wasn't working 😬 

## Solution
`CompositeTrackSelector` is now a pure wrapper, it doesn't extend any interfaces. We expose the `TrackSelector` that the `ExoPlayer` needs through a getter instead. 

### Test(s) added 
Just updated some. I've manually tested this solution on a client app and the track selection is working again.

### Paired with 
Nobody.
