### PR TITLE
NO-ADS/Advert Start End Complete

### DIFF
--- a/core/src/main/java/com/novoda/noplayer/Advert.java
+++ b/core/src/main/java/com/novoda/noplayer/Advert.java
@@ -4,12 +4,18 @@ import android.net.Uri;
 
 public class Advert {
 
+    private final AdvertId advertId;
     private final long durationInMillis;
     private final Uri uri;
 
-    public Advert(long durationInMillis, Uri uri) {
+    public Advert(AdvertId advertId, long durationInMillis, Uri uri) {
+        this.advertId = advertId;
         this.durationInMillis = durationInMillis;
         this.uri = uri;
+    }
+
+    public AdvertId advertId() {
+        return advertId;
     }
 
     public long durationInMillis() {

--- a/core/src/main/java/com/novoda/noplayer/Advert.java
+++ b/core/src/main/java/com/novoda/noplayer/Advert.java
@@ -40,12 +40,16 @@ public class Advert {
         if (durationInMillis != advert.durationInMillis) {
             return false;
         }
+        if (advertId != null ? !advertId.equals(advert.advertId) : advert.advertId != null) {
+            return false;
+        }
         return uri != null ? uri.equals(advert.uri) : advert.uri == null;
     }
 
     @Override
     public int hashCode() {
-        int result = (int) (durationInMillis ^ (durationInMillis >>> 32));
+        int result = advertId != null ? advertId.hashCode() : 0;
+        result = 31 * result + (int) (durationInMillis ^ (durationInMillis >>> 32));
         result = 31 * result + (uri != null ? uri.hashCode() : 0);
         return result;
     }
@@ -53,7 +57,8 @@ public class Advert {
     @Override
     public String toString() {
         return "Advert{"
-                + "durationInMillis=" + durationInMillis
+                + "advertId=" + advertId
+                + ", durationInMillis=" + durationInMillis
                 + ", uri=" + uri
                 + '}';
     }

--- a/core/src/main/java/com/novoda/noplayer/AdvertBreak.java
+++ b/core/src/main/java/com/novoda/noplayer/AdvertBreak.java
@@ -4,10 +4,12 @@ import java.util.List;
 
 public class AdvertBreak {
 
+    private final AdvertBreakId advertBreakId;
     private final long startTimeInMillis;
     private final List<Advert> adverts;
 
-    public AdvertBreak(long startTimeInMillis, List<Advert> adverts) {
+    public AdvertBreak(AdvertBreakId advertBreakId, long startTimeInMillis, List<Advert> adverts) {
+        this.advertBreakId = advertBreakId;
         this.startTimeInMillis = startTimeInMillis;
         this.adverts = adverts;
     }
@@ -34,12 +36,16 @@ public class AdvertBreak {
         if (startTimeInMillis != that.startTimeInMillis) {
             return false;
         }
+        if (advertBreakId != null ? !advertBreakId.equals(that.advertBreakId) : that.advertBreakId != null) {
+            return false;
+        }
         return adverts != null ? adverts.equals(that.adverts) : that.adverts == null;
     }
 
     @Override
     public int hashCode() {
-        int result = (int) (startTimeInMillis ^ (startTimeInMillis >>> 32));
+        int result = advertBreakId != null ? advertBreakId.hashCode() : 0;
+        result = 31 * result + (int) (startTimeInMillis ^ (startTimeInMillis >>> 32));
         result = 31 * result + (adverts != null ? adverts.hashCode() : 0);
         return result;
     }
@@ -47,7 +53,8 @@ public class AdvertBreak {
     @Override
     public String toString() {
         return "AdvertBreak{"
-                + "startTimeInMillis=" + startTimeInMillis
+                + "advertBreakId=" + advertBreakId
+                + ", startTimeInMillis=" + startTimeInMillis
                 + ", adverts=" + adverts
                 + '}';
     }

--- a/core/src/main/java/com/novoda/noplayer/AdvertBreak.java
+++ b/core/src/main/java/com/novoda/noplayer/AdvertBreak.java
@@ -14,6 +14,10 @@ public class AdvertBreak {
         this.adverts = adverts;
     }
 
+    public AdvertBreakId advertBreakId() {
+        return advertBreakId;
+    }
+
     public long startTimeInMillis() {
         return startTimeInMillis;
     }

--- a/core/src/main/java/com/novoda/noplayer/AdvertBreakId.java
+++ b/core/src/main/java/com/novoda/noplayer/AdvertBreakId.java
@@ -1,0 +1,40 @@
+package com.novoda.noplayer;
+
+public class AdvertBreakId {
+
+    private final String id;
+
+    public AdvertBreakId(String id) {
+        this.id = id;
+    }
+
+    public String id() {
+        return id;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        AdvertBreakId that = (AdvertBreakId) o;
+
+        return id != null ? id.equals(that.id) : that.id == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return id != null ? id.hashCode() : 0;
+    }
+
+    @Override
+    public String toString() {
+        return "AdvertBreakId{"
+                + "id='" + id + '\''
+                + '}';
+    }
+}

--- a/core/src/main/java/com/novoda/noplayer/AdvertId.java
+++ b/core/src/main/java/com/novoda/noplayer/AdvertId.java
@@ -1,0 +1,40 @@
+package com.novoda.noplayer;
+
+public class AdvertId {
+
+    private final String id;
+
+    public AdvertId(String id) {
+        this.id = id;
+    }
+
+    public String id() {
+        return id;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        AdvertId advertId = (AdvertId) o;
+
+        return id != null ? id.equals(advertId.id) : advertId.id == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return id != null ? id.hashCode() : 0;
+    }
+
+    @Override
+    public String toString() {
+        return "AdvertId{"
+                + "id='" + id + '\''
+                + '}';
+    }
+}

--- a/core/src/main/java/com/novoda/noplayer/NoPlayer.java
+++ b/core/src/main/java/com/novoda/noplayer/NoPlayer.java
@@ -275,15 +275,13 @@ public interface NoPlayer extends PlayerState {
 
     interface AdvertListener {
 
-        void onAdvertBreakStart(AdvertBreak advertBreak);
+        void onAdvertBreakStart(AdvertBreakId advertBreakId);
 
-        void onAdvertBreakEnd(AdvertBreak advertBreak);
+        void onAdvertBreakEnd(AdvertBreakId advertBreakId);
 
         void onAdvertStart(AdvertId advertId);
 
         void onAdvertEnd(AdvertId advertId);
-
-        void onAdvertEvent(String event); // TODO either pass different data in one method or have separate methods per event
     }
 
     /**

--- a/core/src/main/java/com/novoda/noplayer/NoPlayer.java
+++ b/core/src/main/java/com/novoda/noplayer/NoPlayer.java
@@ -14,6 +14,8 @@ import com.novoda.noplayer.model.Timeout;
 import java.util.List;
 import java.util.Map;
 
+// There are a lot of features for playing and monitoring video.
+@SuppressWarnings("PMD.ExcessivePublicCount")
 public interface NoPlayer extends PlayerState {
 
     /**

--- a/core/src/main/java/com/novoda/noplayer/NoPlayer.java
+++ b/core/src/main/java/com/novoda/noplayer/NoPlayer.java
@@ -275,6 +275,14 @@ public interface NoPlayer extends PlayerState {
 
     interface AdvertListener {
 
+        void onAdvertBreakStart(AdvertBreak advertBreak);
+
+        void onAdvertBreakEnd(AdvertBreak advertBreak);
+
+        void onAdvertStart(AdvertId advertId);
+
+        void onAdvertEnd(AdvertId advertId);
+
         void onAdvertEvent(String event); // TODO either pass different data in one method or have separate methods per event
     }
 

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/AdvertPlaybackState.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/AdvertPlaybackState.java
@@ -8,12 +8,12 @@ import com.novoda.noplayer.AdvertBreak;
 import java.util.Collections;
 import java.util.List;
 
-public final class AdvertPlaybackState {
+final class AdvertPlaybackState {
 
-    private AdvertPlaybackState() {
-    }
+    private final AdPlaybackState adPlaybackState;
+    private final List<AdvertBreak> advertBreaks;
 
-    public static AdPlaybackState from(List<AdvertBreak> advertBreaks) {
+    static AdvertPlaybackState from(List<AdvertBreak> advertBreaks) {
         Collections.sort(advertBreaks, new AdvertBreakStartTimeComparator());
 
         long[] advertOffsets = advertBreakOffset(advertBreaks);
@@ -40,7 +40,21 @@ public final class AdvertPlaybackState {
             advertBreaksWithAdvertDurations[i] = advertDurations;
         }
 
-        return adPlaybackState.withAdDurationsUs(advertBreaksWithAdvertDurations);
+        adPlaybackState = adPlaybackState.withAdDurationsUs(advertBreaksWithAdvertDurations);
+        return new AdvertPlaybackState(adPlaybackState, advertBreaks);
+    }
+
+    private AdvertPlaybackState(AdPlaybackState adPlaybackState, List<AdvertBreak> advertBreaks) {
+        this.adPlaybackState = adPlaybackState;
+        this.advertBreaks = advertBreaks;
+    }
+
+    AdPlaybackState adPlaybackState() {
+        return adPlaybackState;
+    }
+
+    List<AdvertBreak> advertBreaks() {
+        return advertBreaks;
     }
 
     private static long[] advertBreakOffset(List<AdvertBreak> advertBreaks) {

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
@@ -2,6 +2,7 @@ package com.novoda.noplayer.internal.exoplayer;
 
 import android.net.Uri;
 import android.support.annotation.Nullable;
+import android.util.Log;
 
 import com.google.android.exoplayer2.C;
 import com.google.android.exoplayer2.Player;
@@ -98,6 +99,7 @@ class ExoPlayerFacade {
         Timeline.Period period = adTimeline.getPeriod(0, new Timeline.Period());
 
         int currentAdGroupIndex = exoPlayer.getCurrentAdGroupIndex();
+        Log.e("TAG", "currentAdGroupIndex: " + currentAdGroupIndex);
         int advertCount = period.getAdCountInAdGroup(currentAdGroupIndex);
 
         long advertBreakDurationInMicros = combinedAdvertDurationInGroup(period, advertCount);
@@ -121,6 +123,7 @@ class ExoPlayerFacade {
 
     private long combinedAdvertDurationInGroup(Timeline.Period period, int numberOfAdvertsToInclude) {
         int adGroupIndex = exoPlayer.getCurrentAdGroupIndex();
+        Log.e("TAG", "adGroupIndex: " + adGroupIndex);
         long advertBreakDurationInMicros = 0;
         NoPlayerAdsLoader noPlayerAdsLoader = adsLoader.get();
 

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
@@ -2,7 +2,6 @@ package com.novoda.noplayer.internal.exoplayer;
 
 import android.net.Uri;
 import android.support.annotation.Nullable;
-import android.util.Log;
 
 import com.google.android.exoplayer2.C;
 import com.google.android.exoplayer2.Player;
@@ -99,7 +98,6 @@ class ExoPlayerFacade {
         Timeline.Period period = adTimeline.getPeriod(0, new Timeline.Period());
 
         int currentAdGroupIndex = exoPlayer.getCurrentAdGroupIndex();
-        Log.e("TAG", "currentAdGroupIndex: " + currentAdGroupIndex);
         int advertCount = period.getAdCountInAdGroup(currentAdGroupIndex);
 
         long advertBreakDurationInMicros = combinedAdvertDurationInGroup(period, advertCount);
@@ -123,7 +121,6 @@ class ExoPlayerFacade {
 
     private long combinedAdvertDurationInGroup(Timeline.Period period, int numberOfAdvertsToInclude) {
         int adGroupIndex = exoPlayer.getCurrentAdGroupIndex();
-        Log.e("TAG", "adGroupIndex: " + adGroupIndex);
         long advertBreakDurationInMicros = 0;
         NoPlayerAdsLoader noPlayerAdsLoader = adsLoader.get();
 

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
@@ -161,10 +161,8 @@ public class NoPlayerAdsLoader implements AdsLoader, Player.EventListener {
             adGroupIndex = player.getCurrentAdGroupIndex();
             adIndexInGroup = player.getCurrentAdIndexInAdGroup();
 
-            if (reason == Player.TIMELINE_CHANGE_REASON_PREPARED) {
-                if (adGroupIndex != -1 && adIndexInGroup != -1) {
-                    notifyAdvertStart(advertBreaks.get(adGroupIndex));
-                }
+            if (reason == Player.TIMELINE_CHANGE_REASON_PREPARED && adGroupIndex != -1 && adIndexInGroup != -1) {
+                notifyAdvertStart(advertBreaks.get(adGroupIndex));
             }
         }
     }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
@@ -3,7 +3,6 @@ package com.novoda.noplayer.internal.exoplayer;
 import android.os.Handler;
 import android.os.Looper;
 import android.support.annotation.Nullable;
-import android.util.Log;
 
 import com.google.android.exoplayer2.C;
 import com.google.android.exoplayer2.Player;
@@ -115,10 +114,7 @@ public class NoPlayerAdsLoader implements AdsLoader, Player.EventListener {
 
         AdvertBreak advertBreak = advertBreaks.get(advertGroupIndex);
         if (advertIndexInAdvertGroup >= advertBreak.adverts().size()) {
-            throw new IllegalStateException("Cached advert break data contains less adverts than current index. Cached adverts: "
-                                                    + advertBreak.adverts().size()
-                                                    + " index: " + advertIndexInAdvertGroup
-            );
+            throw new IllegalStateException("Cached advert break data contains less adverts than current index.");
         }
 
         return C.msToUs(advertBreak.adverts().get(advertIndexInAdvertGroup).durationInMillis());
@@ -161,7 +157,6 @@ public class NoPlayerAdsLoader implements AdsLoader, Player.EventListener {
 
     @Override
     public void onTimelineChanged(Timeline timeline, @Nullable Object manifest, int reason) {
-        Log.e(TAG, "onTimelineChanged: " + reason);
         if (reason == Player.TIMELINE_CHANGE_REASON_RESET) {
             // The player is being reset and this source will be released.
             return;
@@ -180,7 +175,6 @@ public class NoPlayerAdsLoader implements AdsLoader, Player.EventListener {
 
     @Override
     public void onPositionDiscontinuity(int reason) {
-        Log.e(TAG, "onPositionDiscontinuity: " + reason);
         if (reason == Player.DISCONTINUITY_REASON_AD_INSERTION && player != null && adPlaybackState != null) {
             if (adGroupIndex != -1 && adIndexInGroup != -1) {
                 Advert advert = advertBreaks.get(adGroupIndex).adverts().get(adIndexInGroup);

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
@@ -10,6 +10,7 @@ import com.google.android.exoplayer2.Player;
 import com.google.android.exoplayer2.Timeline;
 import com.google.android.exoplayer2.source.ads.AdPlaybackState;
 import com.google.android.exoplayer2.source.ads.AdsLoader;
+import com.novoda.noplayer.Advert;
 import com.novoda.noplayer.AdvertBreak;
 import com.novoda.noplayer.AdvertsLoader;
 import com.novoda.noplayer.NoPlayer;
@@ -159,7 +160,10 @@ public class NoPlayerAdsLoader implements AdsLoader, Player.EventListener {
             adIndexInGroup = player.getCurrentAdIndexInAdGroup();
 
             if (reason == Player.TIMELINE_CHANGE_REASON_PREPARED && adGroupIndex != -1 && adIndexInGroup != -1) {
-                notifyEventIfPossible("starting advert: " + adGroupIndex + ":" + adIndexInGroup);
+                Advert advert = advertBreaks.get(adGroupIndex).adverts().get(adIndexInGroup);
+                if (advertListener.isPresent()) {
+                    advertListener.get().onAdvertStart(advert.advertId());
+                }
             }
         }
     }
@@ -169,7 +173,11 @@ public class NoPlayerAdsLoader implements AdsLoader, Player.EventListener {
         Log.e(TAG, "onPositionDiscontinuity: " + reason);
         if (reason == Player.DISCONTINUITY_REASON_AD_INSERTION && player != null && adPlaybackState != null) {
             if (adGroupIndex != -1 && adIndexInGroup != -1) {
-                notifyEventIfPossible("played advert: " + adGroupIndex + ":" + adIndexInGroup);
+                Advert advert = advertBreaks.get(adGroupIndex).adverts().get(adIndexInGroup);
+                if (advertListener.isPresent()) {
+                    advertListener.get().onAdvertEnd(advert.advertId());
+                }
+
                 adPlaybackState = adPlaybackState.withPlayedAd(adGroupIndex, adIndexInGroup);
                 updateAdPlaybackState();
             }
@@ -177,7 +185,10 @@ public class NoPlayerAdsLoader implements AdsLoader, Player.EventListener {
             adGroupIndex = player.getCurrentAdGroupIndex();
             adIndexInGroup = player.getCurrentAdIndexInAdGroup();
             if (adGroupIndex != -1 && adIndexInGroup != -1) {
-                notifyEventIfPossible("starting advert: " + adGroupIndex + ":" + adIndexInGroup);
+                Advert advert = advertBreaks.get(adGroupIndex).adverts().get(adIndexInGroup);
+                if (advertListener.isPresent()) {
+                    advertListener.get().onAdvertStart(advert.advertId());
+                }
             }
         }
     }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
@@ -161,7 +161,7 @@ public class NoPlayerAdsLoader implements AdsLoader, Player.EventListener {
             adGroupIndex = player.getCurrentAdGroupIndex();
             adIndexInGroup = player.getCurrentAdIndexInAdGroup();
 
-            if (reason == Player.TIMELINE_CHANGE_REASON_PREPARED && adGroupIndex != -1 && adIndexInGroup != -1) {
+            if (reason == Player.TIMELINE_CHANGE_REASON_PREPARED && isPlayingAdvert()) {
                 notifyAdvertStart(advertBreaks.get(adGroupIndex));
             }
         }
@@ -170,7 +170,7 @@ public class NoPlayerAdsLoader implements AdsLoader, Player.EventListener {
     @Override
     public void onPositionDiscontinuity(int reason) {
         if (reason == Player.DISCONTINUITY_REASON_AD_INSERTION && player != null && adPlaybackState != null) {
-            if (adGroupIndex != -1 && adIndexInGroup != -1) {
+            if (isPlayingAdvert()) {
                 notifyAdvertEnd(advertBreaks.get(adGroupIndex));
                 adPlaybackState = adPlaybackState.withPlayedAd(adGroupIndex, adIndexInGroup);
                 updateAdPlaybackState();
@@ -179,10 +179,14 @@ public class NoPlayerAdsLoader implements AdsLoader, Player.EventListener {
             adGroupIndex = player.getCurrentAdGroupIndex();
             adIndexInGroup = player.getCurrentAdIndexInAdGroup();
 
-            if (adGroupIndex != -1 && adIndexInGroup != -1) {
+            if (isPlayingAdvert()) {
                 notifyAdvertStart(advertBreaks.get(adGroupIndex));
             }
         }
+    }
+
+    private boolean isPlayingAdvert() {
+        return adGroupIndex != -1 && adIndexInGroup != -1;
     }
 
     private void notifyAdvertEnd(AdvertBreak advertBreak) {

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
@@ -80,9 +80,12 @@ public class NoPlayerAdsLoader implements AdsLoader, Player.EventListener {
         @Override
         public void onAdvertsLoaded(List<AdvertBreak> breaks) {
             loadingAds = null;
+            AdvertPlaybackState advertPlaybackState = AdvertPlaybackState.from(breaks);
             advertBreaks.clear();
-            advertBreaks.addAll(breaks);
-            adPlaybackState = AdvertPlaybackState.from(breaks);
+            advertBreaks.addAll(advertPlaybackState.advertBreaks());
+
+            adPlaybackState = advertPlaybackState.adPlaybackState();
+
             handler.post(new Runnable() {
                 @Override
                 public void run() {
@@ -112,7 +115,10 @@ public class NoPlayerAdsLoader implements AdsLoader, Player.EventListener {
 
         AdvertBreak advertBreak = advertBreaks.get(advertGroupIndex);
         if (advertIndexInAdvertGroup >= advertBreak.adverts().size()) {
-            throw new IllegalStateException("Cached advert break data contains less adverts than current index.");
+            throw new IllegalStateException("Cached advert break data contains less adverts than current index. Cached adverts: "
+                                                    + advertBreak.adverts().size()
+                                                    + " index: " + advertIndexInAdvertGroup
+            );
         }
 
         return C.msToUs(advertBreak.adverts().get(advertIndexInAdvertGroup).durationInMillis());

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
@@ -190,7 +190,12 @@ public class NoPlayerAdsLoader implements AdsLoader, Player.EventListener {
 
     private void notifyAdvertStart() {
         if (adGroupIndex != -1 && adIndexInGroup != -1) {
-            Advert advert = advertBreaks.get(adGroupIndex).adverts().get(adIndexInGroup);
+            AdvertBreak advertBreak = advertBreaks.get(adGroupIndex);
+            if (adIndexInGroup == 0) {
+                advertListener.onAdvertBreakStart(advertBreak.advertBreakId());
+            }
+
+            Advert advert = advertBreak.adverts().get(adIndexInGroup);
             advertListener.onAdvertStart(advert.advertId());
         }
     }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
@@ -24,7 +24,6 @@ import java.util.concurrent.TimeUnit;
 
 public class NoPlayerAdsLoader implements AdsLoader, Player.EventListener {
 
-    private static final String TAG = "ADS";
     private final AdvertsLoader loader;
     private final Handler handler;
     private final List<AdvertBreak> advertBreaks;

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
@@ -175,9 +175,7 @@ public class NoPlayerAdsLoader implements AdsLoader, Player.EventListener {
     public void onPositionDiscontinuity(int reason) {
         if (reason == Player.DISCONTINUITY_REASON_AD_INSERTION && player != null && adPlaybackState != null) {
             if (adGroupIndex != -1 && adIndexInGroup != -1) {
-                Advert advert = advertBreaks.get(adGroupIndex).adverts().get(adIndexInGroup);
-                advertListener.onAdvertEnd(advert.advertId());
-
+                notifyAdvertEnd();
                 adPlaybackState = adPlaybackState.withPlayedAd(adGroupIndex, adIndexInGroup);
                 updateAdPlaybackState();
             }
@@ -185,6 +183,16 @@ public class NoPlayerAdsLoader implements AdsLoader, Player.EventListener {
             adGroupIndex = player.getCurrentAdGroupIndex();
             adIndexInGroup = player.getCurrentAdIndexInAdGroup();
             notifyAdvertStart();
+        }
+    }
+
+    private void notifyAdvertEnd() {
+        AdvertBreak advertBreak = advertBreaks.get(adGroupIndex);
+        List<Advert> adverts = advertBreak.adverts();
+        advertListener.onAdvertEnd(adverts.get(adIndexInGroup).advertId());
+
+        if (adIndexInGroup == adverts.size() - 1) {
+            advertListener.onAdvertBreakEnd(advertBreak.advertBreakId());
         }
     }
 

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
@@ -11,6 +11,7 @@ import com.google.android.exoplayer2.source.ads.AdPlaybackState;
 import com.google.android.exoplayer2.source.ads.AdsLoader;
 import com.novoda.noplayer.Advert;
 import com.novoda.noplayer.AdvertBreak;
+import com.novoda.noplayer.AdvertBreakId;
 import com.novoda.noplayer.AdvertId;
 import com.novoda.noplayer.AdvertsLoader;
 import com.novoda.noplayer.NoPlayer;
@@ -68,7 +69,6 @@ public class NoPlayerAdsLoader implements AdsLoader, Player.EventListener {
         }
 
         if (adPlaybackState == null) {
-            advertListener.onAdvertEvent("start loading adverts");
             loadingAds = loader.load(advertsLoadedCallback);
         } else {
             updateAdPlaybackState();
@@ -88,7 +88,6 @@ public class NoPlayerAdsLoader implements AdsLoader, Player.EventListener {
             handler.post(new Runnable() {
                 @Override
                 public void run() {
-                    advertListener.onAdvertEvent("adverts loaded");
                     updateAdPlaybackState();
                 }
             });
@@ -197,12 +196,12 @@ public class NoPlayerAdsLoader implements AdsLoader, Player.EventListener {
         INSTANCE;
 
         @Override
-        public void onAdvertBreakStart(AdvertBreak advertBreak) {
+        public void onAdvertBreakStart(AdvertBreakId advertBreakId) {
             // no-op
         }
 
         @Override
-        public void onAdvertBreakEnd(AdvertBreak advertBreak) {
+        public void onAdvertBreakEnd(AdvertBreakId advertBreakId) {
             // no-op
         }
 
@@ -213,11 +212,6 @@ public class NoPlayerAdsLoader implements AdsLoader, Player.EventListener {
 
         @Override
         public void onAdvertEnd(AdvertId advertId) {
-            // no-op
-        }
-
-        @Override
-        public void onAdvertEvent(String event) {
             // no-op
         }
     }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
@@ -165,9 +165,8 @@ public class NoPlayerAdsLoader implements AdsLoader, Player.EventListener {
             adGroupIndex = player.getCurrentAdGroupIndex();
             adIndexInGroup = player.getCurrentAdIndexInAdGroup();
 
-            if (reason == Player.TIMELINE_CHANGE_REASON_PREPARED && adGroupIndex != -1 && adIndexInGroup != -1) {
-                Advert advert = advertBreaks.get(adGroupIndex).adverts().get(adIndexInGroup);
-                advertListener.onAdvertStart(advert.advertId());
+            if (reason == Player.TIMELINE_CHANGE_REASON_PREPARED) {
+                notifyAdvertStart();
             }
         }
     }
@@ -185,10 +184,14 @@ public class NoPlayerAdsLoader implements AdsLoader, Player.EventListener {
 
             adGroupIndex = player.getCurrentAdGroupIndex();
             adIndexInGroup = player.getCurrentAdIndexInAdGroup();
-            if (adGroupIndex != -1 && adIndexInGroup != -1) {
-                Advert advert = advertBreaks.get(adGroupIndex).adverts().get(adIndexInGroup);
-                advertListener.onAdvertStart(advert.advertId());
-            }
+            notifyAdvertStart();
+        }
+    }
+
+    private void notifyAdvertStart() {
+        if (adGroupIndex != -1 && adIndexInGroup != -1) {
+            Advert advert = advertBreaks.get(adGroupIndex).adverts().get(adIndexInGroup);
+            advertListener.onAdvertStart(advert.advertId());
         }
     }
 

--- a/core/src/main/java/com/novoda/noplayer/internal/listeners/AdvertListeners.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/listeners/AdvertListeners.java
@@ -1,6 +1,6 @@
 package com.novoda.noplayer.internal.listeners;
 
-import com.novoda.noplayer.AdvertBreak;
+import com.novoda.noplayer.AdvertBreakId;
 import com.novoda.noplayer.AdvertId;
 import com.novoda.noplayer.NoPlayer;
 
@@ -24,16 +24,16 @@ class AdvertListeners implements NoPlayer.AdvertListener {
     }
 
     @Override
-    public void onAdvertBreakStart(AdvertBreak advertBreak) {
+    public void onAdvertBreakStart(AdvertBreakId advertBreakId) {
         for (NoPlayer.AdvertListener listener : listeners) {
-            listener.onAdvertBreakStart(advertBreak);
+            listener.onAdvertBreakStart(advertBreakId);
         }
     }
 
     @Override
-    public void onAdvertBreakEnd(AdvertBreak advertBreak) {
+    public void onAdvertBreakEnd(AdvertBreakId advertBreakId) {
         for (NoPlayer.AdvertListener listener : listeners) {
-            listener.onAdvertBreakEnd(advertBreak);
+            listener.onAdvertBreakEnd(advertBreakId);
         }
     }
 
@@ -48,13 +48,6 @@ class AdvertListeners implements NoPlayer.AdvertListener {
     public void onAdvertEnd(AdvertId advertId) {
         for (NoPlayer.AdvertListener listener : listeners) {
             listener.onAdvertEnd(advertId);
-        }
-    }
-
-    @Override
-    public void onAdvertEvent(String event) {
-        for (NoPlayer.AdvertListener listener : listeners) {
-            listener.onAdvertEvent(event);
         }
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/listeners/AdvertListeners.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/listeners/AdvertListeners.java
@@ -1,5 +1,7 @@
 package com.novoda.noplayer.internal.listeners;
 
+import com.novoda.noplayer.AdvertBreak;
+import com.novoda.noplayer.AdvertId;
 import com.novoda.noplayer.NoPlayer;
 
 import java.util.Set;
@@ -22,10 +24,37 @@ class AdvertListeners implements NoPlayer.AdvertListener {
     }
 
     @Override
+    public void onAdvertBreakStart(AdvertBreak advertBreak) {
+        for (NoPlayer.AdvertListener listener : listeners) {
+            listener.onAdvertBreakStart(advertBreak);
+        }
+    }
+
+    @Override
+    public void onAdvertBreakEnd(AdvertBreak advertBreak) {
+        for (NoPlayer.AdvertListener listener : listeners) {
+            listener.onAdvertBreakEnd(advertBreak);
+        }
+    }
+
+    @Override
+    public void onAdvertStart(AdvertId advertId) {
+        for (NoPlayer.AdvertListener listener : listeners) {
+            listener.onAdvertStart(advertId);
+        }
+    }
+
+    @Override
+    public void onAdvertEnd(AdvertId advertId) {
+        for (NoPlayer.AdvertListener listener : listeners) {
+            listener.onAdvertEnd(advertId);
+        }
+    }
+
+    @Override
     public void onAdvertEvent(String event) {
         for (NoPlayer.AdvertListener listener : listeners) {
             listener.onAdvertEvent(event);
         }
-
     }
 }

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/AdvertBreakStartTimeComparatorTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/AdvertBreakStartTimeComparatorTest.java
@@ -2,6 +2,7 @@ package com.novoda.noplayer.internal.exoplayer;
 
 import com.novoda.noplayer.Advert;
 import com.novoda.noplayer.AdvertBreak;
+import com.novoda.noplayer.AdvertBreakId;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -13,16 +14,20 @@ import static org.fest.assertions.api.Assertions.assertThat;
 
 public class AdvertBreakStartTimeComparatorTest {
 
+    private static final AdvertBreakId FIRST_ADVERT_BREAK_ID = new AdvertBreakId("advert_break_one");
+    private static final AdvertBreakId SECOND_ADVERT_BREAK_ID = new AdvertBreakId("advert_break_two");
+    private static final AdvertBreakId THIRD_ADVERT_BREAK_ID = new AdvertBreakId("advert_break_three");
+
     private static final AdvertBreak FIRST_ADVERT_BREAK = new AdvertBreak(
-            10000, Collections.<Advert>emptyList()
+            FIRST_ADVERT_BREAK_ID, 10000, Collections.<Advert>emptyList()
     );
 
     private static final AdvertBreak SECOND_ADVERT_BREAK = new AdvertBreak(
-            20000, Collections.<Advert>emptyList()
+            SECOND_ADVERT_BREAK_ID, 20000, Collections.<Advert>emptyList()
     );
 
     private static final AdvertBreak THIRD_ADVERT_BREAK = new AdvertBreak(
-            20000, Collections.<Advert>emptyList()
+            THIRD_ADVERT_BREAK_ID, 30000, Collections.<Advert>emptyList()
     );
 
     @Test

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/AdvertPlaybackStateTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/AdvertPlaybackStateTest.java
@@ -5,6 +5,7 @@ import android.net.Uri;
 import com.google.android.exoplayer2.source.ads.AdPlaybackState;
 import com.novoda.noplayer.Advert;
 import com.novoda.noplayer.AdvertBreak;
+import com.novoda.noplayer.AdvertBreakId;
 import com.novoda.noplayer.AdvertId;
 
 import java.util.Arrays;
@@ -21,6 +22,10 @@ public class AdvertPlaybackStateTest {
     private static final int ONE_SECOND_IN_MICROS = 1000000;
     private static final int TWO_SECONDS_IN_MICROS = 2000000;
     private static final int THREE_SECONDS_IN_MICROS = 3000000;
+
+    private static final AdvertBreakId FIRST_ADVERT_BREAK_ID = new AdvertBreakId("advert_break_one");
+    private static final AdvertBreakId SECOND_ADVERT_BREAK_ID = new AdvertBreakId("advert_break_two");
+    private static final AdvertBreakId THIRD_ADVERT_BREAK_ID = new AdvertBreakId("advert_break_three");
 
     private static final AdvertId FIRST_ADVERT_ID = new AdvertId("advert_one");
     private static final AdvertId SECOND_ADVERT_ID = new AdvertId("advert_two");
@@ -39,15 +44,15 @@ public class AdvertPlaybackStateTest {
     private static final Advert THIRD_ADVERT = new Advert(THIRD_ADVERT_ID, THREE_SECONDS_IN_MILLIS, THIRD_URI);
 
     private static final AdvertBreak FIRST_ADVERT_BREAK = new AdvertBreak(
-            ONE_SECOND_IN_MILLIS, Collections.singletonList(FIRST_ADVERT)
+            FIRST_ADVERT_BREAK_ID, ONE_SECOND_IN_MILLIS, Collections.singletonList(FIRST_ADVERT)
     );
 
     private static final AdvertBreak SECOND_ADVERT_BREAK = new AdvertBreak(
-            TWO_SECONDS_IN_MILLIS, Arrays.asList(FIRST_ADVERT, SECOND_ADVERT)
+            SECOND_ADVERT_BREAK_ID, TWO_SECONDS_IN_MILLIS, Arrays.asList(FIRST_ADVERT, SECOND_ADVERT)
     );
 
     private static final AdvertBreak THIRD_ADVERT_BREAK = new AdvertBreak(
-            THREE_SECONDS_IN_MILLIS, Arrays.asList(FIRST_ADVERT, SECOND_ADVERT, THIRD_ADVERT)
+            THIRD_ADVERT_BREAK_ID, THREE_SECONDS_IN_MILLIS, Arrays.asList(FIRST_ADVERT, SECOND_ADVERT, THIRD_ADVERT)
     );
 
     @Test

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/AdvertPlaybackStateTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/AdvertPlaybackStateTest.java
@@ -5,6 +5,7 @@ import android.net.Uri;
 import com.google.android.exoplayer2.source.ads.AdPlaybackState;
 import com.novoda.noplayer.Advert;
 import com.novoda.noplayer.AdvertBreak;
+import com.novoda.noplayer.AdvertId;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -21,6 +22,10 @@ public class AdvertPlaybackStateTest {
     private static final int TWO_SECONDS_IN_MICROS = 2000000;
     private static final int THREE_SECONDS_IN_MICROS = 3000000;
 
+    private static final AdvertId FIRST_ADVERT_ID = new AdvertId("advert_one");
+    private static final AdvertId SECOND_ADVERT_ID = new AdvertId("advert_two");
+    private static final AdvertId THIRD_ADVERT_ID = new AdvertId("advert_three");
+
     private static final int ONE_SECOND_IN_MILLIS = 1000;
     private static final int TWO_SECONDS_IN_MILLIS = 2000;
     private static final int THREE_SECONDS_IN_MILLIS = 3000;
@@ -29,9 +34,9 @@ public class AdvertPlaybackStateTest {
     private static final Uri SECOND_URI = mock(Uri.class);
     private static final Uri THIRD_URI = mock(Uri.class);
 
-    private static final Advert FIRST_ADVERT = new Advert(ONE_SECOND_IN_MILLIS, FIRST_URI);
-    private static final Advert SECOND_ADVERT = new Advert(TWO_SECONDS_IN_MILLIS, SECOND_URI);
-    private static final Advert THIRD_ADVERT = new Advert(THREE_SECONDS_IN_MILLIS, THIRD_URI);
+    private static final Advert FIRST_ADVERT = new Advert(FIRST_ADVERT_ID, ONE_SECOND_IN_MILLIS, FIRST_URI);
+    private static final Advert SECOND_ADVERT = new Advert(SECOND_ADVERT_ID, TWO_SECONDS_IN_MILLIS, SECOND_URI);
+    private static final Advert THIRD_ADVERT = new Advert(THIRD_ADVERT_ID, THREE_SECONDS_IN_MILLIS, THIRD_URI);
 
     private static final AdvertBreak FIRST_ADVERT_BREAK = new AdvertBreak(
             ONE_SECOND_IN_MILLIS, Collections.singletonList(FIRST_ADVERT)

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/AdvertPlaybackStateTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/AdvertPlaybackStateTest.java
@@ -54,13 +54,24 @@ public class AdvertPlaybackStateTest {
     public void createsCorrectAdvertPlaybackState() {
         List<AdvertBreak> advertBreaks = Arrays.asList(THIRD_ADVERT_BREAK, SECOND_ADVERT_BREAK, FIRST_ADVERT_BREAK);
 
-        AdPlaybackState adPlaybackState = AdvertPlaybackState.from(advertBreaks);
+        AdvertPlaybackState advertPlaybackState = AdvertPlaybackState.from(advertBreaks);
+        AdPlaybackState adPlaybackState = advertPlaybackState.adPlaybackState();
 
         assertThat(adPlaybackState.adGroupCount).isEqualTo(3);
         assertThat(adPlaybackState.adGroupTimesUs).containsSequence(ONE_SECOND_IN_MICROS, TWO_SECONDS_IN_MICROS, THREE_SECONDS_IN_MICROS);
         assertThatGroupContains(adPlaybackState.adGroups[0], 1, new long[]{ONE_SECOND_IN_MICROS}, new Uri[]{FIRST_URI});
         assertThatGroupContains(adPlaybackState.adGroups[1], 2, new long[]{ONE_SECOND_IN_MICROS, TWO_SECONDS_IN_MICROS}, new Uri[]{FIRST_URI, SECOND_URI});
         assertThatGroupContains(adPlaybackState.adGroups[2], 3, new long[]{ONE_SECOND_IN_MICROS, TWO_SECONDS_IN_MICROS, THREE_SECONDS_IN_MICROS}, new Uri[]{FIRST_URI, SECOND_URI, THIRD_URI});
+    }
+
+    @Test
+    public void advertBreaksAreReorderedBasedOnStartTime() {
+        List<AdvertBreak> advertBreaks = Arrays.asList(THIRD_ADVERT_BREAK, SECOND_ADVERT_BREAK, FIRST_ADVERT_BREAK);
+
+        AdvertPlaybackState advertPlaybackState = AdvertPlaybackState.from(advertBreaks);
+        List<AdvertBreak> actualAdvertBreaks = advertPlaybackState.advertBreaks();
+
+        assertThat(actualAdvertBreaks).containsExactly(FIRST_ADVERT_BREAK, SECOND_ADVERT_BREAK, THIRD_ADVERT_BREAK);
     }
 
     private void assertThatGroupContains(AdPlaybackState.AdGroup adGroup, int numberOfAdverts, long[] advertDurations, Uri[] advertUris) {


### PR DESCRIPTION
## Problem
- We want to be able to notify clients of when advert break start and end events occurs, as well as advert start and end events. 

## Solution
- Define the public API for receiving the above events. This mainly involved emitting the given event, start advert break for example, with an identifier specified by the client. We introduced the appropriate methods on the listeners and created the additional id models. 
- Determine when the events are emitted by `exo-player` and forward the appropriate event to the client with the associated identifier. 

**Then we manually tested, at which point we discovered:**

- The ordering of the advert breaks between this PR and #208 was lost. This ordering is extremely important as `exo-player` uses the order for the method calls to `currentAdvertGroup` and `currentAdvert`. We've introduced a `AdvertPlaybackState` model to wrap the `AdvertBreaks` and the `AdPlaybackState` to ensure the ordering is preserved between loading adverts and passing them to the `exo-player`. 
- The `Optional<AdvertListener>` is tedious to use because we can't add lambdas and we do not have any useful functions on the `Optional` interface. We tried adding some more useful methods to the `Optional` such as a `ifPresent(Func1)` but actually it didn't improve readability at all, due to the lack of any lambdas. In the end we opted to add the `NoOp` version of the advert listener and replace it with calls to `bind`. 

### Test(s) added 
We didn't actually add any tests in this PR. I'm going to open a PR after this one that goes through and adds tests to the `NoPlayerAdsLoader`. 

### Paired with 
@JozefCeluch 
