### PR TITLE
Allow redirects cross protocols

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.0'
+        classpath 'com.android.tools.build:gradle:3.3.1'
         classpath 'com.novoda:bintray-release:0.9'
         classpath 'com.novoda:gradle-static-analysis-plugin:0.8'
         classpath 'com.novoda:gradle-build-properties-plugin:0.4.1'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -59,12 +59,12 @@ android {
 }
 
 dependencies {
-    implementation 'com.google.android.exoplayer:exoplayer:2.9.4'
+    implementation 'com.google.android.exoplayer:exoplayer:2.9.5'
 
     implementation 'com.android.support:support-annotations:28.0.0'
 
     testImplementation 'junit:junit:4.12'
-    testImplementation 'org.mockito:mockito-core:2.23.4'
+    testImplementation 'org.mockito:mockito-core:2.24.0'
     testImplementation 'org.easytesting:fest-assert-core:2.0M10'
 }
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -59,7 +59,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.google.android.exoplayer:exoplayer:2.9.5'
+    implementation 'com.google.android.exoplayer:exoplayer:2.9.6'
 
     implementation 'com.android.support:support-annotations:28.0.0'
 

--- a/core/src/main/java/com/novoda/noplayer/NoPlayerCreator.java
+++ b/core/src/main/java/com/novoda/noplayer/NoPlayerCreator.java
@@ -32,23 +32,32 @@ class NoPlayerCreator {
         this.drmSessionCreatorFactory = drmSessionCreatorFactory;
     }
 
