### PR TITLE
Update dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 allprojects {
-    version = '4.5.1'
+    version = '4.5.2'
 }
 
 def teamPropsFile(propsFile) {
@@ -14,7 +14,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath 'com.android.tools.build:gradle:3.3.0'
         classpath 'com.novoda:bintray-release:0.9'
         classpath 'com.novoda:gradle-static-analysis-plugin:0.8'
         classpath 'com.novoda:gradle-build-properties-plugin:0.4.1'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -59,7 +59,9 @@ android {
 }
 
 dependencies {
-    implementation 'com.google.android.exoplayer:exoplayer:2.9.2'
+    api 'com.google.android.exoplayer:exoplayer:2.9.4'
+
+    implementation 'com.android.support:support-annotations:28.0.0'
 
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:2.23.4'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Dec 21 08:51:35 GMT 2018
+#Fri Feb 01 15:19:30 GMT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip


### PR DESCRIPTION
## Problem

A client uses ExoPlayer classes and those are infered from NoPlayer, but NoPlayer doesn't use `api` for the ExoPlayer dependency so when updating the gradle dependencies in the client, the ExoPlayer ones are no longer visible.

## Solution

Update gradle and all other dependencies
Use `api` for the `ExoPlayer` dependnecy

Updates ExoPlayer to 2.9.4 https://github.com/google/ExoPlayer/blob/release-v2/RELEASENOTES.md#294

### Test(s) added 

Tested the demo application and the logs, all plays fine, subtitles works, no errors in the logs

### Screenshots

No UI changes

### Paired with 

Nobody
