### PR TITLE
Use given MediaSourceEventListener when creating DASH media source

### DIFF
--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/mediasource/MediaSourceFactory.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/mediasource/MediaSourceFactory.java
@@ -37,7 +37,7 @@ public class MediaSourceFactory {
             case H264:
                 return createH264MediaSource(defaultDataSourceFactory, uri, mediaSourceEventListener);
             case DASH:
-                return createDashMediaSource(defaultDataSourceFactory, uri);
+                return createDashMediaSource(defaultDataSourceFactory, uri, mediaSourceEventListener);
             default:
                 throw new UnsupportedOperationException("Content type: " + options + " is not supported.");
         }
@@ -64,9 +64,12 @@ public class MediaSourceFactory {
     }
 
     private MediaSource createDashMediaSource(DefaultDataSourceFactory defaultDataSourceFactory,
-                                              Uri uri) {
+                                              Uri uri,
+                                              MediaSourceEventListener mediaSourceEventListener) {
         DefaultDashChunkSource.Factory chunkSourceFactory = new DefaultDashChunkSource.Factory(defaultDataSourceFactory);
         DashMediaSource.Factory factory = new DashMediaSource.Factory(chunkSourceFactory, defaultDataSourceFactory);
-        return factory.createMediaSource(uri);
+        DashMediaSource mediaSource = factory.createMediaSource(uri);
+        mediaSource.addEventListener(handler, mediaSourceEventListener);
+        return mediaSource;
     }
 }


### PR DESCRIPTION
## Problem
Bitrate listeners aren't hearing any bitrate change events when playing DASH content.

## Solution
When we create a DASH media source, use the given MediaSourceEventListener instance to ensure all of the noplayer listeners make it into exoplayer.

### Test(s) added 
There's no tests around the MediaSourceFactory class and it would be very difficult to add them.

In order to test this works, add a new BitrateChangedListener in the DemoPresenter with some logging in it. Run the demo, check Logcat to see it appear. I made this change but reverted it as I couldn't see any similar code doing anything like it.

### Paired with 
Given good direction by @Mecharyry 