### PR TITLE
NO-ADS/Add callback for played ads

### DIFF
--- a/core/src/main/java/com/novoda/noplayer/NoPlayer.java
+++ b/core/src/main/java/com/novoda/noplayer/NoPlayer.java
@@ -326,6 +326,8 @@ public interface NoPlayer extends PlayerState {
         void onAdvertsDisabled();
 
         void onAdvertsEnabled(List<AdvertBreak> advertBreaks);
+
+        void onAdvertsSkipped(List<AdvertBreak> advertBreaks);
     }
 
     /**

--- a/core/src/main/java/com/novoda/noplayer/SimpleAdvertListener.java
+++ b/core/src/main/java/com/novoda/noplayer/SimpleAdvertListener.java
@@ -43,4 +43,9 @@ public class SimpleAdvertListener implements NoPlayer.AdvertListener {
     public void onAdvertsEnabled(List<AdvertBreak> advertBreaks) {
         // no-op
     }
+
+    @Override
+    public void onAdvertsSkipped(List<AdvertBreak> advertBreaks) {
+        // no op
+    }
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoOpAdvertListener.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoOpAdvertListener.java
@@ -48,4 +48,9 @@ enum NoOpAdvertListener implements NoPlayer.AdvertListener {
     public void onAdvertsEnabled(List<AdvertBreak> advertBreaks) {
         // no-op
     }
+
+    @Override
+    public void onAdvertsSkipped(List<AdvertBreak> advertBreaks) {
+        // no op
+    }
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
@@ -163,7 +163,7 @@ public class NoPlayerAdsLoader implements AdsLoader, Player.EventListener, Adver
         if (reason == Player.TIMELINE_CHANGE_REASON_PREPARED) {
             long contentPosition = player.getContentPosition();
             if (contentPosition > 0) {
-                PlayedAdverts playedAdverts = PlayedAdverts.markAllPastAdvertsAsPlayed(contentPosition, advertBreaks, this.adPlaybackState);
+                PlayedAdverts playedAdverts = PlayedAdverts.from(contentPosition, advertBreaks, this.adPlaybackState);
                 this.adPlaybackState = playedAdverts.adPlaybackState();
                 updateAdPlaybackState();
                 return;

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
@@ -163,7 +163,8 @@ public class NoPlayerAdsLoader implements AdsLoader, Player.EventListener, Adver
         if (reason == Player.TIMELINE_CHANGE_REASON_PREPARED) {
             long contentPosition = player.getContentPosition();
             if (contentPosition > 0) {
-                adPlaybackState = PlayedAdverts.markAllPastAdvertsAsPlayed(contentPosition, advertBreaks, adPlaybackState);
+                PlayedAdverts playedAdverts = PlayedAdverts.markAllPastAdvertsAsPlayed(contentPosition, advertBreaks, this.adPlaybackState);
+                this.adPlaybackState = playedAdverts.adPlaybackState();
                 updateAdPlaybackState();
                 return;
             }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
@@ -166,6 +166,7 @@ public class NoPlayerAdsLoader implements AdsLoader, Player.EventListener, Adver
                 PlayedAdverts playedAdverts = PlayedAdverts.from(contentPosition, advertBreaks, adPlaybackState);
                 this.adPlaybackState = playedAdverts.adPlaybackState();
                 updateAdPlaybackState();
+                advertListener.onAdvertsSkipped(playedAdverts.playedAdvertBreaks());
                 return;
             }
         }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
@@ -163,7 +163,7 @@ public class NoPlayerAdsLoader implements AdsLoader, Player.EventListener, Adver
         if (reason == Player.TIMELINE_CHANGE_REASON_PREPARED) {
             long contentPosition = player.getContentPosition();
             if (contentPosition > 0) {
-                PlayedAdverts playedAdverts = PlayedAdverts.from(contentPosition, advertBreaks, this.adPlaybackState);
+                PlayedAdverts playedAdverts = PlayedAdverts.from(contentPosition, advertBreaks, adPlaybackState);
                 this.adPlaybackState = playedAdverts.adPlaybackState();
                 updateAdPlaybackState();
                 return;

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/PlayedAdverts.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/PlayedAdverts.java
@@ -20,9 +20,9 @@ class PlayedAdverts {
      * @param currentPositionInMillis The position before which all adverts will transition from their current state to Played.
      * @param advertBreaks            The client representation of the adverts, our source of truth.
      * @param adPlaybackState         The {@link AdPlaybackState} to alter advert state on.
-     * @return The {@link AdPlaybackState} with the newly played states.
+     * @return The {@link PlayedAdverts} instance with the newly played states.
      */
