### PR TITLE
Bind AdvertsListener directly to the AdsLoader

### DIFF
--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
@@ -36,7 +36,7 @@ class ExoPlayerFacade {
     private final CompositeTrackSelectorCreator trackSelectorCreator;
     private final ExoPlayerCreator exoPlayerCreator;
     private final RendererTypeRequesterCreator rendererTypeRequesterCreator;
-    private final Optional<AdsLoader> adsLoader;
+    private final Optional<NoPlayerAdsLoader> adsLoader;
 
     @Nullable
     private SimpleExoPlayer exoPlayer;
@@ -53,7 +53,7 @@ class ExoPlayerFacade {
                     CompositeTrackSelectorCreator trackSelectorCreator,
                     ExoPlayerCreator exoPlayerCreator,
                     RendererTypeRequesterCreator rendererTypeRequesterCreator,
-                    Optional<AdsLoader> adsLoader) {
+                    Optional<NoPlayerAdsLoader> adsLoader) {
         this.bandwidthMeterCreator = bandwidthMeterCreator;
         this.androidDeviceVersion = androidDeviceVersion;
         this.mediaSourceFactory = mediaSourceFactory;
@@ -136,6 +136,10 @@ class ExoPlayerFacade {
         exoPlayer.addVideoListener(forwarder.videoListener());
 
         setMovieAudioAttributes(exoPlayer);
+
+        if (adsLoader.isPresent()) {
+            adsLoader.get().bind(forwarder.advertListener());
+        }
 
         MediaSource mediaSource = mediaSourceFactory.create(
                 options,

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
@@ -9,7 +9,6 @@ import com.google.android.exoplayer2.SimpleExoPlayer;
 import com.google.android.exoplayer2.audio.AudioAttributes;
 import com.google.android.exoplayer2.mediacodec.MediaCodecSelector;
 import com.google.android.exoplayer2.source.MediaSource;
-import com.google.android.exoplayer2.source.ads.AdsLoader;
 import com.google.android.exoplayer2.upstream.DefaultBandwidthMeter;
 import com.novoda.noplayer.Options;
 import com.novoda.noplayer.PlayerSurfaceHolder;

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImpl.java
@@ -70,6 +70,7 @@ class ExoPlayerTwoImpl implements NoPlayer {
         forwarder.bind(listenersHolder.getBitrateChangedListeners());
         forwarder.bind(listenersHolder.getInfoListeners());
         forwarder.bind(listenersHolder.getDroppedVideoFramesListeners());
+        forwarder.bind(listenersHolder.getAdvertListeners());
         listenersHolder.addPreparedListener(new PreparedListener() {
             @Override
             public void onPrepared(PlayerState playerState) {

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
@@ -11,6 +11,7 @@ import com.google.android.exoplayer2.source.ads.AdsLoader;
 import com.novoda.noplayer.AdvertBreak;
 import com.novoda.noplayer.AdvertsLoader;
 import com.novoda.noplayer.NoPlayer;
+import com.novoda.noplayer.internal.utils.Optional;
 
 import java.io.IOException;
 import java.util.List;
@@ -29,8 +30,8 @@ public class NoPlayerAdsLoader implements AdsLoader, Player.EventListener {
     private EventListener eventListener;
     @Nullable
     private AdvertsLoader.Cancellable loadingAds;
-    @Nullable
-    private NoPlayer.AdvertListener advertListener;
+
+    private Optional<NoPlayer.AdvertListener> advertListener = Optional.absent();
 
     private int adIndexInGroup = -1;
     private int adGroupIndex = -1;
@@ -40,7 +41,7 @@ public class NoPlayerAdsLoader implements AdsLoader, Player.EventListener {
         this.handler = new Handler(Looper.getMainLooper());
     }
 
-    public void bind(NoPlayer.AdvertListener advertListener) {
+    public void bind(Optional<NoPlayer.AdvertListener> advertListener) {
         this.advertListener = advertListener;
     }
 
@@ -153,8 +154,8 @@ public class NoPlayerAdsLoader implements AdsLoader, Player.EventListener {
     }
 
     private void notifyEventIfPossible(String event) {
-        if (advertListener != null) {
-            advertListener.onAdvertEvent(event);
+        if (advertListener.isPresent()) {
+            advertListener.get().onAdvertEvent(event);
         }
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
@@ -10,6 +10,7 @@ import com.google.android.exoplayer2.source.ads.AdPlaybackState;
 import com.google.android.exoplayer2.source.ads.AdsLoader;
 import com.novoda.noplayer.AdvertBreak;
 import com.novoda.noplayer.AdvertsLoader;
+import com.novoda.noplayer.NoPlayer;
 
 import java.io.IOException;
 import java.util.List;
@@ -28,6 +29,8 @@ public class NoPlayerAdsLoader implements AdsLoader, Player.EventListener {
     private EventListener eventListener;
     @Nullable
     private AdvertsLoader.Cancellable loadingAds;
+    @Nullable
+    private NoPlayer.AdvertListener advertListener;
 
     private int adIndexInGroup = -1;
     private int adGroupIndex = -1;
@@ -35,6 +38,10 @@ public class NoPlayerAdsLoader implements AdsLoader, Player.EventListener {
     NoPlayerAdsLoader(AdvertsLoader loader) {
         this.loader = loader;
         this.handler = new Handler(Looper.getMainLooper());
+    }
+
+    public void bind(NoPlayer.AdvertListener advertListener) {
+        this.advertListener = advertListener;
     }
 
     @Override
@@ -50,6 +57,7 @@ public class NoPlayerAdsLoader implements AdsLoader, Player.EventListener {
         }
 
         if (adPlaybackState == null) {
+            notifyEventIfPossible("start loading adverts");
             loadingAds = loader.load(advertsLoadedCallback);
         } else {
             updateAdPlaybackState();
@@ -64,6 +72,7 @@ public class NoPlayerAdsLoader implements AdsLoader, Player.EventListener {
             handler.post(new Runnable() {
                 @Override
                 public void run() {
+                    notifyEventIfPossible("adverts loaded");
                     updateAdPlaybackState();
                 }
             });
@@ -140,6 +149,12 @@ public class NoPlayerAdsLoader implements AdsLoader, Player.EventListener {
 
             adGroupIndex = player.getCurrentAdGroupIndex();
             adIndexInGroup = player.getCurrentAdIndexInAdGroup();
+        }
+    }
+
+    private void notifyEventIfPossible(String event) {
+        if (advertListener != null) {
+            advertListener.onAdvertEvent(event);
         }
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerExoPlayerCreator.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerExoPlayerCreator.java
@@ -4,7 +4,6 @@ import android.content.Context;
 import android.os.Handler;
 
 import com.google.android.exoplayer2.mediacodec.MediaCodecSelector;
-import com.google.android.exoplayer2.source.ads.AdsLoader;
 import com.google.android.exoplayer2.upstream.DataSource;
 import com.novoda.noplayer.AdvertsLoader;
 import com.novoda.noplayer.NoPlayer;
@@ -78,7 +77,7 @@ public class NoPlayerExoPlayerCreator {
                                 DrmSessionCreator drmSessionCreator,
                                 boolean downgradeSecureDecoder,
                                 boolean allowCrossProtocolRedirects) {
-            Optional<AdsLoader> adsLoader = createAdsLoaderFrom(advertsLoader);
+            Optional<NoPlayerAdsLoader> adsLoader = createAdsLoaderFrom(advertsLoader);
 
             MediaSourceFactory mediaSourceFactory = new MediaSourceFactory(
                     context,
@@ -124,10 +123,10 @@ public class NoPlayerExoPlayerCreator {
             );
         }
 
-        private Optional<AdsLoader> createAdsLoaderFrom(Optional<AdvertsLoader> advertsLoader) {
+        private Optional<NoPlayerAdsLoader> createAdsLoaderFrom(Optional<AdvertsLoader> advertsLoader) {
             if (advertsLoader.isPresent()) {
                 AdvertsLoader loader = advertsLoader.get();
-                AdsLoader adsLoader = new NoPlayerAdsLoader(loader);
+                NoPlayerAdsLoader adsLoader = new NoPlayerAdsLoader(loader);
                 return Optional.of(adsLoader);
             } else {
                 return Optional.absent();

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/ExoPlayerForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/ExoPlayerForwarder.java
@@ -14,6 +14,7 @@ public class ExoPlayerForwarder {
     private final NoPlayerAnalyticsListener analyticsListener;
     private final ExoPlayerVideoListener videoListener;
     private final ExoPlayerDrmSessionEventListener drmSessionEventListener;
+    private NoPlayer.AdvertListener advertListeners;
 
     public ExoPlayerForwarder() {
         exoPlayerEventListener = new EventListener();
@@ -41,6 +42,10 @@ public class ExoPlayerForwarder {
 
     public AnalyticsListener analyticsListener() {
         return analyticsListener;
+    }
+
+    public NoPlayer.AdvertListener advertListener() {
+        return advertListeners;
     }
 
     public void bind(NoPlayer.PreparedListener preparedListener, PlayerState playerState) {
@@ -77,5 +82,9 @@ public class ExoPlayerForwarder {
 
     public void bind(NoPlayer.DroppedVideoFramesListener droppedVideoFramesListeners) {
         analyticsListener.add(droppedVideoFramesListeners);
+    }
+
+    public void bind(NoPlayer.AdvertListener advertListeners) {
+        this.advertListeners = advertListeners;
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/ExoPlayerForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/ExoPlayerForwarder.java
@@ -6,6 +6,7 @@ import com.google.android.exoplayer2.source.MediaSourceEventListener;
 import com.google.android.exoplayer2.video.VideoListener;
 import com.novoda.noplayer.NoPlayer;
 import com.novoda.noplayer.PlayerState;
+import com.novoda.noplayer.internal.utils.Optional;
 
 public class ExoPlayerForwarder {
 
@@ -14,7 +15,7 @@ public class ExoPlayerForwarder {
     private final NoPlayerAnalyticsListener analyticsListener;
     private final ExoPlayerVideoListener videoListener;
     private final ExoPlayerDrmSessionEventListener drmSessionEventListener;
-    private NoPlayer.AdvertListener advertListeners;
+    private Optional<NoPlayer.AdvertListener> advertListeners = Optional.absent();
 
     public ExoPlayerForwarder() {
         exoPlayerEventListener = new EventListener();
@@ -44,7 +45,7 @@ public class ExoPlayerForwarder {
         return analyticsListener;
     }
 
-    public NoPlayer.AdvertListener advertListener() {
+    public Optional<NoPlayer.AdvertListener> advertListener() {
         return advertListeners;
     }
 
@@ -85,6 +86,6 @@ public class ExoPlayerForwarder {
     }
 
     public void bind(NoPlayer.AdvertListener advertListeners) {
-        this.advertListeners = advertListeners;
+        this.advertListeners = Optional.of(advertListeners);
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/mediasource/MediaSourceFactory.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/mediasource/MediaSourceFactory.java
@@ -8,7 +8,6 @@ import com.google.android.exoplayer2.extractor.DefaultExtractorsFactory;
 import com.google.android.exoplayer2.source.ExtractorMediaSource;
 import com.google.android.exoplayer2.source.MediaSource;
 import com.google.android.exoplayer2.source.MediaSourceEventListener;
-import com.google.android.exoplayer2.source.ads.AdsLoader;
 import com.google.android.exoplayer2.source.ads.AdsMediaSource;
 import com.google.android.exoplayer2.source.dash.DashMediaSource;
 import com.google.android.exoplayer2.source.dash.DefaultDashChunkSource;
@@ -19,6 +18,7 @@ import com.google.android.exoplayer2.upstream.DefaultDataSourceFactory;
 import com.google.android.exoplayer2.upstream.DefaultHttpDataSource;
 import com.google.android.exoplayer2.upstream.DefaultHttpDataSourceFactory;
 import com.novoda.noplayer.Options;
+import com.novoda.noplayer.internal.exoplayer.NoPlayerAdsLoader;
 import com.novoda.noplayer.internal.utils.Optional;
 
 public class MediaSourceFactory {
@@ -45,7 +45,7 @@ public class MediaSourceFactory {
                               Uri uri,
                               MediaSourceEventListener mediaSourceEventListener,
                               DefaultBandwidthMeter bandwidthMeter,
-                              Optional<AdsLoader> advertsLoader) {
+                              Optional<NoPlayerAdsLoader> advertsLoader) {
         DefaultDataSourceFactory defaultDataSourceFactory = createDataSourceFactory(bandwidthMeter);
 
         MediaSource contentMediaSource = getMediaSourceFor(options, uri, defaultDataSourceFactory);

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacadeTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacadeTest.java
@@ -107,9 +107,22 @@ public class ExoPlayerFacadeTest {
         }
 
         @Test
-        public void givenAdsLoader_whenLoadingVideo_thenBindsAdvertListener() {
+        public void givenAdsLoader_andListener_whenLoadingVideo_thenBindsAdvertListener() {
             given(optionalAdsLoader.isPresent()).willReturn(true);
             given(optionalAdsLoader.get()).willReturn(adsLoader);
+            given(optionalAdvertListener.isPresent()).willReturn(true);
+            given(optionalAdvertListener.get()).willReturn(advertListener);
+
+            facade.loadVideo(surfaceViewHolder, drmSessionCreator, uri, OPTIONS, exoPlayerForwarder, mediaCodecSelector);
+
+            verify(adsLoader).bind(optionalAdvertListener);
+        }
+
+        @Test
+        public void givenAdsLoader_butAbsentListener_whenLoadingVideo_thenBindsAdvertListener() {
+            given(optionalAdsLoader.isPresent()).willReturn(true);
+            given(optionalAdsLoader.get()).willReturn(adsLoader);
+            given(optionalAdvertListener.isPresent()).willReturn(false);
 
             facade.loadVideo(surfaceViewHolder, drmSessionCreator, uri, OPTIONS, exoPlayerForwarder, mediaCodecSelector);
 
@@ -137,7 +150,16 @@ public class ExoPlayerFacadeTest {
         }
 
         @Test
-        public void givenAdsLoader_whenLoadingVideo_thenDoesNotBindAdvertListener() {
+        public void givenAbsentAdsLoader_butPresentListener_whenLoadingVideo_thenDoesNotBindAdvertListener() {
+            given(optionalAdvertListener.isPresent()).willReturn(true);
+
+            facade.loadVideo(surfaceViewHolder, drmSessionCreator, uri, OPTIONS, exoPlayerForwarder, mediaCodecSelector);
+
+            verify(adsLoader, never()).bind(exoPlayerForwarder.advertListener());
+        }
+
+        @Test
+        public void givenAbsentAdsLoader_whenLoadingVideo_thenDoesNotBindAdvertListener() {
 
             facade.loadVideo(surfaceViewHolder, drmSessionCreator, uri, OPTIONS, exoPlayerForwarder, mediaCodecSelector);
 
@@ -557,6 +579,8 @@ public class ExoPlayerFacadeTest {
         @Mock
         MediaSourceEventListener mediaSourceEventListener;
         @Mock
+        Optional<NoPlayer.AdvertListener> optionalAdvertListener;
+        @Mock
         NoPlayer.AdvertListener advertListener;
         @Mock
         MediaCodecSelector mediaCodecSelector;
@@ -574,7 +598,7 @@ public class ExoPlayerFacadeTest {
             ExoPlayerCreator exoPlayerCreator = mock(ExoPlayerCreator.class);
             given(exoPlayerForwarder.drmSessionEventListener()).willReturn(drmSessionEventListener);
             given(exoPlayerForwarder.mediaSourceEventListener()).willReturn(mediaSourceEventListener);
-            given(exoPlayerForwarder.advertListener()).willReturn(advertListener);
+            given(exoPlayerForwarder.advertListener()).willReturn(optionalAdvertListener);
             given(bandwidthMeterCreator.create(anyLong())).willReturn(defaultBandwidthMeter);
             given(trackSelectorCreator.create(OPTIONS, defaultBandwidthMeter)).willReturn(trackSelector);
             given(exoPlayerCreator.create(drmSessionCreator, drmSessionEventListener, mediaCodecSelector, trackSelector.trackSelector())).willReturn(exoPlayer);

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacadeTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacadeTest.java
@@ -13,9 +13,9 @@ import com.google.android.exoplayer2.drm.DefaultDrmSessionEventListener;
 import com.google.android.exoplayer2.mediacodec.MediaCodecSelector;
 import com.google.android.exoplayer2.source.MediaSource;
 import com.google.android.exoplayer2.source.MediaSourceEventListener;
-import com.google.android.exoplayer2.source.ads.AdsLoader;
 import com.google.android.exoplayer2.upstream.DefaultBandwidthMeter;
 import com.novoda.noplayer.ContentType;
+import com.novoda.noplayer.NoPlayer;
 import com.novoda.noplayer.Options;
 import com.novoda.noplayer.OptionsBuilder;
 import com.novoda.noplayer.PlayerSurfaceHolder;
@@ -107,6 +107,16 @@ public class ExoPlayerFacadeTest {
         }
 
         @Test
+        public void givenAdsLoader_whenLoadingVideo_thenBindsAdvertListener() {
+            given(optionalAdsLoader.isPresent()).willReturn(true);
+            given(optionalAdsLoader.get()).willReturn(adsLoader);
+
+            facade.loadVideo(surfaceViewHolder, drmSessionCreator, uri, OPTIONS, exoPlayerForwarder, mediaCodecSelector);
+
+            verify(adsLoader).bind(exoPlayerForwarder.advertListener());
+        }
+
+        @Test
         public void givenAdsLoader_whenLoadingVideo_thenSetsPlayerOnAdLoader() {
             given(optionalAdsLoader.isPresent()).willReturn(true);
             given(optionalAdsLoader.get()).willReturn(adsLoader);
@@ -124,6 +134,14 @@ public class ExoPlayerFacadeTest {
             facade.release();
 
             verify(adsLoader).release();
+        }
+
+        @Test
+        public void givenAdsLoader_whenLoadingVideo_thenDoesNotBindAdvertListener() {
+
+            facade.loadVideo(surfaceViewHolder, drmSessionCreator, uri, OPTIONS, exoPlayerForwarder, mediaCodecSelector);
+
+            verify(adsLoader, never()).bind(exoPlayerForwarder.advertListener());
         }
 
         @Test
@@ -529,7 +547,7 @@ public class ExoPlayerFacadeTest {
         @Mock
         RendererTypeRequesterCreator rendererTypeRequesterCreator;
         @Mock
-        Optional<AdsLoader> optionalAdsLoader;
+        Optional<NoPlayerAdsLoader> optionalAdsLoader;
         @Mock
         NoPlayerAdsLoader adsLoader;
         @Mock
@@ -538,6 +556,8 @@ public class ExoPlayerFacadeTest {
         DefaultDrmSessionEventListener drmSessionEventListener;
         @Mock
         MediaSourceEventListener mediaSourceEventListener;
+        @Mock
+        NoPlayer.AdvertListener advertListener;
         @Mock
         MediaCodecSelector mediaCodecSelector;
         @Mock
@@ -554,6 +574,7 @@ public class ExoPlayerFacadeTest {
             ExoPlayerCreator exoPlayerCreator = mock(ExoPlayerCreator.class);
             given(exoPlayerForwarder.drmSessionEventListener()).willReturn(drmSessionEventListener);
             given(exoPlayerForwarder.mediaSourceEventListener()).willReturn(mediaSourceEventListener);
+            given(exoPlayerForwarder.advertListener()).willReturn(advertListener);
             given(bandwidthMeterCreator.create(anyLong())).willReturn(defaultBandwidthMeter);
             given(trackSelectorCreator.create(OPTIONS, defaultBandwidthMeter)).willReturn(trackSelector);
             given(exoPlayerCreator.create(drmSessionCreator, drmSessionEventListener, mediaCodecSelector, trackSelector.trackSelector())).willReturn(exoPlayer);


### PR DESCRIPTION
## Problem
Had a discussion with @mr-archano and we were both a little unhappy with how #206 the adverts loading was part of the squashed `ExoPlayerListener` class. 

## Solution
**This is an alternative feature branch where everything has not been collapsed.**

Instead the advert listener is bound to the `ExoPlayerForwarder` but then we grab this `AdvertListener` and bind it to the `AdvertsLoader`. The `AdvertsLoader` still implements the `AdsLoader` and `Player.EventListener` interfaces, we listen to what we want and forward when necessary to the `AdvertListener`. At the moment this is just the load of the advert.

The only issue is that we have to expose the `class` rather than the `interface` of the `AdvertsLoader` so that we can bind the `AdvertsListener` when it becomes available. 

### Paired with 
Nobody.
