### PR TITLE
Update snapshot releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,19 +79,19 @@ compileOptions {
 
 ## Snapshots
 
-[![CI status](https://ci.novoda.com/buildStatus/icon?job=no-player-snapshot)](https://ci.novoda.com/job/no-player-snapshot/lastBuild/console) [![Download from Bintray](https://api.bintray.com/packages/novoda/snapshots/no-player/images/download.svg)](https://bintray.com/novoda/snapshots/no-player/_latestVersion)
+[![CI status](https://ci.novoda.com/buildStatus/icon?job=no-player-snapshot)](https://ci.novoda.com/job/no-player-snapshot/lastBuild/console) [![Download from Bintray](https://api.bintray.com/packages/novoda-oss/snapshots/no-player/images/download.svg)](https://bintray.com/novoda-oss/snapshots/no-player/_latestVersion)
 
-Snapshot builds from [`develop`](https://github.com/novoda/no-player/compare/master...develop) are automatically deployed to a [repository](https://bintray.com/novoda/snapshots/no-player/_latestVersion) that is not synced with JCenter.
+Snapshot builds from [`develop`](https://github.com/novoda/no-player/compare/master...develop) are automatically deployed to a [repository](https://bintray.com/novoda-oss/snapshots/no-player/_latestVersion) that is not synced with JCenter.
 To consume a snapshot build add an additional maven repo as follows:
 ```
 repositories {
     maven {
-        url 'https://novoda.bintray.com/snapshots'
+        url 'https://dl.bintray.com/novoda-oss/snapshots'
     }
 }
 ```
 
-You can find the latest snapshot version following this [link](https://bintray.com/novoda/snapshots/no-player/_latestVersion).
+You can find the latest snapshot version following this [link](https://bintray.com/novoda-oss/snapshots/no-player/_latestVersion).
 
 ## Contributing
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -26,11 +26,11 @@ buildProperties {
         def generateVersion = {
             boolean isSnapshot = cli['bintraySnapshot'].or(false).boolean
             if (isSnapshot) {
-                return "SNAPSHOT-${System.getenv('BUILD_NUMBER') ?: 'LOCAL'}";
+                return "DEVELOP-${System.getenv('BUILD_NUMBER') ?: 'LOCAL'}"
             }
             boolean isExperimental = cli['bintrayExperimental'].or(false).boolean
             if (isExperimental) {
-                return "EXPERIMENTAL-${System.getenv('BUILD_NUMBER') ?: 'LOCAL'}";
+                return "EXPERIMENTAL-${System.getenv('BUILD_NUMBER') ?: 'LOCAL'}"
             }
             return version
         }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -11,15 +11,16 @@ buildProperties {
         def bintrayCredentials = {
             boolean isDryRun = cli['dryRun'].or(true).boolean
             return isDryRun ?
-                    ['bintrayRepo': 'n/a', 'bintrayUser': 'n/a', 'bintrayKey': 'n/a'] :
+                    ['bintrayOrg': 'n/a', 'bintrayRepo': 'n/a', 'bintrayUser': 'n/a', 'bintrayKey': 'n/a'] :
                     new File("${System.getenv('BINTRAY_PROPERTIES')}")
         }
         using(bintrayCredentials()).or(cli)
         description = '''This should contain the following properties:
-                       | - bintrayRepo: name of the repo of the organisation to deploy the artifacts to
-                       | - bintrayUser: name of the account used to deploy the artifacts
-                       | - bintrayKey: API key of the account used to deploy the artifacts
-        '''.stripMargin()
+                        - bintrayOrg: name of the Bintray organisation to deploy the artifacts to
+                        - bintrayRepo: name of the repo of the organisation to deploy the artifacts to
+                        - bintrayUser: name of the account used to deploy the artifacts
+                        - bintrayKey: API key of the account used to deploy the artifacts
+        '''.stripIndent()
     }
     publish {
         def generateVersion = {
@@ -69,7 +70,7 @@ dependencies {
 }
 
 publish {
-    userOrg = 'novoda-oss'
+    userOrg = buildProperties.publish['bintrayOrg'].string
     repoName = buildProperties.publish['bintrayRepo'].string
     groupId = 'com.novoda'
     artifactId = 'no-player'


### PR DESCRIPTION
## Problem

We are trying to migrate all our open source libraries to be hosted on a new Bintray account. The first step is to migrate the release script for the snapshots in order to use: https://bintray.com/novoda-oss/snapshots
A previous attempt at doing this (https://github.com/novoda/no-player/commit/1f22ae6a4647164466f1f236914123dfdb06e293) left the release of snapshots broken.

## Solution

Updated the release configuration to receive an additional `bintrayOrg`as build property. This value is provided to the CI job via a secret file containing all the Bintray-related config parameters, as per description in the [build script](https://github.com/novoda/no-player/blob/a8c0915c7e8d1785b46cd4ea2dd114909aa3997a/core/build.gradle#L18-L22):
```
- bintrayOrg: name of the Bintray organisation to deploy the artifacts to
- bintrayRepo: name of the repo of the organisation to deploy the artifacts to
- bintrayUser: name of the account used to deploy the artifacts
- bintrayKey: API key of the account used to deploy the artifacts
```

As part of the migration we had also to use a different naming pattern for snapshot builds, as the new account doesn't support artifact versions with `SNAPSHOT` in them.

### Test(s) added 

No tests added. Updated README to point to new snapshot repo. Once this is merged we should see a new snapshot linked in the README.

### Screenshots

### Paired with 

Nobody
