### PR TITLE
Use bintray-release plugin 0.9.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,14 +11,11 @@ buildscript {
     repositories {
         google()
         jcenter()
-        maven {
-            url 'https://dl.bintray.com/novoda-oss/snapshots'
-        }
     }
 
     dependencies {
         classpath 'com.android.tools.build:gradle:3.4.0'
-        classpath 'com.novoda:bintray-release:develop-37'
+        classpath 'com.novoda:bintray-release:0.9.1'
         classpath 'com.novoda:gradle-static-analysis-plugin:0.8.1'
         classpath 'com.novoda:gradle-build-properties-plugin:0.4.1'
         classpath "com.github.ben-manes:gradle-versions-plugin:0.21.0"


### PR DESCRIPTION
## Problem

In order to use the latest Gradle version (5.4.1) along with the latest Android Gradle Plugin version (3.4.0) we had to use a snapshot build of the `bintray-release` plugin because we were facing some issues with syncing the package upstream to JCenter.

## Solution

JFrog support fixed the issue with the sync upstream. We can now use the latest version of bintray-release plugin from JCenter, [`0.9.1`](https://jcenter.bintray.com/com/novoda/bintray-release/0.9.1/).

### Test(s) added 

No test needed, just checking whether the CI is happy is enough to validate the change.

### Paired with 

Nobody
