### PR TITLE
Add experimental to the build script

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -24,10 +24,14 @@ buildProperties {
     publish {
         def generateVersion = {
             boolean isSnapshot = cli['bintraySnapshot'].or(false).boolean
+            if (isSnapshot) {
+                return "SNAPSHOT-${System.getenv('BUILD_NUMBER') ?: 'LOCAL'}";
+            }
             boolean isExperimental = cli['bintrayExperimental'].or(false).boolean
-            def snapshotVersion = "SNAPSHOT-${System.getenv('BUILD_NUMBER') ?: 'LOCAL'}"
-            def experimentalVersion = "EXPERIMENTAL-${System.getenv('BUILD_NUMBER') ?: 'LOCAL'}"
-            return isSnapshot ? snapshotVersion : isExperimental ? experimentalVersion : version
+            if (isExperimental) {
+                return "EXPERIMENTAL-${System.getenv('BUILD_NUMBER') ?: 'LOCAL'}";
+            }
+            return version
         }
         using(['version': "${generateVersion()}"])
                 .or(buildProperties.bintray)

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -24,7 +24,10 @@ buildProperties {
     publish {
         def generateVersion = {
             boolean isSnapshot = cli['bintraySnapshot'].or(false).boolean
-            return isSnapshot ? "SNAPSHOT-${System.getenv('BUILD_NUMBER')?:'LOCAL'}" : version
+            boolean isExperimental = cli['bintrayExperimental'].or(false).boolean
+            def snapshotVersion = "SNAPSHOT-${System.getenv('BUILD_NUMBER') ?: 'LOCAL'}"
+            def experimentalVersion = "EXPERIMENTAL-${System.getenv('BUILD_NUMBER') ?: 'LOCAL'}"
+            return isSnapshot ? snapshotVersion : isExperimental ? experimentalVersion : version
         }
         using(['version': "${generateVersion()}"])
                 .or(buildProperties.bintray)


### PR DESCRIPTION
## Problem
We want to be able to try experimental work on `no-player` without affecting the develop branch. This should allow anyone to create a branch and PR it against an `experimental` branch, on merging this should be released to our private bintray repository. 

## Solution
Add experiment to the build script. The CI work is almost done too.

### Paired with 
@mr-archano helped me sort out the CI for this work.
