### PR TITLE
Allow creating player with custom data source factory for exoplayer

### DIFF
--- a/core/src/main/java/com/novoda/noplayer/PlayerBuilder.java
+++ b/core/src/main/java/com/novoda/noplayer/PlayerBuilder.java
@@ -4,6 +4,8 @@ import android.content.Context;
 import android.os.Handler;
 import android.os.Looper;
 
+import com.google.android.exoplayer2.source.MediaSource;
+import com.google.android.exoplayer2.upstream.DataSource;
 import com.novoda.noplayer.drm.DownloadedModularDrm;
 import com.novoda.noplayer.drm.DrmHandler;
 import com.novoda.noplayer.drm.DrmType;
@@ -13,6 +15,7 @@ import com.novoda.noplayer.internal.exoplayer.NoPlayerExoPlayerCreator;
 import com.novoda.noplayer.internal.exoplayer.drm.DrmSessionCreatorFactory;
 import com.novoda.noplayer.internal.mediaplayer.NoPlayerMediaPlayerCreator;
 import com.novoda.noplayer.internal.utils.AndroidDeviceVersion;
+import com.novoda.noplayer.internal.utils.Optional;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -26,6 +29,7 @@ public class PlayerBuilder {
     private DrmType drmType = DrmType.NONE;
     private DrmHandler drmHandler = DrmHandler.NO_DRM;
     private List<PlayerType> prioritizedPlayerTypes = Arrays.asList(PlayerType.EXO_PLAYER, PlayerType.MEDIA_PLAYER);
+    private Optional<DataSource.Factory> dataSourceFactory = Optional.absent();
     private boolean downgradeSecureDecoder;
 
     /**
@@ -103,6 +107,19 @@ public class PlayerBuilder {
     }
 
     /**
+     * Allows to use a custom data source factory for Exoplayer.
+     * e.g A custom data source can implement cachin mechanism
+     * e.g The OkHttpDataSource extension can be used
+     *
+     * @param dataSourceFactory a custom {@link DataSource.Factory} to be used when creating {@link MediaSource}
+     * @return {@link PlayerBuilder}
+     */
+    public PlayerBuilder withDataSourceFactory(DataSource.Factory dataSourceFactory) {
+        this.dataSourceFactory = Optional.of(dataSourceFactory);
+        return this;
+    }
+
+    /**
      * Builds a new {@link NoPlayer} instance.
      *
      * @param context The {@link Context} associated with the player.
@@ -121,7 +138,7 @@ public class PlayerBuilder {
         NoPlayerCreator noPlayerCreator = new NoPlayerCreator(
                 context,
                 prioritizedPlayerTypes,
-                NoPlayerExoPlayerCreator.newInstance(handler),
+                NoPlayerExoPlayerCreator.newInstance(handler, dataSourceFactory),
                 NoPlayerMediaPlayerCreator.newInstance(handler),
                 drmSessionCreatorFactory
         );

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerExoPlayerCreator.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerExoPlayerCreator.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.os.Handler;
 
 import com.google.android.exoplayer2.mediacodec.MediaCodecSelector;
+import com.google.android.exoplayer2.upstream.DataSource;
 import com.novoda.noplayer.NoPlayer;
 import com.novoda.noplayer.internal.Heart;
 import com.novoda.noplayer.internal.SystemClock;
@@ -12,14 +13,15 @@ import com.novoda.noplayer.internal.exoplayer.forwarder.ExoPlayerForwarder;
 import com.novoda.noplayer.internal.exoplayer.mediasource.MediaSourceFactory;
 import com.novoda.noplayer.internal.listeners.PlayerListenersHolder;
 import com.novoda.noplayer.internal.utils.AndroidDeviceVersion;
+import com.novoda.noplayer.internal.utils.Optional;
 import com.novoda.noplayer.model.LoadTimeout;
 
 public class NoPlayerExoPlayerCreator {
 
     private final InternalCreator internalCreator;
 
-    public static NoPlayerExoPlayerCreator newInstance(Handler handler) {
-        InternalCreator internalCreator = new InternalCreator(handler);
+    public static NoPlayerExoPlayerCreator newInstance(Handler handler, Optional<DataSource.Factory> dataSourceFactory) {
+        InternalCreator internalCreator = new InternalCreator(handler, dataSourceFactory);
         return new NoPlayerExoPlayerCreator(internalCreator);
     }
 
@@ -36,13 +38,15 @@ public class NoPlayerExoPlayerCreator {
     static class InternalCreator {
 
         private final Handler handler;
+        private final Optional<DataSource.Factory> dataSourceFactory;
 
-        InternalCreator(Handler handler) {
+        InternalCreator(Handler handler, Optional<DataSource.Factory> dataSourceFactory) {
             this.handler = handler;
+            this.dataSourceFactory = dataSourceFactory;
         }
 
         ExoPlayerTwoImpl create(Context context, DrmSessionCreator drmSessionCreator, boolean downgradeSecureDecoder) {
-            MediaSourceFactory mediaSourceFactory = new MediaSourceFactory(context, handler);
+            MediaSourceFactory mediaSourceFactory = new MediaSourceFactory(context, handler, dataSourceFactory);
 
             MediaCodecSelector mediaCodecSelector = downgradeSecureDecoder
                     ? SecurityDowngradingCodecSelector.newInstance()


### PR DESCRIPTION
## Problem

It is possible that some clients requires for `Exoplayer` and enhanced `DataSource`; for example one can implement a custom caching mechanism or use the `Okhttp` extension that exo player provides: https://github.com/google/ExoPlayer/tree/release-v2/extensions/okhttp

## Solution

Allow `PlayerBuilder` to receive a custom `DataSource.Factory` to be used upon the creation of `MediaSource` at `MediaSourceFactory` 

```
    /**
     * Allows to use a custom data source factory for Exoplayer.
     * e.g A custom data source can implement cachin mechanism
     * e.g The OkHttpDataSource extension can be used
     *
     * @param dataSourceFactory a custom {@link DataSource.Factory} to be used when creating {@link MediaSource}
     * @return {@link PlayerBuilder}
     */
    public PlayerBuilder withDataSourceFactory(DataSource.Factory dataSourceFactory) {
        this.dataSourceFactory = Optional.of(dataSourceFactory);
        return this;
    }
```

### Test(s) added 

There was not tests around the areas affected, no test failed after this

### Paired with 

Nobody