### PR TITLE
Update project dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath 'com.android.tools.build:gradle:3.3.0'
         classpath 'com.novoda:bintray-release:0.9'
         classpath 'com.novoda:gradle-static-analysis-plugin:0.8'
         classpath 'com.novoda:gradle-build-properties-plugin:0.4.1'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -59,7 +59,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.google.android.exoplayer:exoplayer:2.9.2'
+    implementation 'com.google.android.exoplayer:exoplayer:2.9.4'
 
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:2.23.4'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -39,7 +39,7 @@ buildProperties {
 }
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
     buildToolsVersion '28.0.3'
 
     defaultConfig {
@@ -60,6 +60,8 @@ android {
 
 dependencies {
     implementation 'com.google.android.exoplayer:exoplayer:2.9.4'
+
+    implementation 'com.android.support:support-annotations:28.0.0'
 
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:2.23.4'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.0-all.zip


### PR DESCRIPTION
## Problem

Project dependencies are out-dated

## Solution

- Update gradle to 5.0, version 5.1.1 has a bug with `checkstyle` https://docs.gradle.org/5.0/release-notes.html- 
- Updates ExoPlayer to 2.9.4 https://github.com/google/ExoPlayer/blob/release-v2/RELEASENOTES.md#294
```
IMA extension: Clear ads loader listeners on release (#4114).
SmoothStreaming: Fix support for subtitles in DRM protected streams (#5378).
FFmpeg extension: Treat invalid data errors as non-fatal to match the behavior of MediaCodec (#5293).
GVR extension: upgrade GVR SDK dependency to 1.190.0.
Associate fatal player errors of type SOURCE with the loading source in AnalyticsListener.EventTime (#5407).
Add startPositionUs to MediaSource.createPeriod. This fixes an issue where using lazy preparation in ConcatenatingMediaSource with an ExtractorMediaSource overrides initial seek positions (#5350).
Add subtext to the MediaDescriptionAdapter of the PlayerNotificationManager.
Add workaround for video quality problems with Amlogic decoders (#5003).
Fix issue where sending callbacks for playlist changes may cause problems because of parallel player access (#5240).
Fix issue with reusing a ClippingMediaSource with an inner ExtractorMediaSource and a non-zero start position (#5351).
Fix issue where uneven track durations in MP4 streams can cause OOM problems (#3670).
```
- Gradle plugin to 3.3.0 https://developer.android.com/studio/releases/gradle-plugin
- Updated Android compile version to 28
- Added `implementation 'com.android.support:support-annotations:28.0.0'` as it is not required

### Test(s) added 

Tested the demo application and the logs, all plays fine, subtitles works, no errors in the logs

### Screenshots

No UI changes

### Paired with 

Nobody