-    NoPlayer create(DrmType drmType, DrmHandler drmHandler, boolean downgradeSecureDecoder) {
+    NoPlayer create(DrmType drmType, DrmHandler drmHandler, boolean downgradeSecureDecoder, boolean allowCrossProtocolRedirects) {
         for (PlayerType player : prioritizedPlayerTypes) {
             if (player.supports(drmType)) {
-                return createPlayerForType(player, drmType, drmHandler, downgradeSecureDecoder);
+                return createPlayerForType(player, drmType, drmHandler, downgradeSecureDecoder, allowCrossProtocolRedirects);
             }
         }
         throw UnableToCreatePlayerException.unhandledDrmType(drmType);
     }
 
-    private NoPlayer createPlayerForType(PlayerType playerType, DrmType drmType, DrmHandler drmHandler, boolean downgradeSecureDecoder) {
+    private NoPlayer createPlayerForType(PlayerType playerType,
+                                         DrmType drmType,
+                                         DrmHandler drmHandler,
+                                         boolean downgradeSecureDecoder,
+                                         boolean allowCrossProtocolRedirects) {
         switch (playerType) {
             case MEDIA_PLAYER:
                 return noPlayerMediaPlayerCreator.createMediaPlayer(context);
             case EXO_PLAYER:
                 try {
                     DrmSessionCreator drmSessionCreator = drmSessionCreatorFactory.createFor(drmType, drmHandler);
-                    return noPlayerExoPlayerCreator.createExoPlayer(context, drmSessionCreator, downgradeSecureDecoder);
+                    return noPlayerExoPlayerCreator.createExoPlayer(
+                            context,
+                            drmSessionCreator,
+                            downgradeSecureDecoder,
+                            allowCrossProtocolRedirects
+                    );
                 } catch (DrmSessionCreatorException exception) {
                     throw new UnableToCreatePlayerException(exception);
                 }

--- a/core/src/main/java/com/novoda/noplayer/PlayerBuilder.java
+++ b/core/src/main/java/com/novoda/noplayer/PlayerBuilder.java
@@ -106,11 +106,12 @@ public class PlayerBuilder {
      * Builds a new {@link NoPlayer} instance.
      *
      * @param context The {@link Context} associated with the player.
+     * @param userAgent The application's userAgent value
      * @return a {@link NoPlayer} instance.
      * @throws UnableToCreatePlayerException thrown when the configuration is not supported and there is no way to recover.
      * @see NoPlayer
      */
-    public NoPlayer build(Context context) throws UnableToCreatePlayerException {
+    public NoPlayer build(Context context, String userAgent) throws UnableToCreatePlayerException {
         Context applicationContext = context.getApplicationContext();
         Handler handler = new Handler(Looper.getMainLooper());
         ProvisionExecutorCreator provisionExecutorCreator = new ProvisionExecutorCreator();
@@ -122,7 +123,7 @@ public class PlayerBuilder {
         NoPlayerCreator noPlayerCreator = new NoPlayerCreator(
                 applicationContext,
                 prioritizedPlayerTypes,
-                NoPlayerExoPlayerCreator.newInstance(handler),
+                NoPlayerExoPlayerCreator.newInstance(userAgent, handler),
                 NoPlayerMediaPlayerCreator.newInstance(handler),
                 drmSessionCreatorFactory
         );

--- a/core/src/main/java/com/novoda/noplayer/PlayerBuilder.java
+++ b/core/src/main/java/com/novoda/noplayer/PlayerBuilder.java
@@ -27,6 +27,8 @@ public class PlayerBuilder {
     private DrmHandler drmHandler = DrmHandler.NO_DRM;
     private List<PlayerType> prioritizedPlayerTypes = Arrays.asList(PlayerType.EXO_PLAYER, PlayerType.MEDIA_PLAYER);
     private boolean downgradeSecureDecoder;
+    private String userAgent = "user-agent";
+    private boolean allowCrossProtocolRedirects = false;
 
     /**
      * Sets {@link PlayerBuilder} to build a {@link NoPlayer} which supports Widevine classic DRM.
@@ -103,15 +105,33 @@ public class PlayerBuilder {
     }
 
     /**
+     *
+     * @param userAgent The application's userAgent value
+     * @return {@link PlayerBuilder}
+     */
+    public PlayerBuilder withUserAgent(String userAgent) {
+        this.userAgent = userAgent;
+        return this;
+    }
+
+    /**
+     * Network connections will be allowed to perform redirects between HTTP and HTTPS protocols
+     * @return {@link PlayerBuilder}
+     */
+    public PlayerBuilder allowCrossProtocolRedirects() {
+        allowCrossProtocolRedirects = true;
+        return this;
+    }
+
+    /**
      * Builds a new {@link NoPlayer} instance.
      *
      * @param context The {@link Context} associated with the player.
-     * @param userAgent The application's userAgent value
      * @return a {@link NoPlayer} instance.
      * @throws UnableToCreatePlayerException thrown when the configuration is not supported and there is no way to recover.
      * @see NoPlayer
      */
-    public NoPlayer build(Context context, String userAgent) throws UnableToCreatePlayerException {
+    public NoPlayer build(Context context) throws UnableToCreatePlayerException {
         Context applicationContext = context.getApplicationContext();
         Handler handler = new Handler(Looper.getMainLooper());
         ProvisionExecutorCreator provisionExecutorCreator = new ProvisionExecutorCreator();
@@ -127,7 +147,7 @@ public class PlayerBuilder {
                 NoPlayerMediaPlayerCreator.newInstance(handler),
                 drmSessionCreatorFactory
         );
-        return noPlayerCreator.create(drmType, drmHandler, downgradeSecureDecoder);
+        return noPlayerCreator.create(drmType, drmHandler, downgradeSecureDecoder, allowCrossProtocolRedirects);
     }
 
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerExoPlayerCreator.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerExoPlayerCreator.java
@@ -34,8 +34,11 @@ public class NoPlayerExoPlayerCreator {
         this.internalCreator = internalCreator;
     }
 
-    public NoPlayer createExoPlayer(Context context, DrmSessionCreator drmSessionCreator, boolean downgradeSecureDecoder) {
-        ExoPlayerTwoImpl player = internalCreator.create(context, drmSessionCreator, downgradeSecureDecoder);
+    public NoPlayer createExoPlayer(Context context,
+                                    DrmSessionCreator drmSessionCreator,
+                                    boolean downgradeSecureDecoder,
+                                    boolean allowCrossProtocolRedirects) {
+        ExoPlayerTwoImpl player = internalCreator.create(context, drmSessionCreator, downgradeSecureDecoder, allowCrossProtocolRedirects);
         player.initialise();
         return player;
     }
@@ -52,8 +55,17 @@ public class NoPlayerExoPlayerCreator {
             this.dataSourceFactory = dataSourceFactory;
         }
 
-        ExoPlayerTwoImpl create(Context context, DrmSessionCreator drmSessionCreator, boolean downgradeSecureDecoder) {
-            MediaSourceFactory mediaSourceFactory = new MediaSourceFactory(context, userAgent, handler, dataSourceFactory);
+        ExoPlayerTwoImpl create(Context context,
+                                DrmSessionCreator drmSessionCreator,
+                                boolean downgradeSecureDecoder,
+                                boolean allowCrossProtocolRedirects) {
+            MediaSourceFactory mediaSourceFactory = new MediaSourceFactory(
+                    context,
+                    userAgent,
+                    handler,
+                    dataSourceFactory,
+                    allowCrossProtocolRedirects
+            );
 
             MediaCodecSelector mediaCodecSelector = downgradeSecureDecoder
                     ? SecurityDowngradingCodecSelector.newInstance()

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerExoPlayerCreator.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerExoPlayerCreator.java
@@ -20,13 +20,13 @@ public class NoPlayerExoPlayerCreator {
 
     private final InternalCreator internalCreator;
 
-    public static NoPlayerExoPlayerCreator newInstance(Handler handler) {
-        InternalCreator internalCreator = new InternalCreator(handler, Optional.<DataSource.Factory>absent());
+    public static NoPlayerExoPlayerCreator newInstance(String userAgent, Handler handler) {
+        InternalCreator internalCreator = new InternalCreator(userAgent, handler, Optional.<DataSource.Factory>absent());
         return new NoPlayerExoPlayerCreator(internalCreator);
     }
 
-    public static NoPlayerExoPlayerCreator newInstance(Handler handler, DataSource.Factory dataSourceFactory) {
-        InternalCreator internalCreator = new InternalCreator(handler, Optional.of(dataSourceFactory));
+    public static NoPlayerExoPlayerCreator newInstance(String userAgent, Handler handler, DataSource.Factory dataSourceFactory) {
+        InternalCreator internalCreator = new InternalCreator(userAgent, handler, Optional.of(dataSourceFactory));
         return new NoPlayerExoPlayerCreator(internalCreator);
     }
 
@@ -44,14 +44,16 @@ public class NoPlayerExoPlayerCreator {
 
         private final Handler handler;
         private final Optional<DataSource.Factory> dataSourceFactory;
+        private final String userAgent;
 
-        InternalCreator(Handler handler, Optional<DataSource.Factory> dataSourceFactory) {
+        InternalCreator(String userAgent, Handler handler, Optional<DataSource.Factory> dataSourceFactory) {
+            this.userAgent = userAgent;
             this.handler = handler;
             this.dataSourceFactory = dataSourceFactory;
         }
 
         ExoPlayerTwoImpl create(Context context, DrmSessionCreator drmSessionCreator, boolean downgradeSecureDecoder) {
-            MediaSourceFactory mediaSourceFactory = new MediaSourceFactory(context, handler, dataSourceFactory);
+            MediaSourceFactory mediaSourceFactory = new MediaSourceFactory(context, userAgent, handler, dataSourceFactory);
 
             MediaCodecSelector mediaCodecSelector = downgradeSecureDecoder
                     ? SecurityDowngradingCodecSelector.newInstance()

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/mediasource/MediaSourceFactory.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/mediasource/MediaSourceFactory.java
@@ -25,12 +25,18 @@ public class MediaSourceFactory {
     private final Handler handler;
     private final Optional<DataSource.Factory> dataSourceFactory;
     private final String userAgent;
+    private final boolean allowCrossProtocolRedirects;
 
-    public MediaSourceFactory(Context context, String userAgent, Handler handler, Optional<DataSource.Factory> dataSourceFactory) {
+    public MediaSourceFactory(Context context,
+                              String userAgent,
+                              Handler handler,
+                              Optional<DataSource.Factory> dataSourceFactory,
+                              boolean allowCrossProtocolRedirects) {
         this.context = context;
         this.handler = handler;
         this.dataSourceFactory = dataSourceFactory;
         this.userAgent = userAgent;
+        this.allowCrossProtocolRedirects = allowCrossProtocolRedirects;
     }
 
     public MediaSource create(Options options,
@@ -59,7 +65,7 @@ public class MediaSourceFactory {
                     bandwidthMeter,
                     DefaultHttpDataSource.DEFAULT_CONNECT_TIMEOUT_MILLIS,
                     DefaultHttpDataSource.DEFAULT_READ_TIMEOUT_MILLIS,
-                    true /* allowCrossProtocolRedirects */
+                    allowCrossProtocolRedirects
             );
 
             return new DefaultDataSourceFactory(context, bandwidthMeter, httpDataSourceFactory);

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/mediasource/MediaSourceFactory.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/mediasource/MediaSourceFactory.java
@@ -24,11 +24,13 @@ public class MediaSourceFactory {
     private final Context context;
     private final Handler handler;
     private final Optional<DataSource.Factory> dataSourceFactory;
+    private final String userAgent;
 
-    public MediaSourceFactory(Context context, Handler handler, Optional<DataSource.Factory> dataSourceFactory) {
+    public MediaSourceFactory(Context context, String userAgent, Handler handler, Optional<DataSource.Factory> dataSourceFactory) {
         this.context = context;
         this.handler = handler;
         this.dataSourceFactory = dataSourceFactory;
+        this.userAgent = userAgent;
     }
 
     public MediaSource create(Options options,
@@ -53,7 +55,7 @@ public class MediaSourceFactory {
             return new DefaultDataSourceFactory(context, bandwidthMeter, dataSourceFactory.get());
         } else {
             DefaultHttpDataSourceFactory httpDataSourceFactory = new DefaultHttpDataSourceFactory(
-                    "user-agent",
+                    userAgent,
                     bandwidthMeter,
                     DefaultHttpDataSource.DEFAULT_CONNECT_TIMEOUT_MILLIS,
                     DefaultHttpDataSource.DEFAULT_READ_TIMEOUT_MILLIS,

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/mediasource/MediaSourceFactory.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/mediasource/MediaSourceFactory.java
@@ -14,6 +14,8 @@ import com.google.android.exoplayer2.source.hls.HlsMediaSource;
 import com.google.android.exoplayer2.upstream.DataSource;
 import com.google.android.exoplayer2.upstream.DefaultBandwidthMeter;
 import com.google.android.exoplayer2.upstream.DefaultDataSourceFactory;
+import com.google.android.exoplayer2.upstream.DefaultHttpDataSource;
+import com.google.android.exoplayer2.upstream.DefaultHttpDataSourceFactory;
 import com.novoda.noplayer.Options;
 import com.novoda.noplayer.internal.utils.Optional;
 
@@ -50,7 +52,15 @@ public class MediaSourceFactory {
         if (dataSourceFactory.isPresent()) {
             return new DefaultDataSourceFactory(context, bandwidthMeter, dataSourceFactory.get());
         } else {
-            return new DefaultDataSourceFactory(context, "user-agent", bandwidthMeter);
+            DefaultHttpDataSourceFactory httpDataSourceFactory = new DefaultHttpDataSourceFactory(
+                    "user-agent",
+                    bandwidthMeter,
+                    DefaultHttpDataSource.DEFAULT_CONNECT_TIMEOUT_MILLIS,
+                    DefaultHttpDataSource.DEFAULT_READ_TIMEOUT_MILLIS,
+                    true /* allowCrossProtocolRedirects */
+            );
+
+            return new DefaultDataSourceFactory(context, bandwidthMeter, httpDataSourceFactory);
         }
     }
 

--- a/core/src/test/java/com/novoda/noplayer/NoPlayerCreatorTest.java
+++ b/core/src/test/java/com/novoda/noplayer/NoPlayerCreatorTest.java
@@ -12,9 +12,6 @@ import com.novoda.noplayer.internal.exoplayer.drm.DrmSessionCreatorException;
 import com.novoda.noplayer.internal.exoplayer.drm.DrmSessionCreatorFactory;
 import com.novoda.noplayer.internal.mediaplayer.NoPlayerMediaPlayerCreator;
 
-import java.util.Arrays;
-import java.util.List;
-
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -23,6 +20,9 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
+
+import java.util.Arrays;
+import java.util.List;
 
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -35,6 +35,7 @@ public class NoPlayerCreatorTest {
     public abstract static class Base {
 
         static final boolean USE_SECURE_CODEC = false;
+        static final boolean ALLOW_CROSS_PROTOCOL_REDIRECTS = false;
         static final StreamingModularDrm STREAMING_MODULAR_DRM = mock(StreamingModularDrm.class);
         static final DownloadedModularDrm DOWNLOADED_MODULAR_DRM = mock(DownloadedModularDrm.class);
         static final NoPlayer EXO_PLAYER = mock(NoPlayer.class);
@@ -60,7 +61,7 @@ public class NoPlayerCreatorTest {
         @Before
         public void setUp() throws DrmSessionCreatorException {
             given(drmSessionCreatorFactory.createFor(any(DrmType.class), any(DrmHandler.class))).willReturn(drmSessionCreator);
-            given(noPlayerExoPlayerCreator.createExoPlayer(context, drmSessionCreator, USE_SECURE_CODEC)).willReturn(EXO_PLAYER);
+            given(noPlayerExoPlayerCreator.createExoPlayer(context, drmSessionCreator, USE_SECURE_CODEC, ALLOW_CROSS_PROTOCOL_REDIRECTS)).willReturn(EXO_PLAYER);
             given(noPlayerMediaPlayerCreator.createMediaPlayer(context)).willReturn(MEDIA_PLAYER);
             noPlayerCreator = new NoPlayerCreator(context, prioritizedPlayerTypes(), noPlayerExoPlayerCreator, noPlayerMediaPlayerCreator, drmSessionCreatorFactory);
         }
@@ -77,28 +78,28 @@ public class NoPlayerCreatorTest {
 
         @Test
         public void whenCreatingPlayerWithDrmTypeNone_thenReturnsMediaPlayer() {
-            NoPlayer player = noPlayerCreator.create(DrmType.NONE, DrmHandler.NO_DRM, USE_SECURE_CODEC);
+            NoPlayer player = noPlayerCreator.create(DrmType.NONE, DrmHandler.NO_DRM, USE_SECURE_CODEC, ALLOW_CROSS_PROTOCOL_REDIRECTS);
 
             assertThat(player).isEqualTo(MEDIA_PLAYER);
         }
 
         @Test
         public void whenCreatingPlayerWithDrmTypeWidevineClassic_thenReturnsMediaPlayer() {
-            NoPlayer player = noPlayerCreator.create(DrmType.WIDEVINE_CLASSIC, DrmHandler.NO_DRM, USE_SECURE_CODEC);
+            NoPlayer player = noPlayerCreator.create(DrmType.WIDEVINE_CLASSIC, DrmHandler.NO_DRM, USE_SECURE_CODEC, ALLOW_CROSS_PROTOCOL_REDIRECTS);
 
             assertThat(player).isEqualTo(MEDIA_PLAYER);
         }
 
         @Test
         public void whenCreatingPlayerWithDrmTypeWidevineModularStream_thenReturnsExoPlayer() {
-            NoPlayer player = noPlayerCreator.create(DrmType.WIDEVINE_MODULAR_STREAM, STREAMING_MODULAR_DRM, USE_SECURE_CODEC);
+            NoPlayer player = noPlayerCreator.create(DrmType.WIDEVINE_MODULAR_STREAM, STREAMING_MODULAR_DRM, USE_SECURE_CODEC, ALLOW_CROSS_PROTOCOL_REDIRECTS);
 
             assertThat(player).isEqualTo(EXO_PLAYER);
         }
 
         @Test
         public void whenCreatingPlayerWithDrmTypeWidevineModularDownload_thenReturnsExoPlayer() {
-            NoPlayer player = noPlayerCreator.create(DrmType.WIDEVINE_MODULAR_DOWNLOAD, DOWNLOADED_MODULAR_DRM, USE_SECURE_CODEC);
+            NoPlayer player = noPlayerCreator.create(DrmType.WIDEVINE_MODULAR_DOWNLOAD, DOWNLOADED_MODULAR_DRM, USE_SECURE_CODEC, ALLOW_CROSS_PROTOCOL_REDIRECTS);
 
             assertThat(player).isEqualTo(EXO_PLAYER);
         }
@@ -113,28 +114,28 @@ public class NoPlayerCreatorTest {
 
         @Test
         public void whenCreatingPlayerWithDrmTypeNone_thenReturnsExoPlayer() {
-            NoPlayer player = noPlayerCreator.create(DrmType.NONE, DrmHandler.NO_DRM, USE_SECURE_CODEC);
+            NoPlayer player = noPlayerCreator.create(DrmType.NONE, DrmHandler.NO_DRM, USE_SECURE_CODEC, ALLOW_CROSS_PROTOCOL_REDIRECTS);
 
             assertThat(player).isEqualTo(EXO_PLAYER);
         }
 
         @Test
         public void whenCreatingPlayerWithDrmTypeWidevineClassic_thenReturnsMediaPlayer() {
-            NoPlayer player = noPlayerCreator.create(DrmType.WIDEVINE_CLASSIC, DrmHandler.NO_DRM, USE_SECURE_CODEC);
+            NoPlayer player = noPlayerCreator.create(DrmType.WIDEVINE_CLASSIC, DrmHandler.NO_DRM, USE_SECURE_CODEC, ALLOW_CROSS_PROTOCOL_REDIRECTS);
 
             assertThat(player).isEqualTo(MEDIA_PLAYER);
         }
 
         @Test
         public void whenCreatingPlayerWithDrmTypeWidevineModularStream_thenReturnsExoPlayer() {
-            NoPlayer player = noPlayerCreator.create(DrmType.WIDEVINE_MODULAR_STREAM, STREAMING_MODULAR_DRM, USE_SECURE_CODEC);
+            NoPlayer player = noPlayerCreator.create(DrmType.WIDEVINE_MODULAR_STREAM, STREAMING_MODULAR_DRM, USE_SECURE_CODEC, ALLOW_CROSS_PROTOCOL_REDIRECTS);
 
             assertThat(player).isEqualTo(EXO_PLAYER);
         }
 
         @Test
         public void whenCreatingPlayerWithDrmTypeWidevineModularDownload_thenReturnsExoPlayer() {
-            NoPlayer player = noPlayerCreator.create(DrmType.WIDEVINE_MODULAR_DOWNLOAD, DOWNLOADED_MODULAR_DRM, USE_SECURE_CODEC);
+            NoPlayer player = noPlayerCreator.create(DrmType.WIDEVINE_MODULAR_DOWNLOAD, DOWNLOADED_MODULAR_DRM, USE_SECURE_CODEC, ALLOW_CROSS_PROTOCOL_REDIRECTS);
 
             assertThat(player).isEqualTo(EXO_PLAYER);
         }

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/NoPlayerExoPlayerCreatorTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/NoPlayerExoPlayerCreatorTest.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.verify;
 public class NoPlayerExoPlayerCreatorTest {
 
     private static final boolean USE_SECURE_CODEC = true;
+    private static final boolean ALLOW_CROSS_PROTOCOL_REDIRECTS = true;
 
     @Rule
     public MockitoRule mockitoRule = MockitoJUnit.rule();
@@ -34,13 +35,13 @@ public class NoPlayerExoPlayerCreatorTest {
 
     @Before
     public void setUp() {
-        given(internalCreator.create(context, drmSessionCreator, USE_SECURE_CODEC)).willReturn(player);
+        given(internalCreator.create(context, drmSessionCreator, USE_SECURE_CODEC, ALLOW_CROSS_PROTOCOL_REDIRECTS)).willReturn(player);
         creator = new NoPlayerExoPlayerCreator(internalCreator);
     }
 
     @Test
     public void whenCreatingExoPlayerTwo_thenInitialisesPlayer() {
-        creator.createExoPlayer(context, drmSessionCreator, USE_SECURE_CODEC);
+        creator.createExoPlayer(context, drmSessionCreator, USE_SECURE_CODEC, ALLOW_CROSS_PROTOCOL_REDIRECTS);
 
         verify(player).initialise();
     }

--- a/demo/src/main/java/com/novoda/demo/MainActivity.java
+++ b/demo/src/main/java/com/novoda/demo/MainActivity.java
@@ -46,7 +46,9 @@ public class MainActivity extends Activity {
         player = new PlayerBuilder()
                 .withWidevineModularStreamingDrm(drmHandler)
                 .withDowngradedSecureDecoder()
-                .build(this, "Android/Linux");
+                .withUserAgent("Android/Linux")
+                .allowCrossProtocolRedirects()
+                .build(this);
 
         demoPresenter = new DemoPresenter(controllerView, player, player.getListeners(), playerView);
         dialogCreator = new DialogCreator(this, player);

--- a/demo/src/main/java/com/novoda/demo/MainActivity.java
+++ b/demo/src/main/java/com/novoda/demo/MainActivity.java
@@ -46,7 +46,7 @@ public class MainActivity extends Activity {
         player = new PlayerBuilder()
                 .withWidevineModularStreamingDrm(drmHandler)
                 .withDowngradedSecureDecoder()
-                .build(this);
+                .build(this, "Android/Linux");
 
         demoPresenter = new DemoPresenter(controllerView, player, player.getListeners(), playerView);
         dialogCreator = new DialogCreator(this, player);


### PR DESCRIPTION
## Problem

When there is a redirect between `HTTP` and `HTTPS` the request fails

## Solution

- Enable redirects to cross protocols
- Update project dependencies, ExoPlayer to v2.9.6 https://github.com/google/ExoPlayer/blob/release-v2/RELEASENOTES.md#296
- Let the clients pass their own `user-agent` as currently, it had a dummy hardcoded value

### Test(s) added 

No tests added
Tested video playback through the demo application

### Screenshots

No UI changes

### Paired with 

Nobody
