### PR TITLE
NO-ADS/Add advert listener

### DIFF
--- a/core/src/main/java/com/novoda/noplayer/Listeners.java
+++ b/core/src/main/java/com/novoda/noplayer/Listeners.java
@@ -144,4 +144,18 @@ public interface Listeners {
      * @param droppedVideoFramesListener to remove.
      */
     void removeDroppedVideoFrames(NoPlayer.DroppedVideoFramesListener droppedVideoFramesListener);
+
+    /**
+     * Add a given {@link com.novoda.noplayer.NoPlayer.AdvertListener} to be notified about advert events.
+     *
+     * @param advertListener to notify.
+     */
+    void addAdvertListener(NoPlayer.AdvertListener advertListener);
+
+    /**
+     * Remove a given {@link com.novoda.noplayer.NoPlayer.AdvertListener}.
+     *
+     * @param advertListener to remove.
+     */
+    void removeAdvertListener(NoPlayer.AdvertListener advertListener);
 }

--- a/core/src/main/java/com/novoda/noplayer/NoPlayer.java
+++ b/core/src/main/java/com/novoda/noplayer/NoPlayer.java
@@ -273,6 +273,11 @@ public interface NoPlayer extends PlayerState {
         void onVideoSizeChanged(int width, int height, int unappliedRotationDegrees, float pixelWidthHeightRatio);
     }
 
+    interface AdvertListener {
+
+        void onAdvertEvent(String event); // TODO either pass different data in one method or have separate methods per event
+    }
+
     /**
      * A listener for debugging information.
      */

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
@@ -141,7 +141,8 @@ class ExoPlayerFacade {
                 options,
                 uri,
                 forwarder.mediaSourceEventListener(),
-                bandwidthMeter
+                bandwidthMeter,
+                adsLoader
         );
         attachToSurface(playerSurfaceHolder);
         exoPlayer.prepare(mediaSource, RESET_POSITION, DO_NOT_RESET_STATE);

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerExoPlayerCreator.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerExoPlayerCreator.java
@@ -85,7 +85,6 @@ public class NoPlayerExoPlayerCreator {
                     userAgent,
                     handler,
                     dataSourceFactory,
-                    adsLoader,
                     allowCrossProtocolRedirects
             );
 

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/mediasource/MediaSourceFactory.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/mediasource/MediaSourceFactory.java
@@ -27,27 +27,25 @@ public class MediaSourceFactory {
     private final Handler handler;
     private final Optional<DataSource.Factory> dataSourceFactory;
     private final String userAgent;
-    private final Optional<AdsLoader> advertsLoader;
     private final boolean allowCrossProtocolRedirects;
 
     public MediaSourceFactory(Context context,
                               String userAgent,
                               Handler handler,
                               Optional<DataSource.Factory> dataSourceFactory,
-                              Optional<AdsLoader> advertsLoader,
                               boolean allowCrossProtocolRedirects) {
         this.context = context;
         this.handler = handler;
         this.dataSourceFactory = dataSourceFactory;
         this.userAgent = userAgent;
-        this.advertsLoader = advertsLoader;
         this.allowCrossProtocolRedirects = allowCrossProtocolRedirects;
     }
 
     public MediaSource create(Options options,
                               Uri uri,
                               MediaSourceEventListener mediaSourceEventListener,
-                              DefaultBandwidthMeter bandwidthMeter) {
+                              DefaultBandwidthMeter bandwidthMeter,
+                              Optional<AdsLoader> advertsLoader) {
         DefaultDataSourceFactory defaultDataSourceFactory = createDataSourceFactory(bandwidthMeter);
 
         MediaSource contentMediaSource = getMediaSourceFor(options, uri, defaultDataSourceFactory);

--- a/core/src/main/java/com/novoda/noplayer/internal/listeners/AdvertListeners.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/listeners/AdvertListeners.java
@@ -1,0 +1,31 @@
+package com.novoda.noplayer.internal.listeners;
+
+import com.novoda.noplayer.NoPlayer;
+
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
+
+class AdvertListeners implements NoPlayer.AdvertListener {
+
+    private final Set<NoPlayer.AdvertListener> listeners = new CopyOnWriteArraySet<>();
+
+    public void add(NoPlayer.AdvertListener listener) {
+        listeners.add(listener);
+    }
+
+    public void remove(NoPlayer.AdvertListener listener) {
+        listeners.remove(listener);
+    }
+
+    public void clear() {
+        listeners.clear();
+    }
+
+    @Override
+    public void onAdvertEvent(String event) {
+        for (NoPlayer.AdvertListener listener : listeners) {
+            listener.onAdvertEvent(event);
+        }
+
+    }
+}

--- a/core/src/main/java/com/novoda/noplayer/internal/listeners/PlayerListenersHolder.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/listeners/PlayerListenersHolder.java
@@ -15,6 +15,7 @@ public class PlayerListenersHolder implements Listeners {
     private final VideoSizeChangedListeners videoSizeChangedListeners;
     private final BitrateChangedListeners bitrateChangedListeners;
     private final DroppedFramesListeners droppedFramesListeners;
+    private final AdvertListeners advertListeners;
 
     private final HeartbeatCallbacks heartbeatCallbacks;
 
@@ -29,6 +30,7 @@ public class PlayerListenersHolder implements Listeners {
         bitrateChangedListeners = new BitrateChangedListeners();
         heartbeatCallbacks = new HeartbeatCallbacks();
         droppedFramesListeners = new DroppedFramesListeners();
+        advertListeners = new AdvertListeners();
     }
 
     @Override
@@ -131,6 +133,16 @@ public class PlayerListenersHolder implements Listeners {
         droppedFramesListeners.remove(droppedVideoFramesListener);
     }
 
+    @Override
+    public void addAdvertListener(NoPlayer.AdvertListener advertListener) {
+        advertListeners.add(advertListener);
+    }
+
+    @Override
+    public void removeAdvertListener(NoPlayer.AdvertListener advertListener) {
+        advertListeners.remove(advertListener);
+    }
+
     public NoPlayer.ErrorListener getErrorListeners() {
         return errorListeners;
     }
@@ -171,6 +183,10 @@ public class PlayerListenersHolder implements Listeners {
         return droppedFramesListeners;
     }
 
+    public NoPlayer.AdvertListener getAdvertListeners() {
+        return advertListeners;
+    }
+
     public void resetState() {
         preparedListeners.resetPreparedState();
         completionListeners.resetCompletedState();
@@ -187,5 +203,6 @@ public class PlayerListenersHolder implements Listeners {
         bitrateChangedListeners.clear();
         heartbeatCallbacks.clear();
         droppedFramesListeners.clear();
+        advertListeners.clear();
     }
 }

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacadeTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacadeTest.java
@@ -579,7 +579,8 @@ public class ExoPlayerFacadeTest {
                             OPTIONS,
                             uri,
                             mediaSourceEventListener,
-                            defaultBandwidthMeter
+                            defaultBandwidthMeter,
+                            optionalAdsLoader
                     )
             ).willReturn(mediaSource);
 


### PR DESCRIPTION
## Problem

We want to allow clients to be notified about advert events

## Solution

This just adds a listener interface and the necessary wiring. It's not used anywhere yet and even the interface is not fully defined yet, both those things will be done in separate PRs.

I also did an unrelated change that moved the `AdsLoader` dependency from the constructor of the `MediaSourceFactory` to its `create` method. This will be useful later on too.

### Test(s) added 

no tests, it's not really doing anything yet

### Screenshots

no UI changes, yet

### Paired with 

nobody
