### PR TITLE
Provide both Surface and SurfaceHolder in MediaPlayer

### DIFF
--- a/core/src/main/java/com/novoda/noplayer/PlayerSurfaceHolder.java
+++ b/core/src/main/java/com/novoda/noplayer/PlayerSurfaceHolder.java
@@ -22,7 +22,7 @@ public class PlayerSurfaceHolder {
     public static PlayerSurfaceHolder create(TextureView textureView) {
         PlayerViewSurfaceHolder surfaceHolder = new PlayerViewSurfaceHolder();
         textureView.setSurfaceTextureListener(surfaceHolder);
-        return new PlayerSurfaceHolder(null, textureView, new PlayerViewSurfaceHolder());
+        return new PlayerSurfaceHolder(null, textureView, surfaceHolder);
     }
 
     PlayerSurfaceHolder(@Nullable SurfaceView surfaceView, @Nullable TextureView textureView, PlayerViewSurfaceHolder surfaceHolder) {

--- a/core/src/main/java/com/novoda/noplayer/SurfaceRequester.java
+++ b/core/src/main/java/com/novoda/noplayer/SurfaceRequester.java
@@ -1,6 +1,8 @@
 package com.novoda.noplayer;
 
 import android.view.Surface;
+import android.view.SurfaceHolder;
+import com.novoda.noplayer.model.Either;
 
 public interface SurfaceRequester {
 
@@ -10,8 +12,7 @@ public interface SurfaceRequester {
 
     interface Callback {
 
-        void onSurfaceReady(Surface surface);
-
+        void onSurfaceReady(Either<Surface, SurfaceHolder> surface);
     }
 
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerFacade.java
@@ -68,7 +68,7 @@ class AndroidMediaPlayerFacade {
         this.mediaPlayerCreator = mediaPlayerCreator;
     }
 
-    public void prepareVideo(Uri videoUri, Either<Surface, SurfaceHolder> surface) {
+    void prepareVideo(Uri videoUri, Either<Surface, SurfaceHolder> surface) {
         requestAudioFocus();
         release();
         try {

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerFacade.java
@@ -181,26 +181,20 @@ class AndroidMediaPlayerFacade {
         mediaPlayer.start();
     }
 
-    private void attachSurface(MediaPlayer mediaPlayer, Either<Surface, SurfaceHolder> surface) {
-        surface.apply(setSurface(mediaPlayer), setDisplay(mediaPlayer));
-    }
-
-    private Either.Consumer<Surface> setSurface(final MediaPlayer mediaPlayer) {
-        return new Either.Consumer<Surface>() {
+    private void attachSurface(final MediaPlayer mediaPlayer, Either<Surface, SurfaceHolder> surface) {
+        Either.Consumer<Surface> setSurface = new Either.Consumer<Surface>() {
             @Override
             public void accept(Surface value) {
                 mediaPlayer.setSurface(value);
             }
         };
-    }
-
-    private Either.Consumer<SurfaceHolder> setDisplay(final MediaPlayer mediaPlayer) {
-        return new Either.Consumer<SurfaceHolder>() {
+        Either.Consumer<SurfaceHolder> setDisplay = new Either.Consumer<SurfaceHolder>() {
             @Override
             public void accept(SurfaceHolder value) {
                 mediaPlayer.setDisplay(value);
             }
         };
+        surface.apply(setSurface, setDisplay);
     }
 
     void pause() throws IllegalStateException {

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImpl.java
@@ -3,20 +3,22 @@ package com.novoda.noplayer.internal.mediaplayer;
 import android.media.MediaPlayer;
 import android.net.Uri;
 import android.view.Surface;
+import android.view.SurfaceHolder;
 import android.view.View;
 import com.novoda.noplayer.Listeners;
 import com.novoda.noplayer.NoPlayer;
 import com.novoda.noplayer.Options;
 import com.novoda.noplayer.PlayerInformation;
 import com.novoda.noplayer.PlayerState;
-import com.novoda.noplayer.PlayerView;
 import com.novoda.noplayer.PlayerSurfaceHolder;
+import com.novoda.noplayer.PlayerView;
 import com.novoda.noplayer.SurfaceRequester;
 import com.novoda.noplayer.internal.Heart;
 import com.novoda.noplayer.internal.listeners.PlayerListenersHolder;
 import com.novoda.noplayer.internal.mediaplayer.forwarder.MediaPlayerForwarder;
 import com.novoda.noplayer.internal.utils.Optional;
 import com.novoda.noplayer.model.AudioTracks;
+import com.novoda.noplayer.model.Either;
 import com.novoda.noplayer.model.LoadTimeout;
 import com.novoda.noplayer.model.PlayerAudioTrack;
 import com.novoda.noplayer.model.PlayerSubtitleTrack;
@@ -146,7 +148,7 @@ class AndroidMediaPlayerImpl implements NoPlayer {
         heart.startBeatingHeart();
         requestSurface(new SurfaceRequester.Callback() {
             @Override
-            public void onSurfaceReady(Surface surface) {
+            public void onSurfaceReady(Either<Surface, SurfaceHolder> surface) {
                 mediaPlayer.start(surface);
                 listenersHolder.getStateChangedListeners().onVideoPlaying();
             }
@@ -160,7 +162,7 @@ class AndroidMediaPlayerImpl implements NoPlayer {
         } else {
             requestSurface(new SurfaceRequester.Callback() {
                 @Override
-                public void onSurfaceReady(Surface surface) {
+                public void onSurfaceReady(Either<Surface, SurfaceHolder> surface) {
                     initialSeekWorkaround(surface, positionInMillis);
                 }
             });
@@ -171,7 +173,7 @@ class AndroidMediaPlayerImpl implements NoPlayer {
      * Workaround to fix some devices (nexus 7 2013 in particular) from natively crashing the mediaplayer
      * by starting the mediaplayer before seeking it.
      */
-    private void initialSeekWorkaround(Surface surface, final long initialPlayPositionInMillis) throws IllegalStateException {
+    private void initialSeekWorkaround(Either<Surface, SurfaceHolder> surface, final long initialPlayPositionInMillis) throws IllegalStateException {
         listenersHolder.getBufferStateListeners().onBufferStarted();
         initialisePlaybackForSeeking(surface);
         delayedActionExecutor.performAfterDelay(new DelayedActionExecutor.Action() {
@@ -182,7 +184,7 @@ class AndroidMediaPlayerImpl implements NoPlayer {
         }, INITIAL_PLAY_SEEK_DELAY_IN_MILLIS);
     }
 
-    private void initialisePlaybackForSeeking(Surface surface) {
+    private void initialisePlaybackForSeeking(Either<Surface, SurfaceHolder> surface) {
         mediaPlayer.start(surface);
         mediaPlayer.pause();
     }
@@ -231,7 +233,7 @@ class AndroidMediaPlayerImpl implements NoPlayer {
         listenersHolder.getBufferStateListeners().onBufferStarted();
         requestSurface(new SurfaceRequester.Callback() {
             @Override
-            public void onSurfaceReady(Surface surface) {
+            public void onSurfaceReady(Either<Surface, SurfaceHolder> surface) {
                 mediaPlayer.prepareVideo(uri, surface);
             }
         });

--- a/core/src/main/java/com/novoda/noplayer/model/Either.java
+++ b/core/src/main/java/com/novoda/noplayer/model/Either.java
@@ -1,0 +1,50 @@
+package com.novoda.noplayer.model;
+
+public abstract class Either<L, R> {
+
+    public static <L, R> Either<L, R> left(L left) {
+        return new Left<>(left);
+    }
+
+    public static <L, R> Either<L, R> right(R right) {
+        return new Right<>(right);
+    }
+
+    Either() {
+        // restrict subclasses to the package
+    }
+
+    public abstract void apply(Consumer<L> leftConsumer, Consumer<R> rightConsumer);
+
+    static class Left<L, R> extends Either<L, R> {
+
+        private final L valueLeft;
+
+        Left(L valueLeft) {
+            this.valueLeft = valueLeft;
+        }
+
+        @Override
+        public void apply(Consumer<L> leftConsumer, Consumer<R> rightConsumer) {
+            leftConsumer.accept(valueLeft);
+        }
+    }
+
+    static class Right<L, R> extends Either<L, R> {
+
+        private final R valueRight;
+
+        Right(R valueRight) {
+            this.valueRight = valueRight;
+        }
+
+        @Override
+        public void apply(Consumer<L> leftConsumer, Consumer<R> rightConsumer) {
+            rightConsumer.accept(valueRight);
+        }
+    }
+
+    public interface Consumer<T> {
+        void accept(T value);
+    }
+}

--- a/core/src/test/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerFacadeTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerFacadeTest.java
@@ -5,10 +5,12 @@ import android.media.AudioManager;
 import android.media.MediaPlayer;
 import android.net.Uri;
 import android.view.Surface;
+import android.view.SurfaceHolder;
 import com.novoda.noplayer.SurfaceRequester;
 import com.novoda.noplayer.internal.mediaplayer.forwarder.MediaPlayerForwarder;
 import com.novoda.noplayer.internal.utils.NoPlayerLog;
 import com.novoda.noplayer.model.AudioTracks;
+import com.novoda.noplayer.model.Either;
 import com.novoda.noplayer.model.PlayerAudioTrack;
 import com.novoda.noplayer.model.PlayerAudioTrackFixture;
 import com.novoda.noplayer.model.PlayerSubtitleTrack;
@@ -94,6 +96,7 @@ public class AndroidMediaPlayerFacadeTest {
     private MediaPlayer.OnCompletionListener completionListener;
     @Mock
     private MediaPlayerForwarder forwarder;
+    private Either<Surface, SurfaceHolder> eitherSurface;
 
     private AndroidMediaPlayerFacade facade;
 
@@ -105,6 +108,16 @@ public class AndroidMediaPlayerFacadeTest {
 
         given(mediaPlayerCreator.createMediaPlayer()).willReturn(mediaPlayer);
         given(playbackStateChecker.isInPlaybackState(eq(mediaPlayer), any(PlaybackStateChecker.PlaybackState.class))).willReturn(IS_IN_PLAYBACK_STATE);
+        eitherSurface = Either.left(surface);
+        givenSurfaceRequesterReturns(eitherSurface);
+
+        given(forwarder.onPreparedListener()).willReturn(preparedListener);
+        given(forwarder.onCompletionListener()).willReturn(completionListener);
+        given(forwarder.onErrorListener()).willReturn(errorListener);
+        given(forwarder.onSizeChangedListener()).willReturn(videoSizeChangedListener);
+    }
+
+    private void givenSurfaceRequesterReturns(final Either<Surface, SurfaceHolder> surface) {
         doAnswer(new Answer<Void>() {
             @Override
             public Void answer(InvocationOnMock invocation) {
@@ -113,11 +126,6 @@ public class AndroidMediaPlayerFacadeTest {
                 return null;
             }
         }).when(surfaceRequester).requestSurface(any(SurfaceRequester.Callback.class));
-
-        given(forwarder.onPreparedListener()).willReturn(preparedListener);
-        given(forwarder.onCompletionListener()).willReturn(completionListener);
-        given(forwarder.onErrorListener()).willReturn(errorListener);
-        given(forwarder.onSizeChangedListener()).willReturn(videoSizeChangedListener);
     }
 
     @Test
@@ -137,8 +145,8 @@ public class AndroidMediaPlayerFacadeTest {
 
     @Test
     public void whenPreparingMultipleTimes_thenReleasesMediaPlayer() {
-        facade.prepareVideo(ANY_URI, surface);
-        facade.prepareVideo(ANY_URI, surface);
+        facade.prepareVideo(ANY_URI, eitherSurface);
+        facade.prepareVideo(ANY_URI, eitherSurface);
 
         verify(mediaPlayer).reset();
         verify(mediaPlayer).release();
@@ -152,10 +160,25 @@ public class AndroidMediaPlayerFacadeTest {
     }
 
     @Test
-    public void whenPreparing_thenSetsDisplay() {
-        givenMediaPlayerIsPrepared();
+    public void givenSurfaceRequesterReturnsSurface_whenPreparing_thenSetsSurface() {
+        Surface surface = mock(Surface.class);
+        Either<Surface, SurfaceHolder> eitherSurface = Either.left(surface);
+        givenSurfaceRequesterReturns(eitherSurface);
+
+        givenMediaPlayerIsPreparedWith(eitherSurface);
 
         verify(mediaPlayer).setSurface(surface);
+    }
+
+    @Test
+    public void givenSurfaceRequesterReturnsSurfaceHolder_whenPreparing_thenSetsDisplay() {
+        SurfaceHolder surfaceHolder = mock(SurfaceHolder.class);
+        Either<Surface, SurfaceHolder> eitherSurface = Either.right(surfaceHolder);
+        givenSurfaceRequesterReturns(eitherSurface);
+
+        givenMediaPlayerIsPreparedWith(eitherSurface);
+
+        verify(mediaPlayer).setDisplay(surfaceHolder);
     }
 
     @Test
@@ -196,7 +219,7 @@ public class AndroidMediaPlayerFacadeTest {
 
     @Test
     public void givenBoundPreparedListener_andMediaPlayerIsPrepared_whenPrepared_thenForwardsOnPrepared() {
-        facade.prepareVideo(ANY_URI, surface);
+        facade.prepareVideo(ANY_URI, eitherSurface);
         ArgumentCaptor<MediaPlayer.OnPreparedListener> argumentCaptor = ArgumentCaptor.forClass(MediaPlayer.OnPreparedListener.class);
         verify(mediaPlayer).setOnPreparedListener(argumentCaptor.capture());
         argumentCaptor.getValue().onPrepared(mediaPlayer);
@@ -288,27 +311,39 @@ public class AndroidMediaPlayerFacadeTest {
     }
 
     @Test
-    public void givenMediaPlayerIsPrepared_whenStarting_thenSetsDisplay() {
+    public void givenMediaPlayerIsPreparedWithSurface_whenStarting_thenSetsSurface() {
         givenMediaPlayerIsPrepared();
         reset(mediaPlayer);
 
-        facade.start(surface);
+        facade.start(eitherSurface);
 
         verify(mediaPlayer).setSurface(surface);
+    }
+
+    @Test
+    public void givenMediaPlayerIsPreparedWithSurfaceHolder_whenStarting_thenSetsDisplay() {
+        SurfaceHolder surfaceHolder = mock(SurfaceHolder.class);
+        Either<Surface, SurfaceHolder> eitherSurface = Either.right(surfaceHolder);
+        givenMediaPlayerIsPreparedWith(eitherSurface);
+        reset(mediaPlayer);
+
+        facade.start(eitherSurface);
+
+        verify(mediaPlayer).setDisplay(surfaceHolder);
     }
 
     @Test
     public void givenMediaPlayerIsNotPrepared_whenStarting_thenThrowsIllegalStateException() {
         thrown.expect(ExceptionMatcher.matches(ERROR_MESSAGE, IllegalStateException.class));
 
-        facade.start(surface);
+        facade.start(eitherSurface);
     }
 
     @Test
     public void givenMediaPlayerIsPrepared_whenStarting_thenStartsMediaPlayer() {
         givenMediaPlayerIsPrepared();
 
-        facade.start(surface);
+        facade.start(eitherSurface);
 
         verify(mediaPlayer).start();
     }
@@ -601,7 +636,11 @@ public class AndroidMediaPlayerFacadeTest {
     }
 
     private void givenMediaPlayerIsPrepared() {
-        facade.prepareVideo(ANY_URI, surface);
+        givenMediaPlayerIsPreparedWith(eitherSurface);
+    }
+
+    private void givenMediaPlayerIsPreparedWith(Either<Surface, SurfaceHolder> eitherSurface) {
+        facade.prepareVideo(ANY_URI, eitherSurface);
         ArgumentCaptor<MediaPlayer.OnPreparedListener> argumentCaptor = ArgumentCaptor.forClass(MediaPlayer.OnPreparedListener.class);
         verify(mediaPlayer).setOnPreparedListener(argumentCaptor.capture());
         argumentCaptor.getValue().onPrepared(mediaPlayer);

--- a/core/src/test/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImplTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImplTest.java
@@ -3,6 +3,7 @@ package com.novoda.noplayer.internal.mediaplayer;
 import android.media.MediaPlayer;
 import android.net.Uri;
 import android.view.Surface;
+import android.view.SurfaceHolder;
 import android.view.View;
 import com.novoda.noplayer.ContentType;
 import com.novoda.noplayer.NoPlayer;
@@ -17,6 +18,7 @@ import com.novoda.noplayer.internal.listeners.PlayerListenersHolder;
 import com.novoda.noplayer.internal.mediaplayer.forwarder.MediaPlayerForwarder;
 import com.novoda.noplayer.internal.utils.NoPlayerLog;
 import com.novoda.noplayer.model.AudioTracks;
+import com.novoda.noplayer.model.Either;
 import com.novoda.noplayer.model.LoadTimeout;
 import com.novoda.noplayer.model.PlayerAudioTrack;
 import com.novoda.noplayer.model.PlayerAudioTrackFixture;
@@ -686,7 +688,7 @@ public class AndroidMediaPlayerImplTest {
         @Mock
         NoPlayer.StateChangedListener stateChangedListener;
         @Mock
-        Surface surface;
+        Either<Surface, SurfaceHolder> surface;
         @Mock
         PlayerView playerView;
         @Mock

--- a/core/src/test/java/com/novoda/noplayer/model/EitherTest.java
+++ b/core/src/test/java/com/novoda/noplayer/model/EitherTest.java
@@ -1,0 +1,37 @@
+package com.novoda.noplayer.model;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class EitherTest {
+
+    @Mock
+    private Either.Consumer<String> leftConsumer;
+    @Mock
+    private Either.Consumer<Integer> rightConsumer;
+
+    @Test
+    public void givenEitherContainsLeft_whenApplyingConsumers_thenRunsLeftConsumerWithCorrectValue() {
+        String value = "foo";
+        Either<String, Integer> either = Either.left(value);
+
+        either.apply(leftConsumer, rightConsumer);
+
+        verify(leftConsumer).accept(value);
+    }
+
+    @Test
+    public void givenEitherContainsRight_whenApplyingConsumers_thenRunsRightConsumerWithCorrectValue() {
+        Integer value = 42;
+        Either<String, Integer> either = Either.right(value);
+
+        either.apply(leftConsumer, rightConsumer);
+
+        verify(rightConsumer).accept(value);
+    }
+}


### PR DESCRIPTION
## Problem

While adding a support for `TextureView` I (possibly) changed the behavior of `MediaPlayer` with the `SurfaceView` because instead of providing `SurfaceHolder` to MediaPlayer I started providing `Surface`. I don't know if that changes any behavior, so it's probably for the best to keep the changes to minimum.

## Solution

Add support to provide both `Surface` and `SurfaceHolder` to MediaPlayer by introducing a concept of `Either`. That way, the `Surface` is only provided if no-player is used with `TextureView` which is completely separate from the previous `SurfaceView` behavior that uses `SurfaceHolder`.

### Test(s) added 

updated and added where necessary

### Screenshots

no UI changes

### Paired with 

nobody
