### PR TITLE
NO-ADS/Skipping adverts based on start position

### DIFF
--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
@@ -3,6 +3,7 @@ package com.novoda.noplayer.internal.exoplayer;
 import android.os.Handler;
 import android.os.Looper;
 import android.support.annotation.Nullable;
+import android.util.Log;
 
 import com.google.android.exoplayer2.C;
 import com.google.android.exoplayer2.Player;
@@ -156,11 +157,20 @@ public class NoPlayerAdsLoader implements AdsLoader, Player.EventListener {
             return;
         }
 
-        if (player != null) {
+        if (player != null && adPlaybackState != null) {
             adGroupIndex = player.getCurrentAdGroupIndex();
             adIndexInGroup = player.getCurrentAdIndexInAdGroup();
+            long contentPosition = player.getContentPosition();
 
             if (reason == Player.TIMELINE_CHANGE_REASON_PREPARED && isPlayingAdvert()) {
+                if (contentPosition > 0) {
+                    for (int i = adGroupIndex; i >= 0; i--) {
+                        adPlaybackState = adPlaybackState.withSkippedAdGroup(i);
+                    }
+                    updateAdPlaybackState();
+                    return;
+                }
+
                 notifyAdvertStart(advertBreaks.get(adGroupIndex));
             }
         }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
@@ -3,7 +3,6 @@ package com.novoda.noplayer.internal.exoplayer;
 import android.os.Handler;
 import android.os.Looper;
 import android.support.annotation.Nullable;
-import android.util.Log;
 
 import com.google.android.exoplayer2.C;
 import com.google.android.exoplayer2.Player;
@@ -164,9 +163,7 @@ public class NoPlayerAdsLoader implements AdsLoader, Player.EventListener {
 
             if (reason == Player.TIMELINE_CHANGE_REASON_PREPARED && isPlayingAdvert()) {
                 if (contentPosition > 0) {
-                    for (int i = adGroupIndex; i >= 0; i--) {
-                        adPlaybackState = adPlaybackState.withSkippedAdGroup(i);
-                    }
+                    adPlaybackState = SkippedAdverts.from(contentPosition, advertBreaks, adPlaybackState);
                     updateAdPlaybackState();
                     return;
                 }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/SkippedAdverts.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/SkippedAdverts.java
@@ -12,16 +12,16 @@ final class SkippedAdverts {
     }
 
     static AdPlaybackState from(long currentPositionInMillis, List<AdvertBreak> advertBreaks, AdPlaybackState adPlaybackState) {
-        AdPlaybackState advertPlaybackState = adPlaybackState;
+        AdPlaybackState adPlaybackStateWithSkippedAdGroups = adPlaybackState;
         for (int i = advertBreaks.size() - 1; i >= 0; i--) {
             AdvertBreak advertBreak = advertBreaks.get(i);
             if (advertBreak.startTimeInMillis() >= currentPositionInMillis) {
                 continue;
             }
 
-            advertPlaybackState = advertPlaybackState.withSkippedAdGroup(i);
+            adPlaybackStateWithSkippedAdGroups = adPlaybackStateWithSkippedAdGroups.withSkippedAdGroup(i);
         }
-        return advertPlaybackState;
+        return adPlaybackStateWithSkippedAdGroups;
     }
 
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/SkippedAdverts.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/SkippedAdverts.java
@@ -7,16 +7,21 @@ import java.util.List;
 
 final class SkippedAdverts {
 
+    private SkippedAdverts() {
+        // Utility class.
+    }
+
     static AdPlaybackState from(long currentPositionInMillis, List<AdvertBreak> advertBreaks, AdPlaybackState adPlaybackState) {
+        AdPlaybackState advertPlaybackState = adPlaybackState;
         for (int i = advertBreaks.size() - 1; i >= 0; i--) {
             AdvertBreak advertBreak = advertBreaks.get(i);
             if (advertBreak.startTimeInMillis() >= currentPositionInMillis) {
                 continue;
             }
 
-            adPlaybackState = adPlaybackState.withSkippedAdGroup(i);
+            advertPlaybackState = advertPlaybackState.withSkippedAdGroup(i);
         }
-        return adPlaybackState;
+        return advertPlaybackState;
     }
 
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/SkippedAdverts.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/SkippedAdverts.java
@@ -1,0 +1,22 @@
+package com.novoda.noplayer.internal.exoplayer;
+
+import com.google.android.exoplayer2.source.ads.AdPlaybackState;
+import com.novoda.noplayer.AdvertBreak;
+
+import java.util.List;
+
+final class SkippedAdverts {
+
+    static AdPlaybackState from(long currentPositionInMillis, List<AdvertBreak> advertBreaks, AdPlaybackState adPlaybackState) {
+        for (int i = advertBreaks.size() - 1; i >= 0; i--) {
+            AdvertBreak advertBreak = advertBreaks.get(i);
+            if (advertBreak.startTimeInMillis() >= currentPositionInMillis) {
+                continue;
+            }
+
+            adPlaybackState = adPlaybackState.withSkippedAdGroup(i);
+        }
+        return adPlaybackState;
+    }
+
+}

--- a/core/src/test/java/com/novoda/noplayer/AdvertBreakFixtures.java
+++ b/core/src/test/java/com/novoda/noplayer/AdvertBreakFixtures.java
@@ -8,7 +8,7 @@ public class AdvertBreakFixtures {
 
     private AdvertBreakId advertBreakId = new AdvertBreakId("advert_break_id");
     private long startTimeInMillis = 1000;
-    private List<Advert> adverts = new ArrayList<>();
+    private final List<Advert> adverts = new ArrayList<>();
 
     public static AdvertBreakFixtures anAdvertBreak() {
         return new AdvertBreakFixtures();

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/SkippedAdvertsTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/SkippedAdvertsTest.java
@@ -4,18 +4,16 @@ import com.google.android.exoplayer2.source.ads.AdPlaybackState;
 import com.novoda.noplayer.AdvertBreak;
 
 import java.util.Arrays;
-import java.util.List;
 
 import org.junit.Test;
 
+import static com.google.android.exoplayer2.source.ads.AdPlaybackState.AD_STATE_AVAILABLE;
+import static com.google.android.exoplayer2.source.ads.AdPlaybackState.AD_STATE_SKIPPED;
 import static com.novoda.noplayer.AdvertBreakFixtures.anAdvertBreak;
 import static com.novoda.noplayer.AdvertFixtures.anAdvert;
 import static org.fest.assertions.api.Assertions.assertThat;
 
 public class SkippedAdvertsTest {
-
-    public static final int AD_STATE_AVAILABLE = 1;
-    public static final int AD_STATE_SKIPPED = 2;
 
     private static final int BEGINNING = 0;
     private static final int TEN_SECONDS_IN_MILLIS = 10000;
@@ -41,12 +39,11 @@ public class SkippedAdvertsTest {
             .withAdvert(anAdvert().build())
             .build();
 
-    private final List<AdvertBreak> advertBreaks = Arrays.asList(FIRST_ADVERT_BREAK, SECOND_ADVERT_BREAK, THIRD_ADVERT_BREAK, FOURTH_ADVERT_BREAK);
-    private final AdvertPlaybackState advertPlaybackState = AdvertPlaybackState.from(advertBreaks);
+    private final AdvertPlaybackState advertPlaybackState = AdvertPlaybackState.from(Arrays.asList(FIRST_ADVERT_BREAK, SECOND_ADVERT_BREAK, THIRD_ADVERT_BREAK, FOURTH_ADVERT_BREAK));
 
     @Test
     public void doesNotSkipAdvert_whenCurrentPositionIsAtAdvertPosition() {
-        AdPlaybackState adPlaybackState = SkippedAdverts.from(THIRTY_SECONDS_IN_MILLIS, advertBreaks, advertPlaybackState.adPlaybackState());
+        AdPlaybackState adPlaybackState = SkippedAdverts.from(THIRTY_SECONDS_IN_MILLIS, advertPlaybackState.advertBreaks(), advertPlaybackState.adPlaybackState());
 
         assertThatGroupContains(adPlaybackState.adGroups[0], new int[]{AD_STATE_SKIPPED});
         assertThatGroupContains(adPlaybackState.adGroups[1], new int[]{AD_STATE_SKIPPED});
@@ -56,7 +53,7 @@ public class SkippedAdvertsTest {
 
     @Test
     public void skipsAdvertsPriorToCurrentPosition() {
-        AdPlaybackState adPlaybackState = SkippedAdverts.from(THIRTY_FIVE_SECONDS_IN_MILLIS, advertBreaks, advertPlaybackState.adPlaybackState());
+        AdPlaybackState adPlaybackState = SkippedAdverts.from(THIRTY_FIVE_SECONDS_IN_MILLIS, advertPlaybackState.advertBreaks(), advertPlaybackState.adPlaybackState());
 
         assertThatGroupContains(adPlaybackState.adGroups[0], new int[]{AD_STATE_SKIPPED});
         assertThatGroupContains(adPlaybackState.adGroups[1], new int[]{AD_STATE_SKIPPED});
@@ -66,7 +63,7 @@ public class SkippedAdvertsTest {
 
     @Test
     public void skipsNoAdverts_whenPositionIsStart() {
-        AdPlaybackState adPlaybackState = SkippedAdverts.from(BEGINNING, advertBreaks, advertPlaybackState.adPlaybackState());
+        AdPlaybackState adPlaybackState = SkippedAdverts.from(BEGINNING, advertPlaybackState.advertBreaks(), advertPlaybackState.adPlaybackState());
 
         assertThatGroupContains(adPlaybackState.adGroups[0], new int[]{AD_STATE_AVAILABLE});
         assertThatGroupContains(adPlaybackState.adGroups[1], new int[]{AD_STATE_AVAILABLE});

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/SkippedAdvertsTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/SkippedAdvertsTest.java
@@ -1,0 +1,80 @@
+package com.novoda.noplayer.internal.exoplayer;
+
+import com.google.android.exoplayer2.source.ads.AdPlaybackState;
+import com.novoda.noplayer.AdvertBreak;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+
+import static com.novoda.noplayer.AdvertBreakFixtures.anAdvertBreak;
+import static com.novoda.noplayer.AdvertFixtures.anAdvert;
+import static org.fest.assertions.api.Assertions.assertThat;
+
+public class SkippedAdvertsTest {
+
+    public static final int AD_STATE_AVAILABLE = 1;
+    public static final int AD_STATE_SKIPPED = 2;
+
+    private static final int BEGINNING = 0;
+    private static final int TEN_SECONDS_IN_MILLIS = 10000;
+    private static final int TWENTY_SECONDS_IN_MILLIS = 20000;
+    private static final int THIRTY_SECONDS_IN_MILLIS = 30000;
+    private static final int THIRTY_FIVE_SECONDS_IN_MILLIS = 35000;
+    private static final int FOURTY_SECONDS_IN_MILLIS = 40000;
+
+    private static final AdvertBreak FIRST_ADVERT_BREAK = anAdvertBreak()
+            .withStartTimeInMillis(TEN_SECONDS_IN_MILLIS)
+            .withAdvert(anAdvert().build())
+            .build();
+    private static final AdvertBreak SECOND_ADVERT_BREAK = anAdvertBreak()
+            .withStartTimeInMillis(TWENTY_SECONDS_IN_MILLIS)
+            .withAdvert(anAdvert().build())
+            .build();
+    private static final AdvertBreak THIRD_ADVERT_BREAK = anAdvertBreak()
+            .withStartTimeInMillis(THIRTY_SECONDS_IN_MILLIS)
+            .withAdvert(anAdvert().build())
+            .build();
+    private static final AdvertBreak FOURTH_ADVERT_BREAK = anAdvertBreak()
+            .withStartTimeInMillis(FOURTY_SECONDS_IN_MILLIS)
+            .withAdvert(anAdvert().build())
+            .build();
+
+    private final List<AdvertBreak> advertBreaks = Arrays.asList(FIRST_ADVERT_BREAK, SECOND_ADVERT_BREAK, THIRD_ADVERT_BREAK, FOURTH_ADVERT_BREAK);
+    private final AdvertPlaybackState advertPlaybackState = AdvertPlaybackState.from(advertBreaks);
+
+    @Test
+    public void doesNotSkipAdvert_whenCurrentPositionIsAtAdvertPosition() {
+        AdPlaybackState adPlaybackState = SkippedAdverts.from(THIRTY_SECONDS_IN_MILLIS, advertBreaks, advertPlaybackState.adPlaybackState());
+
+        assertThatGroupContains(adPlaybackState.adGroups[0], new int[]{AD_STATE_SKIPPED});
+        assertThatGroupContains(adPlaybackState.adGroups[1], new int[]{AD_STATE_SKIPPED});
+        assertThatGroupContains(adPlaybackState.adGroups[2], new int[]{AD_STATE_AVAILABLE});
+        assertThatGroupContains(adPlaybackState.adGroups[3], new int[]{AD_STATE_AVAILABLE});
+    }
+
+    @Test
+    public void skipsAdvertsPriorToCurrentPosition() {
+        AdPlaybackState adPlaybackState = SkippedAdverts.from(THIRTY_FIVE_SECONDS_IN_MILLIS, advertBreaks, advertPlaybackState.adPlaybackState());
+
+        assertThatGroupContains(adPlaybackState.adGroups[0], new int[]{AD_STATE_SKIPPED});
+        assertThatGroupContains(adPlaybackState.adGroups[1], new int[]{AD_STATE_SKIPPED});
+        assertThatGroupContains(adPlaybackState.adGroups[2], new int[]{AD_STATE_SKIPPED});
+        assertThatGroupContains(adPlaybackState.adGroups[3], new int[]{AD_STATE_AVAILABLE});
+    }
+
+    @Test
+    public void skipsNoAdverts_whenPositionIsStart() {
+        AdPlaybackState adPlaybackState = SkippedAdverts.from(BEGINNING, advertBreaks, advertPlaybackState.adPlaybackState());
+
+        assertThatGroupContains(adPlaybackState.adGroups[0], new int[]{AD_STATE_AVAILABLE});
+        assertThatGroupContains(adPlaybackState.adGroups[1], new int[]{AD_STATE_AVAILABLE});
+        assertThatGroupContains(adPlaybackState.adGroups[2], new int[]{AD_STATE_AVAILABLE});
+        assertThatGroupContains(adPlaybackState.adGroups[3], new int[]{AD_STATE_AVAILABLE});
+    }
+
+    private void assertThatGroupContains(AdPlaybackState.AdGroup adGroup, int[] states) {
+        assertThat(adGroup.states).containsOnly(states);
+    }
+}

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/SkippedAdvertsTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/SkippedAdvertsTest.java
@@ -4,6 +4,7 @@ import com.google.android.exoplayer2.source.ads.AdPlaybackState;
 import com.novoda.noplayer.AdvertBreak;
 
 import java.util.Arrays;
+import java.util.List;
 
 import org.junit.Test;
 
@@ -38,12 +39,13 @@ public class SkippedAdvertsTest {
             .withStartTimeInMillis(FORTY_SECONDS_IN_MILLIS)
             .withAdvert(anAdvert().build())
             .build();
-
-    private final AdvertPlaybackState advertPlaybackState = AdvertPlaybackState.from(Arrays.asList(FIRST_ADVERT_BREAK, SECOND_ADVERT_BREAK, THIRD_ADVERT_BREAK, FOURTH_ADVERT_BREAK));
+    private static final AdvertPlaybackState advertPlaybackState = AdvertPlaybackState.from(Arrays.asList(FIRST_ADVERT_BREAK, SECOND_ADVERT_BREAK, THIRD_ADVERT_BREAK, FOURTH_ADVERT_BREAK));
+    private static final List<AdvertBreak> ADVERT_BREAKS = advertPlaybackState.advertBreaks();
+    private static final AdPlaybackState AD_PLAYBACK_STATE = advertPlaybackState.adPlaybackState();
 
     @Test
     public void doesNotSkipAdvert_whenCurrentPositionIsAtAdvertPosition() {
-        AdPlaybackState adPlaybackState = SkippedAdverts.from(THIRTY_SECONDS_IN_MILLIS, advertPlaybackState.advertBreaks(), advertPlaybackState.adPlaybackState());
+        AdPlaybackState adPlaybackState = SkippedAdverts.from(THIRTY_SECONDS_IN_MILLIS, ADVERT_BREAKS, AD_PLAYBACK_STATE);
 
         assertThatGroupContains(adPlaybackState.adGroups[0], new int[]{AD_STATE_SKIPPED});
         assertThatGroupContains(adPlaybackState.adGroups[1], new int[]{AD_STATE_SKIPPED});
@@ -53,7 +55,7 @@ public class SkippedAdvertsTest {
 
     @Test
     public void skipsAdvertsPriorToCurrentPosition() {
-        AdPlaybackState adPlaybackState = SkippedAdverts.from(THIRTY_FIVE_SECONDS_IN_MILLIS, advertPlaybackState.advertBreaks(), advertPlaybackState.adPlaybackState());
+        AdPlaybackState adPlaybackState = SkippedAdverts.from(THIRTY_FIVE_SECONDS_IN_MILLIS, ADVERT_BREAKS, AD_PLAYBACK_STATE);
 
         assertThatGroupContains(adPlaybackState.adGroups[0], new int[]{AD_STATE_SKIPPED});
         assertThatGroupContains(adPlaybackState.adGroups[1], new int[]{AD_STATE_SKIPPED});
@@ -63,7 +65,7 @@ public class SkippedAdvertsTest {
 
     @Test
     public void skipsNoAdverts_whenPositionIsStart() {
-        AdPlaybackState adPlaybackState = SkippedAdverts.from(BEGINNING, advertPlaybackState.advertBreaks(), advertPlaybackState.adPlaybackState());
+        AdPlaybackState adPlaybackState = SkippedAdverts.from(BEGINNING, ADVERT_BREAKS, AD_PLAYBACK_STATE);
 
         assertThatGroupContains(adPlaybackState.adGroups[0], new int[]{AD_STATE_AVAILABLE});
         assertThatGroupContains(adPlaybackState.adGroups[1], new int[]{AD_STATE_AVAILABLE});

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/SkippedAdvertsTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/SkippedAdvertsTest.java
@@ -20,7 +20,7 @@ public class SkippedAdvertsTest {
     private static final int TWENTY_SECONDS_IN_MILLIS = 20000;
     private static final int THIRTY_SECONDS_IN_MILLIS = 30000;
     private static final int THIRTY_FIVE_SECONDS_IN_MILLIS = 35000;
-    private static final int FOURTY_SECONDS_IN_MILLIS = 40000;
+    private static final int FORTY_SECONDS_IN_MILLIS = 40000;
 
     private static final AdvertBreak FIRST_ADVERT_BREAK = anAdvertBreak()
             .withStartTimeInMillis(TEN_SECONDS_IN_MILLIS)
@@ -35,7 +35,7 @@ public class SkippedAdvertsTest {
             .withAdvert(anAdvert().build())
             .build();
     private static final AdvertBreak FOURTH_ADVERT_BREAK = anAdvertBreak()
-            .withStartTimeInMillis(FOURTY_SECONDS_IN_MILLIS)
+            .withStartTimeInMillis(FORTY_SECONDS_IN_MILLIS)
             .withAdvert(anAdvert().build())
             .build();
 


### PR DESCRIPTION
## Problem
We want to be able to skip adverts based on the initial playback position. In this case if the initial position also happens to be an advert position we play the advert first.

## Solution
Create a `SkippedAdverts` collaborator that determines the adverts to skip based on the `initial position` the `client model (AdvertBreaks)` and the `adPlaybackState`, that we will modify. 

### Test(s) added 
Yes, tested the `SkippedAdverts` collaborator. Unfortunately it has somewhat of a hard dependency on the `AdvertPlaybackState` working so if that fails so will these tests. I couldn't really avoid it without redoing a lot of work that class already does. 

#### Manual testing

Case | outcome
--- | ---
What happens if you pass a time that is on an advert? | Made it so that this advert will play before the main content. 
What happens if you perform a seek forwards? | It will not skip adverts, the player needs to be in the preparing state for the timeline and calling the `onTimelineChanged` in the `advertsLoader`. As far as I know, this can never happen except on initial load. 
What happens if you perform a seek backwards? | Nothing, the adverts have already been skipped, they will not trigger again.

## Screen Capture
Just shows that loading the video passing a time skips the adverts before that point.

![skipping_adverts mp4](https://user-images.githubusercontent.com/3380092/55619889-87b26280-5791-11e9-82af-9a6b015e7ead.gif)


### Paired with 
Nobody.
