### PR TITLE
Add max video bitrate

### DIFF
--- a/core/src/main/java/com/novoda/noplayer/NoPlayer.java
+++ b/core/src/main/java/com/novoda/noplayer/NoPlayer.java
@@ -227,6 +227,18 @@ public interface NoPlayer extends PlayerState {
     @FloatRange(from = 0.0f, to = 1.0f)
     float getVolume() throws IllegalStateException;
 
+    /**
+     * Clears the maximum video bitrate, if set.
+     */
+    void clearMaxVideoBitrate();
+
+    /**
+     * Sets a maximum video bitrate. If the content is playing, the video will switch to a different quality.
+     *
+     * @param maxVideoBitrate The maximum video bitrate in bit per second.
+     */
+    void setMaxVideoBitrate(int maxVideoBitrate);
+
     interface PlayerError {
 
         PlayerErrorType type();

--- a/core/src/main/java/com/novoda/noplayer/Options.java
+++ b/core/src/main/java/com/novoda/noplayer/Options.java
@@ -10,6 +10,7 @@ public class Options {
     private final ContentType contentType;
     private final int minDurationBeforeQualityIncreaseInMillis;
     private final int maxInitialBitrate;
+    private final int maxVideoBitrate;
     private final Optional<Long> initialPositionInMillis;
 
     /**
@@ -21,7 +22,8 @@ public class Options {
         OptionsBuilder optionsBuilder = new OptionsBuilder()
                 .withContentType(contentType)
                 .withMinDurationBeforeQualityIncreaseInMillis(minDurationBeforeQualityIncreaseInMillis)
-                .withMaxInitialBitrate(maxInitialBitrate);
+                .withMaxInitialBitrate(maxInitialBitrate)
+                .withMaxVideoBitrate(maxVideoBitrate);
 
         if (initialPositionInMillis.isPresent()) {
             optionsBuilder = optionsBuilder.withInitialPositionInMillis(initialPositionInMillis.get());
@@ -32,10 +34,12 @@ public class Options {
     Options(ContentType contentType,
             int minDurationBeforeQualityIncreaseInMillis,
             int maxInitialBitrate,
+            int maxVideoBitrate,
             Optional<Long> initialPositionInMillis) {
         this.contentType = contentType;
         this.minDurationBeforeQualityIncreaseInMillis = minDurationBeforeQualityIncreaseInMillis;
         this.maxInitialBitrate = maxInitialBitrate;
+        this.maxVideoBitrate = maxVideoBitrate;
         this.initialPositionInMillis = initialPositionInMillis;
     }
 
@@ -49,6 +53,10 @@ public class Options {
 
     public int maxInitialBitrate() {
         return maxInitialBitrate;
+    }
+
+    public int maxVideoBitrate() {
+        return maxVideoBitrate;
     }
 
     public Optional<Long> getInitialPositionInMillis() {
@@ -72,6 +80,9 @@ public class Options {
         if (maxInitialBitrate != options.maxInitialBitrate) {
             return false;
         }
+        if (maxVideoBitrate != options.maxVideoBitrate) {
+            return false;
+        }
         if (contentType != options.contentType) {
             return false;
         }
@@ -84,6 +95,7 @@ public class Options {
         int result = contentType != null ? contentType.hashCode() : 0;
         result = 31 * result + minDurationBeforeQualityIncreaseInMillis;
         result = 31 * result + maxInitialBitrate;
+        result = 31 * result + maxVideoBitrate;
         result = 31 * result + (initialPositionInMillis != null ? initialPositionInMillis.hashCode() : 0);
         return result;
     }
@@ -94,6 +106,7 @@ public class Options {
                 + "contentType=" + contentType
                 + ", minDurationBeforeQualityIncreaseInMillis=" + minDurationBeforeQualityIncreaseInMillis
                 + ", maxInitialBitrate=" + maxInitialBitrate
+                + ", maxVideoBitrate=" + maxVideoBitrate
                 + ", initialPositionInMillis=" + initialPositionInMillis
                 + '}';
     }

--- a/core/src/main/java/com/novoda/noplayer/OptionsBuilder.java
+++ b/core/src/main/java/com/novoda/noplayer/OptionsBuilder.java
@@ -11,10 +11,12 @@ public class OptionsBuilder {
 
     private static final int DEFAULT_MIN_DURATION_FOR_QUALITY_INCREASE_MS = 10000;
     private static final int DEFAULT_MAX_INITIAL_BITRATE = 800000;
+    private static final int DEFAULT_MAX_VIDEO_BITRATE = Integer.MAX_VALUE;
 
     private ContentType contentType = ContentType.H264;
     private int minDurationBeforeQualityIncreaseInMillis = DEFAULT_MIN_DURATION_FOR_QUALITY_INCREASE_MS;
     private int maxInitialBitrate = DEFAULT_MAX_INITIAL_BITRATE;
+    private int maxVideoBitrate = DEFAULT_MAX_VIDEO_BITRATE;
     private Optional<Long> initialPositionInMillis = Optional.absent();
 
     /**
@@ -55,6 +57,19 @@ public class OptionsBuilder {
     }
 
     /**
+     * Sets {@link OptionsBuilder} to build {@link Options} with given maximum video bitrate in order to
+     * control what is the maximum video quality with which {@link NoPlayer} starts the playback. Setting a higher value
+     * allows the player to choose a higher quality video track.
+     *
+     * @param maxVideoBitrate maximum bitrate that limits the initial track selection.
+     * @return {@link OptionsBuilder}
+     */
+    public OptionsBuilder withMaxVideoBitrate(int maxVideoBitrate) {
+        this.maxVideoBitrate = maxVideoBitrate;
+        return this;
+    }
+
+    /**
      * Sets {@link OptionsBuilder} to build {@link Options} with given initial position in millis in order
      * to specify the start position of the content that will be played. Omitting to set this will start
      * playback at the beginning of the content.
@@ -73,6 +88,12 @@ public class OptionsBuilder {
      * @return a {@link Options} instance.
      */
     public Options build() {
-        return new Options(contentType, minDurationBeforeQualityIncreaseInMillis, maxInitialBitrate, initialPositionInMillis);
+        return new Options(
+                contentType,
+                minDurationBeforeQualityIncreaseInMillis,
+                maxInitialBitrate,
+                maxVideoBitrate,
+                initialPositionInMillis
+        );
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/CompositeTrackSelector.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/CompositeTrackSelector.java
@@ -77,4 +77,12 @@ class CompositeTrackSelector {
     boolean clearSubtitleTrack(RendererTypeRequester rendererTypeRequester) {
         return subtitleTrackSelector.clearSubtitleTrack(rendererTypeRequester);
     }
+
+    void clearMaxVideoBitrate() {
+        videoTrackSelector.clearMaxVideoBitrate();
+    }
+
+    void setMaxVideoBitrate(int maxVideoBitrate) {
+        videoTrackSelector.setMaxVideoBitrate(maxVideoBitrate);
+    }
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/CompositeTrackSelectorCreator.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/CompositeTrackSelectorCreator.java
@@ -25,6 +25,10 @@ class CompositeTrackSelectorCreator {
                 Clock.DEFAULT
         );
         DefaultTrackSelector trackSelector = new DefaultTrackSelector(adaptiveTrackSelectionFactory);
+        DefaultTrackSelector.Parameters trackSelectorParameters = trackSelector.buildUponParameters()
+                .setMaxVideoBitrate(options.maxVideoBitrate())
+                .build();
+        trackSelector.setParameters(trackSelectorParameters);
 
         ExoPlayerTrackSelector exoPlayerTrackSelector = ExoPlayerTrackSelector.newInstance(trackSelector);
         ExoPlayerAudioTrackSelector audioTrackSelector = new ExoPlayerAudioTrackSelector(exoPlayerTrackSelector);

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
@@ -237,10 +237,19 @@ class ExoPlayerFacade {
         return exoPlayer.getVolume();
     }
 
+    void clearMaxVideoBitrate() {
+        assertVideoLoaded();
+        compositeTrackSelector.clearMaxVideoBitrate();
+    }
+
+    void setMaxVideoBitrate(int maxVideoBitrate) {
+        assertVideoLoaded();
+        compositeTrackSelector.setMaxVideoBitrate(maxVideoBitrate);
+    }
+
     private void assertVideoLoaded() {
         if (exoPlayer == null) {
             throw new IllegalStateException("Video must be loaded before trying to interact with the player");
         }
     }
-
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImpl.java
@@ -137,6 +137,16 @@ class ExoPlayerTwoImpl implements NoPlayer {
     }
 
     @Override
+    public void clearMaxVideoBitrate() {
+        exoPlayer.clearMaxVideoBitrate();
+    }
+
+    @Override
+    public void setMaxVideoBitrate(int maxVideoBitrate) {
+        exoPlayer.setMaxVideoBitrate(maxVideoBitrate);
+    }
+
+    @Override
     public Listeners getListeners() {
         return listenersHolder;
     }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/mediasource/ExoPlayerTrackSelector.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/mediasource/ExoPlayerTrackSelector.java
@@ -80,4 +80,20 @@ public class ExoPlayerTrackSelector {
                 && trackGroups.get(groupIndex).length > 0
                 && trackInfo().getAdaptiveSupport(audioRendererIndex.get(), groupIndex, false) != RendererCapabilities.ADAPTIVE_NOT_SUPPORTED;
     }
+
+    void clearMaxVideoBitrate() {
+        setMaxVideoBitrateParameter(Integer.MAX_VALUE);
+    }
+
+    void setMaxVideoBitrate(int maxVideoBitrate) {
+        setMaxVideoBitrateParameter(maxVideoBitrate);
+    }
+
+    private void setMaxVideoBitrateParameter(int maxValue) {
+        trackSelector.setParameters(
+                trackSelector.buildUponParameters()
+                        .setMaxVideoBitrate(maxValue)
+                        .build()
+        );
+    }
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/mediasource/ExoPlayerVideoTrackSelector.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/mediasource/ExoPlayerVideoTrackSelector.java
@@ -87,4 +87,12 @@ public class ExoPlayerVideoTrackSelector {
     public boolean clearVideoTrack(RendererTypeRequester rendererTypeRequester) {
         return trackSelector.clearSelectionOverrideFor(VIDEO, rendererTypeRequester);
     }
+
+    public void clearMaxVideoBitrate() {
+        trackSelector.clearMaxVideoBitrate();
+    }
+
+    public void setMaxVideoBitrate(int maxVideoBitrate) {
+        trackSelector.setMaxVideoBitrate(maxVideoBitrate);
+    }
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerFacade.java
@@ -322,4 +322,14 @@ class AndroidMediaPlayerFacade {
         assertIsInPlaybackState();
         return volume;
     }
+
+    void clearMaxVideoBitrate() {
+        assertIsInPlaybackState();
+        NoPlayerLog.w("Tried to clear max video bitrate but has not been implemented for MediaPlayer.");
+    }
+
+    void setMaxVideoBitrate(int maxVideoBitrate) {
+        assertIsInPlaybackState();
+        NoPlayerLog.w("Tried to set max video bitrate but has not been implemented for MediaPlayer.");
+    }
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerFacade.java
@@ -26,6 +26,8 @@ import static com.novoda.noplayer.internal.mediaplayer.PlaybackStateChecker.Play
 import static com.novoda.noplayer.internal.mediaplayer.PlaybackStateChecker.PlaybackState.PAUSED;
 import static com.novoda.noplayer.internal.mediaplayer.PlaybackStateChecker.PlaybackState.PLAYING;
 
+// Not much we can do, wrapping MediaPlayer is a lot of work
+@SuppressWarnings("PMD.GodClass")
 class AndroidMediaPlayerFacade {
 
     private static final Map<String, String> NO_HEADERS = null;

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImpl.java
@@ -5,6 +5,7 @@ import android.net.Uri;
 import android.view.Surface;
 import android.view.SurfaceHolder;
 import android.view.View;
+
 import com.novoda.noplayer.Listeners;
 import com.novoda.noplayer.NoPlayer;
 import com.novoda.noplayer.Options;
@@ -364,6 +365,16 @@ class AndroidMediaPlayerImpl implements NoPlayer {
     @Override
     public List<PlayerSubtitleTrack> getSubtitleTracks() throws IllegalStateException {
         return mediaPlayer.getSubtitleTracks();
+    }
+
+    @Override
+    public void clearMaxVideoBitrate() {
+        mediaPlayer.clearMaxVideoBitrate();
+    }
+
+    @Override
+    public void setMaxVideoBitrate(int maxVideoBitrate) {
+        mediaPlayer.setMaxVideoBitrate(maxVideoBitrate);
     }
 
     @Override

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/mediasource/ExoPlayerVideoTrackSelectorTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/mediasource/ExoPlayerVideoTrackSelectorTest.java
@@ -11,9 +11,6 @@ import com.novoda.noplayer.internal.exoplayer.RendererTypeRequester;
 import com.novoda.noplayer.internal.utils.Optional;
 import com.novoda.noplayer.model.PlayerVideoTrack;
 
-import java.util.Arrays;
-import java.util.List;
-
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -21,6 +18,9 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
+
+import java.util.Arrays;
+import java.util.List;
 
 import static com.novoda.noplayer.internal.exoplayer.mediasource.VideoFormatFixture.aVideoFormat;
 import static org.fest.assertions.api.Assertions.assertThat;
@@ -116,6 +116,24 @@ public class ExoPlayerVideoTrackSelectorTest {
         Optional<PlayerVideoTrack> selectedVideoTrack = exoPlayerVideoTrackSelector.getSelectedVideoTrack(exoPlayer, rendererTypeRequester, ContentType.HLS);
 
         assertThat(selectedVideoTrack).isEqualTo(Optional.<PlayerVideoTrack>absent());
+    }
+
+    @Test
+    public void givenTrackSelector_whenClearMaxVideoBitrate_thenClearsMaxVideoBitrate() {
+        givenTrackSelectorContainsTracks();
+
+        exoPlayerVideoTrackSelector.clearMaxVideoBitrate();
+
+        verify(trackSelector).clearMaxVideoBitrate();
+    }
+
+    @Test
+    public void givenTrackSelector_whenSetMaxVideoBitrate1000000_thenSetsMaxVideoBitrate1000000() {
+        givenTrackSelectorContainsTracks();
+
+        exoPlayerVideoTrackSelector.setMaxVideoBitrate(1000000);
+
+        verify(trackSelector).setMaxVideoBitrate(1000000);
     }
 
     private void givenTrackSelectorContainsTracks() {

--- a/demo/src/main/res/layout/activity_main.xml
+++ b/demo/src/main/res/layout/activity_main.xml
@@ -33,6 +33,13 @@
         android:layout_height="wrap_content"
         android:text="@string/subtitle" />
 
+      <CheckBox
+          android:id="@+id/button_hd_selection"
+          style="?android:attr/buttonBarButtonStyle"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="@string/hd"/>
+
     </LinearLayout>
 
     <com.novoda.noplayer.NoPlayerView

--- a/demo/src/main/res/values/strings.xml
+++ b/demo/src/main/res/values/strings.xml
@@ -6,6 +6,7 @@
   <string name="video">Video</string>
   <string name="audio">Audio</string>
   <string name="subtitle">Subtitle</string>
+  <string name="hd">HD</string>
 
   <string name="content_description_play_pause">Play/pause</string>
 


### PR DESCRIPTION
## Problem

There might be the need to set a maximum video bitrate in order to manually limit the quality of the video in a forceful way (e.g. SD only), even if the manifest publishes higher quality representations.

## Solution

Use `DefaultTrackSelector`'s parameters to set a maximum video bitrate both when we `loadVideo` and at any moment during the playing of the video.

### Test(s) added 

Yes, just to make sure we delegate the setting and clearing of the maximum video bitrate.

### GIF

![2019-04-05-17-45-27](https://user-images.githubusercontent.com/1140238/55643457-1394b080-57cb-11e9-9ea0-cc78070710f0.gif)

### Paired with 

Checked for the new API with @Mecharyry 