### PR TITLE
Deprecate `playAt` for seeking initial position

### DIFF
--- a/core/src/main/java/com/novoda/noplayer/NoPlayer.java
+++ b/core/src/main/java/com/novoda/noplayer/NoPlayer.java
@@ -32,12 +32,16 @@ public interface NoPlayer extends PlayerState {
     void play() throws IllegalStateException;
 
     /**
-     * Plays content of a prepared Player at a given position.
+     * Deprecated: This does not perform the way it was originally intended. A seek can, and most likely will,
+     * occur after the content has already started playing. This can lead to some unexpected behaviour.
+     * Plays content of a prepared Player at a given position. Use {@link #loadVideo(Uri, Options)} passing
+     * a initial position to the {@link Options}.
      *
      * @param positionInMillis to start playing content from.
      * @throws IllegalStateException - if called before {@link NoPlayer#loadVideo(Uri, Options)}.
      * @see NoPlayer.PreparedListener
      */
+    @Deprecated
     void playAt(long positionInMillis) throws IllegalStateException;
 
     /**

--- a/core/src/main/java/com/novoda/noplayer/Options.java
+++ b/core/src/main/java/com/novoda/noplayer/Options.java
@@ -1,15 +1,22 @@
 package com.novoda.noplayer;
 
+import com.novoda.noplayer.internal.utils.Optional;
+
 public class Options {
 
     private final ContentType contentType;
     private final int minDurationBeforeQualityIncreaseInMillis;
     private final int maxInitialBitrate;
+    private final Optional<Long> initialPositionInMillis;
 
-    Options(ContentType contentType, int minDurationBeforeQualityIncreaseInMillis, int maxInitialBitrate) {
+    Options(ContentType contentType,
+            int minDurationBeforeQualityIncreaseInMillis,
+            int maxInitialBitrate,
+            Optional<Long> initialPositionInMillis) {
         this.contentType = contentType;
         this.minDurationBeforeQualityIncreaseInMillis = minDurationBeforeQualityIncreaseInMillis;
         this.maxInitialBitrate = maxInitialBitrate;
+        this.initialPositionInMillis = initialPositionInMillis;
     }
 
     public ContentType contentType() {
@@ -22,6 +29,10 @@ public class Options {
 
     public int maxInitialBitrate() {
         return maxInitialBitrate;
+    }
+
+    public Optional<Long> getInitialPositionInMillis() {
+        return initialPositionInMillis;
     }
 
     @Override
@@ -41,7 +52,10 @@ public class Options {
         if (maxInitialBitrate != options.maxInitialBitrate) {
             return false;
         }
-        return contentType == options.contentType;
+        if (contentType != options.contentType) {
+            return false;
+        }
+        return initialPositionInMillis != null ? initialPositionInMillis.equals(options.initialPositionInMillis) : options.initialPositionInMillis == null;
     }
 
     @Override
@@ -49,6 +63,7 @@ public class Options {
         int result = contentType != null ? contentType.hashCode() : 0;
         result = 31 * result + minDurationBeforeQualityIncreaseInMillis;
         result = 31 * result + maxInitialBitrate;
+        result = 31 * result + (initialPositionInMillis != null ? initialPositionInMillis.hashCode() : 0);
         return result;
     }
 
@@ -58,6 +73,7 @@ public class Options {
                 + "contentType=" + contentType
                 + ", minDurationBeforeQualityIncreaseInMillis=" + minDurationBeforeQualityIncreaseInMillis
                 + ", maxInitialBitrate=" + maxInitialBitrate
+                + ", initialPositionInMillis=" + initialPositionInMillis
                 + '}';
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/Options.java
+++ b/core/src/main/java/com/novoda/noplayer/Options.java
@@ -75,7 +75,8 @@ public class Options {
         if (contentType != options.contentType) {
             return false;
         }
-        return initialPositionInMillis != null ? initialPositionInMillis.equals(options.initialPositionInMillis) : options.initialPositionInMillis == null;
+        return initialPositionInMillis != null
+                ? initialPositionInMillis.equals(options.initialPositionInMillis) : options.initialPositionInMillis == null;
     }
 
     @Override

--- a/core/src/main/java/com/novoda/noplayer/Options.java
+++ b/core/src/main/java/com/novoda/noplayer/Options.java
@@ -2,6 +2,9 @@ package com.novoda.noplayer;
 
 import com.novoda.noplayer.internal.utils.Optional;
 
+/**
+ * Options to customise the underlying player.
+ */
 public class Options {
 
     private final ContentType contentType;
@@ -9,6 +12,11 @@ public class Options {
     private final int maxInitialBitrate;
     private final Optional<Long> initialPositionInMillis;
 
+    /**
+     * Creates a {@link OptionsBuilder} from this Options.
+     *
+     * @return a new instance of {@link OptionsBuilder}.
+     */
     public OptionsBuilder toOptionsBuilder() {
         OptionsBuilder optionsBuilder = new OptionsBuilder()
                 .withContentType(contentType)

--- a/core/src/main/java/com/novoda/noplayer/Options.java
+++ b/core/src/main/java/com/novoda/noplayer/Options.java
@@ -9,6 +9,18 @@ public class Options {
     private final int maxInitialBitrate;
     private final Optional<Long> initialPositionInMillis;
 
+    public OptionsBuilder toOptionsBuilder() {
+        OptionsBuilder optionsBuilder = new OptionsBuilder()
+                .withContentType(contentType)
+                .withMinDurationBeforeQualityIncreaseInMillis(minDurationBeforeQualityIncreaseInMillis)
+                .withMaxInitialBitrate(maxInitialBitrate);
+
+        if (initialPositionInMillis.isPresent()) {
+            optionsBuilder = optionsBuilder.withInitialPositionInMillis(initialPositionInMillis.get());
+        }
+        return optionsBuilder;
+    }
+
     Options(ContentType contentType,
             int minDurationBeforeQualityIncreaseInMillis,
             int maxInitialBitrate,

--- a/core/src/main/java/com/novoda/noplayer/OptionsBuilder.java
+++ b/core/src/main/java/com/novoda/noplayer/OptionsBuilder.java
@@ -2,6 +2,8 @@ package com.novoda.noplayer;
 
 import android.net.Uri;
 
+import com.novoda.noplayer.internal.utils.Optional;
+
 /**
  * Builds instances of {@link Options} for {@link NoPlayer#loadVideo(Uri, Options)}.
  */
@@ -13,6 +15,7 @@ public class OptionsBuilder {
     private ContentType contentType = ContentType.H264;
     private int minDurationBeforeQualityIncreaseInMillis = DEFAULT_MIN_DURATION_FOR_QUALITY_INCREASE_MS;
     private int maxInitialBitrate = DEFAULT_MAX_INITIAL_BITRATE;
+    private Optional<Long> initialPositionInMillis = Optional.absent();
 
     /**
      * Sets {@link OptionsBuilder} to build {@link Options} with a given {@link ContentType}.
@@ -44,10 +47,23 @@ public class OptionsBuilder {
      * allows the player to choose a higher quality video track at the beginning.
      *
      * @param maxInitialBitrate maximum bitrate that limits the initial track selection.
-     * @return {@link OptionsBuilder}
+     * @return {@link OptionsBuilder}.
      */
     public OptionsBuilder withMaxInitialBitrate(int maxInitialBitrate) {
         this.maxInitialBitrate = maxInitialBitrate;
+        return this;
+    }
+
+    /**
+     * Sets {@link OptionsBuilder} to build {@link Options} with given initial position in millis in order
+     * to specify the start position of the content that will be played. Omitting to set this will start
+     * playback at the beginning of the content.
+     *
+     * @param initialPositionInMillis position that the content should begin playback at.
+     * @return {@link OptionsBuilder}.
+     */
+    public OptionsBuilder withInitialPositionInMillis(long initialPositionInMillis) {
+        this.initialPositionInMillis = Optional.of(initialPositionInMillis);
         return this;
     }
 
@@ -57,6 +73,6 @@ public class OptionsBuilder {
      * @return a {@link Options} instance.
      */
     public Options build() {
-        return new Options(contentType, minDurationBeforeQualityIncreaseInMillis, maxInitialBitrate);
+        return new Options(contentType, minDurationBeforeQualityIncreaseInMillis, maxInitialBitrate, initialPositionInMillis);
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
@@ -26,7 +26,6 @@ import java.util.List;
 
 class ExoPlayerFacade {
 
-    private static final boolean RESET_POSITION = true;
     private static final boolean DO_NOT_RESET_STATE = false;
 
     private final BandwidthMeterCreator bandwidthMeterCreator;
@@ -136,7 +135,14 @@ class ExoPlayerFacade {
                 bandwidthMeter
         );
         attachToSurface(playerSurfaceHolder);
-        exoPlayer.prepare(mediaSource, RESET_POSITION, DO_NOT_RESET_STATE);
+
+        boolean hasInitialPosition = options.getInitialPositionInMillis().isPresent();
+        if (hasInitialPosition) {
+            Long initialPositionInMillis = options.getInitialPositionInMillis().get();
+            exoPlayer.seekTo(exoPlayer.getCurrentWindowIndex(), initialPositionInMillis);
+        }
+
+        exoPlayer.prepare(mediaSource, !hasInitialPosition, DO_NOT_RESET_STATE);
     }
 
     private void setMovieAudioAttributes(SimpleExoPlayer exoPlayer) {

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
@@ -139,7 +139,7 @@ class ExoPlayerFacade {
         boolean hasInitialPosition = options.getInitialPositionInMillis().isPresent();
         if (hasInitialPosition) {
             Long initialPositionInMillis = options.getInitialPositionInMillis().get();
-            exoPlayer.seekTo(exoPlayer.getCurrentWindowIndex(), initialPositionInMillis);
+            exoPlayer.seekTo(initialPositionInMillis);
         }
 
         exoPlayer.prepare(mediaSource, !hasInitialPosition, DO_NOT_RESET_STATE);


### PR DESCRIPTION
## Problem
Whilst working on the adverts loader I noticed that when we want to perform a seek to an initial position we do: 

`loadVideo` -> `playAt` / `seekTo`

This has very little chance of notifying us in the correct order. `ExoPlayer` is essentially message based so you are going to be rendering the first frame of content before performing a seek in this flow. After looking at the `ExoPlayer` code in a little more detail I can see that we need to perform a seek **before** we prepare the underlying player. This way the timeline and the position information is updated prior to the first frame being rendered. 

## Solution
Add an `initialPositionInMillis` to the `Options`. When this `Option` is available we perform a seek and tell the player not to reset the positional information for the player. This means when the first frame rendered it will be from that position in the Timeline. 

### Test(s) added 
Just updating the facade tests to ensure that when this position information is present we will perform a seek before playing.

### Screenshots
For those that are interested I have some rather long logs. These are informational, so these are the listeners that exo-player calls when it does anything 


**Before**
```
caller: onPlayerStateChanged
caller: onPlayerStateChanged
caller: onLoadStarted
caller: onLoadStarted
caller: onSurfaceSizeChanged
caller: onLoadCompleted
caller: onLoadCompleted
caller: onTimelineChanged
caller: onTimelineChanged
caller: onMediaPeriodCreated
caller: onMediaPeriodCreated
caller: onLoadingChanged
caller: onLoadingChanged
caller: onDecoderEnabled
caller: onDecoderEnabled
caller: onLoadStarted
caller: onLoadStarted
caller: onLoadStarted
caller: onLoadStarted
caller: onTracksChanged
caller: onTracksChanged
caller: onReadingStarted
caller: onReadingStarted
caller: onBandwidthEstimate
caller: onLoadCompleted
caller: onLoadCompleted
caller: onLoadStarted
caller: onLoadStarted
caller: onDownstreamFormatChanged
caller: onDownstreamFormatChanged
caller: onBandwidthEstimate
caller: onLoadCompleted
caller: onLoadCompleted
caller: onLoadStarted
caller: onLoadStarted
caller: onDownstreamFormatChanged
caller: onDownstreamFormatChanged
caller: onBandwidthEstimate
caller: onDecoderInitialized
caller: onDecoderInputFormatChanged
caller: onBandwidthEstimate
caller: onDecoderInitialized
caller: onDecoderInputFormatChanged
caller: onLoadCompleted
caller: onLoadCompleted
caller: onLoadCompleted
caller: onLoadCompleted
caller: onLoadStarted
caller: onLoadStarted
caller: onLoadStarted
caller: onLoadStarted
caller: onVideoSizeChanged
caller: onRenderedFirstFrame // RENDERS FRAME :100:
caller: onSurfaceSizeChanged
caller: onAudioSessionId
caller: onPlayerStateChanged
caller: onSeekStarted   // POSITION INFORMATION CORRECT AFTER THIS POINT
caller: onPositionDiscontinuity
caller: onPositionDiscontinuity
caller: onPlayerStateChanged
caller: onPlayerStateChanged
caller: onPlayerStateChanged
caller: onPlayerStateChanged
caller: onPlayerStateChanged
caller: onSeekProcessed
caller: onPositionDiscontinuity
caller: onBandwidthEstimate
caller: onLoadCanceled
caller: onLoadCanceled
caller: onBandwidthEstimate
caller: onLoadCanceled
caller: onLoadCanceled
caller: onLoadStarted
caller: onLoadStarted
caller: onLoadStarted
caller: onLoadStarted
caller: onBandwidthEstimate
caller: onLoadCompleted
caller: onLoadCompleted
caller: onBandwidthEstimate
caller: onLoadCompleted
caller: onLoadCompleted
caller: onLoadStarted
caller: onLoadStarted
caller: onLoadStarted
caller: onLoadStarted
caller: onBandwidthEstimate
caller: onLoadCompleted
caller: onLoadCompleted
caller: onBandwidthEstimate
caller: onLoadCompleted
caller: onLoadCompleted
caller: onLoadStarted
caller: onLoadStarted
caller: onRenderedFirstFrame  // RENDERS IT AGAIN?!!! :x:
caller: onPlayerStateChanged
caller: onPlayerStateChanged
caller: onBandwidthEstimate
caller: onLoadCompleted
caller: onLoadCompleted
caller: onLoadStarted
caller: onLoadStarted
caller: onLoadStarted
caller: onLoadStarted
caller: onSurfaceSizeChanged
```

**After**
```
caller: onSeekStarted // POSITION INFORMATION CORRECT AFTER THIS POINT
caller: onPositionDiscontinuity
caller: onPositionDiscontinuity
caller: onPlayerStateChanged
caller: onPlayerStateChanged
caller: onLoadStarted
caller: onLoadStarted
caller: onSurfaceSizeChanged
caller: onLoadCompleted
caller: onLoadCompleted
caller: onTimelineChanged
caller: onTimelineChanged
caller: onSeekProcessed
caller: onPositionDiscontinuity
caller: onMediaPeriodCreated
caller: onMediaPeriodCreated
caller: onLoadingChanged
caller: onLoadingChanged
caller: onDecoderEnabled
caller: onDecoderEnabled
caller: onLoadStarted
caller: onLoadStarted
caller: onLoadStarted
caller: onLoadStarted
caller: onTracksChanged
caller: onTracksChanged
caller: onReadingStarted
caller: onReadingStarted
caller: onBandwidthEstimate
caller: onLoadCompleted
caller: onLoadCompleted
caller: onLoadStarted
caller: onLoadStarted
caller: onDownstreamFormatChanged
caller: onDownstreamFormatChanged
caller: onBandwidthEstimate
caller: onLoadCompleted
caller: onLoadCompleted
caller: onLoadStarted
caller: onLoadStarted
caller: onDownstreamFormatChanged
caller: onDownstreamFormatChanged
caller: onBandwidthEstimate
caller: onDecoderInitialized
caller: onDecoderInputFormatChanged
caller: onLoadCompleted
caller: onLoadCompleted
caller: onLoadStarted
caller: onLoadStarted
caller: onDecoderInitialized
caller: onDecoderInputFormatChanged
caller: onBandwidthEstimate
caller: onLoadCompleted
caller: onLoadCompleted
caller: onAudioSessionId
caller: onLoadStarted
caller: onLoadStarted
caller: onBandwidthEstimate
caller: onLoadCompleted
caller: onLoadCompleted
caller: onLoadStarted
caller: onLoadStarted
caller: onBandwidthEstimate
caller: onLoadCompleted
caller: onLoadCompleted
caller: onVideoSizeChanged
caller: onSurfaceSizeChanged
caller: onRenderedFirstFrame  // RENDERS ONCE!
caller: onPlayerStateChanged
caller: onPlayerStateChanged
caller: onPlayerStateChanged
caller: onPlayerStateChanged
caller: onBandwidthEstimate
caller: onLoadCompleted
caller: onLoadCompleted
```

### Paired with 
Nobody.
