### PR TITLE
Downgrade Gradle version 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 allprojects {
-    version = '4.5.4'
+    version = '4.5.4-local'
 }
 
 def teamPropsFile(propsFile) {
@@ -14,7 +14,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.0'
+        classpath 'com.android.tools.build:gradle:3.3.1'
         classpath 'com.novoda:bintray-release:0.9'
         classpath 'com.novoda:gradle-static-analysis-plugin:0.8.1'
         classpath 'com.novoda:gradle-build-properties-plugin:0.4.1'
@@ -33,7 +33,7 @@ subprojects {
 
 wrapper {
     distributionType Wrapper.DistributionType.ALL
-    gradleVersion '5.4'
+    gradleVersion '5.0'
 }
 
 allprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 allprojects {
-    version = '4.5.4-local'
+    version = '4.5.4'
 }
 
 def teamPropsFile(propsFile) {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Thu Apr 25 12:10:18 CEST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.0-all.zip


### PR DESCRIPTION
## Problem

Updating to latest Gradle version broke the publishing of artifacts due to incompatible `bintray-release` plugin (it will be updated soon).

## Solution

In the meantime we downgrade the Gradle version to the previous working version.

### Test(s) added 

only build files changes

### Paired with 

nobody