-    static PlayedAdverts markAllPastAdvertsAsPlayed(long currentPositionInMillis, List<AdvertBreak> advertBreaks, AdPlaybackState adPlaybackState) {
+    static PlayedAdverts from(long currentPositionInMillis, List<AdvertBreak> advertBreaks, AdPlaybackState adPlaybackState) {
         AdPlaybackState adPlaybackStateWithPlayedAdGroups = adPlaybackState;
         List<AdvertBreak> playedAdvertBreaks = new ArrayList<>(advertBreaks.size());
         for (int advertBreakIndex = advertBreaks.size() - 1; advertBreakIndex >= 0; advertBreakIndex--) {

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/PlayedAdverts.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/PlayedAdverts.java
@@ -3,13 +3,14 @@ package com.novoda.noplayer.internal.exoplayer;
 import com.google.android.exoplayer2.source.ads.AdPlaybackState;
 import com.novoda.noplayer.AdvertBreak;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
-final class PlayedAdverts {
+class PlayedAdverts {
 
-    private PlayedAdverts() {
-        // Utility class.
-    }
+    private final AdPlaybackState adPlaybackState;
+    private final List<AdvertBreak> playedAdvertBreaks;
 
     /**
      * Transforms all adverts before the current player position to the Played state.
@@ -21,19 +22,33 @@ final class PlayedAdverts {
      * @param adPlaybackState         The {@link AdPlaybackState} to alter advert state on.
      * @return The {@link AdPlaybackState} with the newly played states.
      */
-    static AdPlaybackState markAllPastAdvertsAsPlayed(long currentPositionInMillis, List<AdvertBreak> advertBreaks, AdPlaybackState adPlaybackState) {
+    static PlayedAdverts markAllPastAdvertsAsPlayed(long currentPositionInMillis, List<AdvertBreak> advertBreaks, AdPlaybackState adPlaybackState) {
         AdPlaybackState adPlaybackStateWithPlayedAdGroups = adPlaybackState;
+        List<AdvertBreak> playedAdvertBreaks = new ArrayList<>(advertBreaks.size());
         for (int advertBreakIndex = advertBreaks.size() - 1; advertBreakIndex >= 0; advertBreakIndex--) {
             AdvertBreak advertBreak = advertBreaks.get(advertBreakIndex);
             if (advertBreak.startTimeInMillis() >= currentPositionInMillis) {
                 continue;
             }
-
+            playedAdvertBreaks.add(advertBreak);
             for (int advertIndex = 0; advertIndex < advertBreak.adverts().size(); advertIndex++) {
                 adPlaybackStateWithPlayedAdGroups = adPlaybackStateWithPlayedAdGroups.withPlayedAd(advertBreakIndex, advertIndex);
             }
         }
-        return adPlaybackStateWithPlayedAdGroups;
+        Collections.sort(playedAdvertBreaks, new AdvertBreakStartTimeComparator());
+        return new PlayedAdverts(adPlaybackStateWithPlayedAdGroups, playedAdvertBreaks);
     }
 
+    private PlayedAdverts(AdPlaybackState adPlaybackState, List<AdvertBreak> playedAdvertBreaks) {
+        this.adPlaybackState = adPlaybackState;
+        this.playedAdvertBreaks = playedAdvertBreaks;
+    }
+
+    public AdPlaybackState adPlaybackState() {
+        return adPlaybackState;
+    }
+
+    public List<AdvertBreak> playedAdvertBreaks() {
+        return playedAdvertBreaks;
+    }
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/PlayedAdverts.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/PlayedAdverts.java
@@ -7,7 +7,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-class PlayedAdverts {
+final class PlayedAdverts {
 
     private final AdPlaybackState adPlaybackState;
     private final List<AdvertBreak> playedAdvertBreaks;

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/PlayedAdverts.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/PlayedAdverts.java
@@ -31,7 +31,8 @@ class PlayedAdverts {
                 continue;
             }
             playedAdvertBreaks.add(advertBreak);
-            for (int advertIndex = 0; advertIndex < advertBreak.adverts().size(); advertIndex++) {
+            int advertCount = advertBreak.adverts().size();
+            for (int advertIndex = 0; advertIndex < advertCount; advertIndex++) {
                 adPlaybackStateWithPlayedAdGroups = adPlaybackStateWithPlayedAdGroups.withPlayedAd(advertBreakIndex, advertIndex);
             }
         }

--- a/core/src/main/java/com/novoda/noplayer/internal/listeners/AdvertListeners.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/listeners/AdvertListeners.java
@@ -79,4 +79,11 @@ class AdvertListeners implements NoPlayer.AdvertListener {
             listener.onAdvertsEnabled(advertBreaks);
         }
     }
+
+    @Override
+    public void onAdvertsSkipped(List<AdvertBreak> advertBreaks) {
+        for (NoPlayer.AdvertListener listener : listeners) {
+            listener.onAdvertsSkipped(advertBreaks);
+        }
+    }
 }

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/PlayedAdvertsTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/PlayedAdvertsTest.java
@@ -44,7 +44,7 @@ public class PlayedAdvertsTest {
 
     @Test
     public void doesNotMarkAsPlayed_whenCurrentPositionIsAtAdvertStartPosition() {
-        PlayedAdverts playedAdverts = PlayedAdverts.markAllPastAdvertsAsPlayed(THIRTY_SECONDS_IN_MILLIS, ADVERT_BREAKS, AD_PLAYBACK_STATE);
+        PlayedAdverts playedAdverts = PlayedAdverts.from(THIRTY_SECONDS_IN_MILLIS, ADVERT_BREAKS, AD_PLAYBACK_STATE);
         AdPlaybackState adPlaybackState = playedAdverts.adPlaybackState();
 
         assertThatGroupContains(adPlaybackState.adGroups[0], new int[]{AD_STATE_PLAYED});
@@ -55,7 +55,7 @@ public class PlayedAdvertsTest {
 
     @Test
     public void doesNotAddToPlayedAdvertBreaks_whenCurrentPositionIsAtAdvertStartPosition() {
-        PlayedAdverts playedAdverts = PlayedAdverts.markAllPastAdvertsAsPlayed(THIRTY_SECONDS_IN_MILLIS, ADVERT_BREAKS, AD_PLAYBACK_STATE);
+        PlayedAdverts playedAdverts = PlayedAdverts.from(THIRTY_SECONDS_IN_MILLIS, ADVERT_BREAKS, AD_PLAYBACK_STATE);
         List<AdvertBreak> playedAdvertBreaks = playedAdverts.playedAdvertBreaks();
 
         assertThat(playedAdvertBreaks).containsExactly(FIRST_ADVERT_BREAK, SECOND_ADVERT_BREAK);
@@ -63,7 +63,7 @@ public class PlayedAdvertsTest {
 
     @Test
     public void marksAdvertsPriorToCurrentPositionAsPlayed() {
-        PlayedAdverts playedAdverts = PlayedAdverts.markAllPastAdvertsAsPlayed(THIRTY_FIVE_SECONDS_IN_MILLIS, ADVERT_BREAKS, AD_PLAYBACK_STATE);
+        PlayedAdverts playedAdverts = PlayedAdverts.from(THIRTY_FIVE_SECONDS_IN_MILLIS, ADVERT_BREAKS, AD_PLAYBACK_STATE);
         AdPlaybackState adPlaybackState = playedAdverts.adPlaybackState();
 
         assertThatGroupContains(adPlaybackState.adGroups[0], new int[]{AD_STATE_PLAYED});
@@ -74,7 +74,7 @@ public class PlayedAdvertsTest {
 
     @Test
     public void addsAdvertBreaksPriorToCurrentPositionToPlayedAdvertBreaks() {
-        PlayedAdverts playedAdverts = PlayedAdverts.markAllPastAdvertsAsPlayed(THIRTY_FIVE_SECONDS_IN_MILLIS, ADVERT_BREAKS, AD_PLAYBACK_STATE);
+        PlayedAdverts playedAdverts = PlayedAdverts.from(THIRTY_FIVE_SECONDS_IN_MILLIS, ADVERT_BREAKS, AD_PLAYBACK_STATE);
         List<AdvertBreak> playedAdvertBreaks = playedAdverts.playedAdvertBreaks();
 
         assertThat(playedAdvertBreaks).containsExactly(FIRST_ADVERT_BREAK, SECOND_ADVERT_BREAK, THIRD_ADVERT_BREAK);
@@ -82,7 +82,7 @@ public class PlayedAdvertsTest {
 
     @Test
     public void marksNoAdvertsAsPlayed_whenPositionIsStart() {
-        PlayedAdverts playedAdverts = PlayedAdverts.markAllPastAdvertsAsPlayed(BEGINNING, ADVERT_BREAKS, AD_PLAYBACK_STATE);
+        PlayedAdverts playedAdverts = PlayedAdverts.from(BEGINNING, ADVERT_BREAKS, AD_PLAYBACK_STATE);
         AdPlaybackState adPlaybackState = playedAdverts.adPlaybackState();
 
         assertThatGroupContains(adPlaybackState.adGroups[0], new int[]{AD_STATE_AVAILABLE});
@@ -93,7 +93,7 @@ public class PlayedAdvertsTest {
 
     @Test
     public void addsNoAdvertBreaksToPlayedAdvertBreaks_whenPositionIsStart() {
-        PlayedAdverts playedAdverts = PlayedAdverts.markAllPastAdvertsAsPlayed(BEGINNING, ADVERT_BREAKS, AD_PLAYBACK_STATE);
+        PlayedAdverts playedAdverts = PlayedAdverts.from(BEGINNING, ADVERT_BREAKS, AD_PLAYBACK_STATE);
         List<AdvertBreak> playedAdvertBreaks = playedAdverts.playedAdvertBreaks();
 
         assertThat(playedAdvertBreaks).isEmpty();

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/PlayedAdvertsTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/PlayedAdvertsTest.java
@@ -3,10 +3,10 @@ package com.novoda.noplayer.internal.exoplayer;
 import com.google.android.exoplayer2.source.ads.AdPlaybackState;
 import com.novoda.noplayer.AdvertBreak;
 
+import org.junit.Test;
+
 import java.util.Arrays;
 import java.util.List;
-
-import org.junit.Test;
 
 import static com.google.android.exoplayer2.source.ads.AdPlaybackState.AD_STATE_AVAILABLE;
 import static com.google.android.exoplayer2.source.ads.AdPlaybackState.AD_STATE_PLAYED;
@@ -44,7 +44,8 @@ public class PlayedAdvertsTest {
 
     @Test
     public void doesNotMarkAsPlayed_whenCurrentPositionIsAtAdvertStartPosition() {
-        AdPlaybackState adPlaybackState = PlayedAdverts.markAllPastAdvertsAsPlayed(THIRTY_SECONDS_IN_MILLIS, ADVERT_BREAKS, AD_PLAYBACK_STATE);
+        PlayedAdverts playedAdverts = PlayedAdverts.markAllPastAdvertsAsPlayed(THIRTY_SECONDS_IN_MILLIS, ADVERT_BREAKS, AD_PLAYBACK_STATE);
+        AdPlaybackState adPlaybackState = playedAdverts.adPlaybackState();
 
         assertThatGroupContains(adPlaybackState.adGroups[0], new int[]{AD_STATE_PLAYED});
         assertThatGroupContains(adPlaybackState.adGroups[1], new int[]{AD_STATE_PLAYED});
@@ -53,8 +54,17 @@ public class PlayedAdvertsTest {
     }
 
     @Test
+    public void doesNotAddToPlayedAdvertBreaks_whenCurrentPositionIsAtAdvertStartPosition() {
+        PlayedAdverts playedAdverts = PlayedAdverts.markAllPastAdvertsAsPlayed(THIRTY_SECONDS_IN_MILLIS, ADVERT_BREAKS, AD_PLAYBACK_STATE);
+        List<AdvertBreak> playedAdvertBreaks = playedAdverts.playedAdvertBreaks();
+
+        assertThat(playedAdvertBreaks).containsExactly(FIRST_ADVERT_BREAK, SECOND_ADVERT_BREAK);
+    }
+
+    @Test
     public void marksAdvertsPriorToCurrentPositionAsPlayed() {
-        AdPlaybackState adPlaybackState = PlayedAdverts.markAllPastAdvertsAsPlayed(THIRTY_FIVE_SECONDS_IN_MILLIS, ADVERT_BREAKS, AD_PLAYBACK_STATE);
+        PlayedAdverts playedAdverts = PlayedAdverts.markAllPastAdvertsAsPlayed(THIRTY_FIVE_SECONDS_IN_MILLIS, ADVERT_BREAKS, AD_PLAYBACK_STATE);
+        AdPlaybackState adPlaybackState = playedAdverts.adPlaybackState();
 
         assertThatGroupContains(adPlaybackState.adGroups[0], new int[]{AD_STATE_PLAYED});
         assertThatGroupContains(adPlaybackState.adGroups[1], new int[]{AD_STATE_PLAYED});
@@ -63,13 +73,30 @@ public class PlayedAdvertsTest {
     }
 
     @Test
+    public void addsAdvertBreaksPriorToCurrentPositionToPlayedAdvertBreaks() {
+        PlayedAdverts playedAdverts = PlayedAdverts.markAllPastAdvertsAsPlayed(THIRTY_FIVE_SECONDS_IN_MILLIS, ADVERT_BREAKS, AD_PLAYBACK_STATE);
+        List<AdvertBreak> playedAdvertBreaks = playedAdverts.playedAdvertBreaks();
+
+        assertThat(playedAdvertBreaks).containsExactly(FIRST_ADVERT_BREAK, SECOND_ADVERT_BREAK, THIRD_ADVERT_BREAK);
+    }
+
+    @Test
     public void marksNoAdvertsAsPlayed_whenPositionIsStart() {
-        AdPlaybackState adPlaybackState = PlayedAdverts.markAllPastAdvertsAsPlayed(BEGINNING, ADVERT_BREAKS, AD_PLAYBACK_STATE);
+        PlayedAdverts playedAdverts = PlayedAdverts.markAllPastAdvertsAsPlayed(BEGINNING, ADVERT_BREAKS, AD_PLAYBACK_STATE);
+        AdPlaybackState adPlaybackState = playedAdverts.adPlaybackState();
 
         assertThatGroupContains(adPlaybackState.adGroups[0], new int[]{AD_STATE_AVAILABLE});
         assertThatGroupContains(adPlaybackState.adGroups[1], new int[]{AD_STATE_AVAILABLE});
         assertThatGroupContains(adPlaybackState.adGroups[2], new int[]{AD_STATE_AVAILABLE});
         assertThatGroupContains(adPlaybackState.adGroups[3], new int[]{AD_STATE_AVAILABLE});
+    }
+
+    @Test
+    public void addsNoAdvertBreaksToPlayedAdvertBreaks_whenPositionIsStart() {
+        PlayedAdverts playedAdverts = PlayedAdverts.markAllPastAdvertsAsPlayed(BEGINNING, ADVERT_BREAKS, AD_PLAYBACK_STATE);
+        List<AdvertBreak> playedAdvertBreaks = playedAdverts.playedAdvertBreaks();
+
+        assertThat(playedAdvertBreaks).isEmpty();
     }
 
     private void assertThatGroupContains(AdPlaybackState.AdGroup adGroup, int[] states) {


### PR DESCRIPTION
## Problem

We weren't notifying about ad breaks that were skipped due to playback starting at a different position other than 0.

## Solution

This adds a callback that's called after the `AdPlaybackState` is updated with the played ads. This just expands on the existing logic that was there already in the `PlayedAdverts` class and uses the same approach we used for `AdvertPlaybackState`.

I wasn't sure whether to call the method `onAdvertsSkipped` or `onAdvertsPlayed`. Alternatively we could also have a method `onAdvertBreakPlayed` (singular) that could be called for both when advert break ends and for each of the ones that are marked as played at the beginning.

### Test(s) added 

updated tests for `PlayedAdverts`

### Screenshots

| Before | After |
| ------ | ----- |
| gif/png _before_ | gif/png _after_ |

### Paired with 

nobody
