### PR TITLE
Wrap to optional inside new instance method

### DIFF
--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerExoPlayerCreator.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerExoPlayerCreator.java
@@ -25,8 +25,8 @@ public class NoPlayerExoPlayerCreator {
         return new NoPlayerExoPlayerCreator(internalCreator);
     }
 
-    public static NoPlayerExoPlayerCreator newInstance(Handler handler, Optional<DataSource.Factory> dataSourceFactory) {
-        InternalCreator internalCreator = new InternalCreator(handler, dataSourceFactory);
+    public static NoPlayerExoPlayerCreator newInstance(Handler handler, DataSource.Factory dataSourceFactory) {
+        InternalCreator internalCreator = new InternalCreator(handler, Optional.of(dataSourceFactory));
         return new NoPlayerExoPlayerCreator(internalCreator);
     }
 


### PR DESCRIPTION
## Problem

For those using `NoPlayerExoPlayerCreator.newInstance(Handler handler, Optional<DataSource.Factory> dataSourceFactory)` there is a need to make use of the `NoPlayer` internal `Optional` class.

## Solution

Do the wrapping inside the `newInstance` so they are agnostic of this
