### PR TITLE
Add equals, hashcode and toString to Options.

### DIFF
--- a/core/src/main/java/com/novoda/noplayer/Options.java
+++ b/core/src/main/java/com/novoda/noplayer/Options.java
@@ -23,4 +23,41 @@ public class Options {
     public int maxInitialBitrate() {
         return maxInitialBitrate;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        Options options = (Options) o;
+
+        if (minDurationBeforeQualityIncreaseInMillis != options.minDurationBeforeQualityIncreaseInMillis) {
+            return false;
+        }
+        if (maxInitialBitrate != options.maxInitialBitrate) {
+            return false;
+        }
+        return contentType == options.contentType;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = contentType != null ? contentType.hashCode() : 0;
+        result = 31 * result + minDurationBeforeQualityIncreaseInMillis;
+        result = 31 * result + maxInitialBitrate;
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "Options{"
+                + "contentType=" + contentType
+                + ", minDurationBeforeQualityIncreaseInMillis=" + minDurationBeforeQualityIncreaseInMillis
+                + ", maxInitialBitrate=" + maxInitialBitrate
+                + '}';
+    }
 }


### PR DESCRIPTION
## Problem
Realised that `Options` does not have an equals or hashcode 😬. If testing in a client application with mockito or similar this will break 😬 

## Solution
Add equals, hashcode and toString.

### Paired with 
Nobody.
