### PR TITLE
NO-ADS/Skipping Events

### DIFF
--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
@@ -194,19 +194,22 @@ public class NoPlayerAdsLoader implements AdsLoader, Player.EventListener {
     @Override
     public void onPositionDiscontinuity(int reason) {
         Log.d(TAG, "onPositionDiscontinuity: " + reason);
-        if (reason == Player.DISCONTINUITY_REASON_AD_INSERTION && player != null && adPlaybackState != null) {
-            if (isPlayingAdvert()) {
-                notifyAdvertEnd(advertBreaks.get(adGroupIndex));
-                adPlaybackState = adPlaybackState.withPlayedAd(adGroupIndex, adIndexInGroup);
-                updateAdPlaybackState();
-                resetAdvertPosition();
-            }
+        if (reason != Player.DISCONTINUITY_REASON_AD_INSERTION || player == null || adPlaybackState == null) {
+            // We need all of the above to be able to respond to advert events.
+            return;
+        }
 
-            if (advertHasNotStarted()) {
-                adGroupIndex = player.getCurrentAdGroupIndex();
-                adIndexInGroup = player.getCurrentAdIndexInAdGroup();
-                notifyAdvertStart(advertBreaks.get(adGroupIndex));
-            }
+        if (isPlayingAdvert()) {
+            notifyAdvertEnd(advertBreaks.get(adGroupIndex));
+            adPlaybackState = adPlaybackState.withPlayedAd(adGroupIndex, adIndexInGroup);
+            updateAdPlaybackState();
+            resetAdvertPosition();
+        }
+
+        if (advertHasNotStarted()) {
+            adGroupIndex = player.getCurrentAdGroupIndex();
+            adIndexInGroup = player.getCurrentAdIndexInAdGroup();
+            notifyAdvertStart(advertBreaks.get(adGroupIndex));
         }
     }
 

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
@@ -24,7 +24,6 @@ import java.util.concurrent.TimeUnit;
 
 public class NoPlayerAdsLoader implements AdsLoader, Player.EventListener {
 
-    private static final String TAG = "Loader";
     private final AdvertsLoader loader;
     private final Handler handler;
 
@@ -39,7 +38,7 @@ public class NoPlayerAdsLoader implements AdsLoader, Player.EventListener {
 
     private NoPlayer.AdvertListener advertListener = NoOpAdvertListener.INSTANCE;
     private List<AdvertBreak> advertBreaks = Collections.emptyList();
-    private int adIndexInGroup = -1;     // Our source of truth.
+    private int adIndexInGroup = -1;
     private int adGroupIndex = -1;
 
     static NoPlayerAdsLoader create(AdvertsLoader loader) {

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
@@ -156,19 +156,18 @@ public class NoPlayerAdsLoader implements AdsLoader, Player.EventListener {
             return;
         }
 
-        adGroupIndex = player.getCurrentAdGroupIndex();
-        adIndexInGroup = player.getCurrentAdIndexInAdGroup();
-        long contentPosition = player.getContentPosition();
-
         if (reason == Player.TIMELINE_CHANGE_REASON_PREPARED && isPlayingAdvert()) {
+            long contentPosition = player.getContentPosition();
             if (contentPosition > 0) {
                 adPlaybackState = SkippedAdverts.from(contentPosition, advertBreaks, adPlaybackState);
                 updateAdPlaybackState();
                 return;
             }
-
-            notifyAdvertStart(advertBreaks.get(adGroupIndex));
         }
+
+        adGroupIndex = player.getCurrentAdGroupIndex();
+        adIndexInGroup = player.getCurrentAdIndexInAdGroup();
+        notifyAdvertStart(advertBreaks.get(adGroupIndex));
     }
 
     @Override

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
@@ -3,7 +3,6 @@ package com.novoda.noplayer.internal.exoplayer;
 import android.os.Handler;
 import android.os.Looper;
 import android.support.annotation.Nullable;
-import android.util.Log;
 
 import com.google.android.exoplayer2.C;
 import com.google.android.exoplayer2.Player;
@@ -158,8 +157,6 @@ public class NoPlayerAdsLoader implements AdsLoader, Player.EventListener {
             return;
         }
 
-        Log.d(TAG, "onTimelineChanged: advertIsPlaying: " + player.isPlayingAd());
-        Log.d(TAG, "onTimelineChanged: advertGroup: " + player.getCurrentAdGroupIndex() + " advert: " + player.getCurrentAdIndexInAdGroup());
         if (reason == Player.TIMELINE_CHANGE_REASON_PREPARED) {
             long contentPosition = player.getContentPosition();
             if (contentPosition > 0) {
@@ -182,18 +179,15 @@ public class NoPlayerAdsLoader implements AdsLoader, Player.EventListener {
 
     private void notifyAdvertStart(AdvertBreak advertBreak) {
         if (adIndexInGroup == 0) {
-            Log.d(TAG, "notifyAdvertBreakStart: ");
             advertListener.onAdvertBreakStart(advertBreak.advertBreakId());
         }
 
         Advert advert = advertBreak.adverts().get(adIndexInGroup);
         advertListener.onAdvertStart(advert.advertId());
-        Log.d(TAG, "notifyAdvertStart: ");
     }
 
     @Override
     public void onPositionDiscontinuity(int reason) {
-        Log.d(TAG, "onPositionDiscontinuity: " + reason);
         if (reason != Player.DISCONTINUITY_REASON_AD_INSERTION || player == null || adPlaybackState == null) {
             // We need all of the above to be able to respond to advert events.
             return;
@@ -218,12 +212,10 @@ public class NoPlayerAdsLoader implements AdsLoader, Player.EventListener {
     }
 
     private void notifyAdvertEnd(AdvertBreak advertBreak) {
-        Log.d(TAG, "notifyAdvertEnd: ");
         List<Advert> adverts = advertBreak.adverts();
         advertListener.onAdvertEnd(adverts.get(adIndexInGroup).advertId());
 
         if (adIndexInGroup == adverts.size() - 1) {
-            Log.d(TAG, "notifyAdvertBreakEnd: ");
             advertListener.onAdvertBreakEnd(advertBreak.advertBreakId());
         }
     }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
@@ -188,15 +188,20 @@ public class NoPlayerAdsLoader implements AdsLoader, Player.EventListener {
                 notifyAdvertEnd(advertBreaks.get(adGroupIndex));
                 adPlaybackState = adPlaybackState.withPlayedAd(adGroupIndex, adIndexInGroup);
                 updateAdPlaybackState();
+                resetAdvertPosition();
             }
 
-            adGroupIndex = player.getCurrentAdGroupIndex();
-            adIndexInGroup = player.getCurrentAdIndexInAdGroup();
-
-            if (isPlayingAdvert()) {
+            if (advertHasNotStarted()) {
+                adGroupIndex = player.getCurrentAdGroupIndex();
+                adIndexInGroup = player.getCurrentAdIndexInAdGroup();
                 notifyAdvertStart(advertBreaks.get(adGroupIndex));
             }
         }
+    }
+
+    private void resetAdvertPosition() {
+        adGroupIndex = -1;
+        adIndexInGroup = -1;
     }
 
     private boolean isPlayingAdvert() {
@@ -211,8 +216,6 @@ public class NoPlayerAdsLoader implements AdsLoader, Player.EventListener {
         if (adIndexInGroup == adverts.size() - 1) {
             Log.d(TAG, "notifyAdvertBreakEnd: ");
             advertListener.onAdvertBreakEnd(advertBreak.advertBreakId());
-            adGroupIndex = -1; // Reset on end of advert break.
-            adIndexInGroup = -1;
         }
     }
 

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
@@ -199,6 +199,7 @@ public class NoPlayerAdsLoader implements AdsLoader, Player.EventListener {
 
         if (adIndexInGroup == adverts.size() - 1) {
             advertListener.onAdvertBreakEnd(advertBreak.advertBreakId());
+            adGroupIndex = -1; // Reset on end of advert break.
             adIndexInGroup = -1;
         }
     }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
@@ -180,6 +180,17 @@ public class NoPlayerAdsLoader implements AdsLoader, Player.EventListener {
         return player.isPlayingAd() && (adGroupIndex == -1 || adIndexInGroup == -1);
     }
 
+    private void notifyAdvertStart(AdvertBreak advertBreak) {
+        if (adIndexInGroup == 0) {
+            Log.d(TAG, "notifyAdvertBreakStart: ");
+            advertListener.onAdvertBreakStart(advertBreak.advertBreakId());
+        }
+
+        Advert advert = advertBreak.adverts().get(adIndexInGroup);
+        advertListener.onAdvertStart(advert.advertId());
+        Log.d(TAG, "notifyAdvertStart: ");
+    }
+
     @Override
     public void onPositionDiscontinuity(int reason) {
         Log.d(TAG, "onPositionDiscontinuity: " + reason);
@@ -199,11 +210,6 @@ public class NoPlayerAdsLoader implements AdsLoader, Player.EventListener {
         }
     }
 
-    private void resetAdvertPosition() {
-        adGroupIndex = -1;
-        adIndexInGroup = -1;
-    }
-
     private boolean isPlayingAdvert() {
         return adGroupIndex != -1 && adIndexInGroup != -1;
     }
@@ -219,15 +225,9 @@ public class NoPlayerAdsLoader implements AdsLoader, Player.EventListener {
         }
     }
 
-    private void notifyAdvertStart(AdvertBreak advertBreak) {
-        if (adIndexInGroup == 0) {
-            Log.d(TAG, "notifyAdvertBreakStart: ");
-            advertListener.onAdvertBreakStart(advertBreak.advertBreakId());
-        }
-
-        Advert advert = advertBreak.adverts().get(adIndexInGroup);
-        advertListener.onAdvertStart(advert.advertId());
-        Log.d(TAG, "notifyAdvertStart: ");
+    private void resetAdvertPosition() {
+        adGroupIndex = -1;
+        adIndexInGroup = -1;
     }
 
     private enum NoOpAdvertListener implements NoPlayer.AdvertListener {


### PR DESCRIPTION
## Problem
It seems that when I introduced the #212 skipping adverts I failed to test all scenarios, it seems that some advert events are not emitted based on the skip position. 

## Solution
So it seems that when we enter `onTimelineChanged` for the `Player.TIMELINE_CHANGE_REASON_PREPARED` the player may know of an advert position even if it is technically incorrect because it is before the current time and we are about to skip it. If we perform a skip then the `player` position data for adverts is invalidated and it becomes `-1` until it determines the new advert position data. 

So first step was to split the `skipping` from the `start advert event` because the position data can be incorrect. 

Second step was to make the pairing between `start advert break` and `end advert break` more explicit:  
- When the positional data is missing we extract it from the `player` and cache it locally, triggering the advert break and advert start events. 
- `onPositionDiscontinuity` deals with advert start and end events, when the positional data is present we are at the end of the advert so we check the position and emit the advert break and advert events. 
- once we emit these we reset the position data to `-1`, this highlights we are ready for another  advert break start event.
- and it goes round and round.

### Screenshots

##### From Beginning 
Before | ![Screenshot 2019-04-08 at 16 39 43](https://user-images.githubusercontent.com/3380092/55738260-b2fdb180-5a1e-11e9-8c90-50d89bfbd937.png) |
| ------ | ----- | 
After| ![after_beginning](https://user-images.githubusercontent.com/3380092/55738261-b3964800-5a1e-11e9-83c0-575311523259.png)

##### From 29 seconds
Before | ![before_29_seconds](https://user-images.githubusercontent.com/3380092/55738374-e9d3c780-5a1e-11e9-912a-48c5c157faae.png)
--- | ---
After | ![after_29_seconds](https://user-images.githubusercontent.com/3380092/55738376-ea6c5e00-5a1e-11e9-82e8-791928557f61.png)

##### From 30 seconds
Here you can see an advert end event before the `AdvertBreakStart`

Before | ![before_30_seconds](https://user-images.githubusercontent.com/3380092/55738426-05d76900-5a1f-11e9-8eee-1214207ebd6d.png) 
--- | ---
After | ![after_30_seconds](https://user-images.githubusercontent.com/3380092/55738428-05d76900-5a1f-11e9-8286-0caf54ef8858.png)

### Paired with 
Nobody
