### PR TITLE
NO-ADS/Update condition of isPlayingAdvert

### DIFF
--- a/core/src/main/java/com/novoda/noplayer/PlayerState.java
+++ b/core/src/main/java/com/novoda/noplayer/PlayerState.java
@@ -2,23 +2,92 @@ package com.novoda.noplayer;
 
 public interface PlayerState {
 
+    /**
+     * Returns {@code true} after {@link NoPlayer#play()} is called.
+     *
+     * @return true if player is playing or buffering content.
+     */
     boolean isPlaying();
 
+    /**
+     * Returns {@code true} when player is prepared to start playing and adverts are loaded
+     * (see {@link PlayerBuilder#withAdverts(AdvertsLoader)}.
+     *
+     * @return true when player is prepared to play adverts.
+     */
     boolean isSetToPlayAdvert();
 
+    /**
+     * Returns {@code true} when player is prepared to start playing content.
+     *
+     * @return true when player is prepared to play content.
+     */
     boolean isSetToPlayContent();
 
+    /**
+     * Width of the video.
+     * <p>
+     * To be notified when the size changes, use {@link NoPlayer.VideoSizeChangedListener}.
+     *
+     * @return video width in pixels.
+     */
     int videoWidth();
 
+    /**
+     * Height of the video.
+     * <p>
+     * To be notified when the size changes, use {@link NoPlayer.VideoSizeChangedListener}.
+     *
+     * @return video height in pixels.
+     */
     int videoHeight();
 
+    /**
+     * Position in an advert break that is being played in milliseconds.
+     * <p>
+     * If the advert break contains multiple adverts then the durations of played adverts will be accumulated
+     * with the progress of the advert that is being played.
+     *
+     * @return position in advert break or 0 if the player is not playing an advert.
+     */
     long positionInAdvertBreakInMillis();
 
+    /**
+     * Duration of an advert break that is being played in milliseconds.
+     * <p>
+     * Consists of accumulated lengths of all adverts in the advert break.
+     *
+     * @return duration of advert break or 0 if the player is not playing an advert.
+     */
     long advertBreakDurationInMillis();
 
+    /**
+     * Position in the video that is being played in milliseconds.
+     * <p>
+     * If the player is playing an advert then this value will be a position inside a single advert.
+     * To get the position in the advert break use {@link #positionInAdvertBreakInMillis()}.
+     *
+     * @return position in media that is being played.
+     */
     long playheadPositionInMillis();
 
+    /**
+     * Duration of the video that is being played in milliseconds.
+     * <p>
+     * If the player is playing an advert then this value will be a duration of a single advert.
+     * To get the duration of the whole advert break use {@link #advertBreakDurationInMillis()}.
+     *
+     * @return duration of media that is being played.
+     */
     long mediaDurationInMillis();
 
+    /**
+     * Buffered percentage of the video that is being played.
+     * <p>
+     * If the player is playing an advert break then this value will represent a buffer of each individual advert
+     * in the advert break and not the whole advert break.
+     *
+     * @return percentage value between 0 and 100.
+     */
     int bufferPercentage();
 }

--- a/core/src/main/java/com/novoda/noplayer/PlayerState.java
+++ b/core/src/main/java/com/novoda/noplayer/PlayerState.java
@@ -4,9 +4,9 @@ public interface PlayerState {
 
     boolean isPlaying();
 
-    boolean isPlayingAdvert();
+    boolean isSetToPlayAdvert();
 
-    boolean isPlayingContent();
+    boolean isSetToPlayContent();
 
     int videoWidth();
 

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
@@ -70,12 +70,12 @@ class ExoPlayerFacade {
         return exoPlayer != null && exoPlayer.getPlayWhenReady();
     }
 
-    boolean isPlayingAdvert() {
-        return isPlaying() && exoPlayer.isPlayingAd();
+    boolean isSetToPlayAdvert() {
+        return exoPlayer != null && exoPlayer.isPlayingAd();
     }
 
-    boolean isPlayingContent() {
-        return isPlaying() && !exoPlayer.isPlayingAd();
+    boolean isSetToPlayContent() {
+        return exoPlayer != null && !isSetToPlayAdvert();
     }
 
     long mediaDurationInMillis() throws IllegalStateException {
@@ -91,7 +91,7 @@ class ExoPlayerFacade {
     long advertBreakDurationInMillis() throws IllegalStateException {
         assertVideoLoaded();
         Timeline currentTimeline = exoPlayer.getCurrentTimeline();
-        if (isPlayingAdvert() && adsLoader.isPresent() && currentTimeline instanceof SinglePeriodAdTimeline) {
+        if (isSetToPlayAdvert() && adsLoader.isPresent() && currentTimeline instanceof SinglePeriodAdTimeline) {
             SinglePeriodAdTimeline adTimeline = (SinglePeriodAdTimeline) currentTimeline;
             Timeline.Period period = adTimeline.getPeriod(0, new Timeline.Period());
 
@@ -108,7 +108,7 @@ class ExoPlayerFacade {
     long positionInAdvertBreakInMillis() throws IllegalStateException {
         assertVideoLoaded();
         Timeline currentTimeline = exoPlayer.getCurrentTimeline();
-        if (isPlayingAdvert() && adsLoader.isPresent() && currentTimeline instanceof SinglePeriodAdTimeline) {
+        if (isSetToPlayAdvert() && adsLoader.isPresent() && currentTimeline instanceof SinglePeriodAdTimeline) {
             SinglePeriodAdTimeline adTimeline = (SinglePeriodAdTimeline) currentTimeline;
             Timeline.Period period = adTimeline.getPeriod(0, new Timeline.Period());
 

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImpl.java
@@ -99,13 +99,13 @@ class ExoPlayerTwoImpl implements NoPlayer {
     }
 
     @Override
-    public boolean isPlayingAdvert() {
-        return exoPlayer.isPlayingAdvert();
+    public boolean isSetToPlayAdvert() {
+        return exoPlayer.isSetToPlayAdvert();
     }
 
     @Override
-    public boolean isPlayingContent() {
-        return exoPlayer.isPlayingContent();
+    public boolean isSetToPlayContent() {
+        return exoPlayer.isSetToPlayContent();
     }
 
     @Override

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImpl.java
@@ -210,12 +210,12 @@ class AndroidMediaPlayerImpl implements NoPlayer {
     }
 
     @Override
-    public boolean isPlayingAdvert() {
+    public boolean isSetToPlayAdvert() {
         return false;
     }
 
     @Override
-    public boolean isPlayingContent() {
+    public boolean isSetToPlayContent() {
         return mediaPlayer.isPlaying();
     }
 

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacadeTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacadeTest.java
@@ -4,7 +4,6 @@ import android.net.Uri;
 import android.view.SurfaceHolder;
 import android.view.SurfaceView;
 import android.view.TextureView;
-
 import com.google.android.exoplayer2.C;
 import com.google.android.exoplayer2.Player;
 import com.google.android.exoplayer2.SimpleExoPlayer;
@@ -34,10 +33,6 @@ import com.novoda.noplayer.model.PlayerAudioTrackFixture;
 import com.novoda.noplayer.model.PlayerSubtitleTrack;
 import com.novoda.noplayer.model.PlayerVideoTrack;
 import com.novoda.noplayer.model.PlayerVideoTrackFixture;
-
-import java.util.Collections;
-import java.util.List;
-
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -48,8 +43,10 @@ import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
-
 import utils.ExceptionMatcher;
+
+import java.util.Collections;
+import java.util.List;
 
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -277,17 +274,17 @@ public class ExoPlayerFacadeTest {
         }
 
         @Test
-        public void whenQueryingIsPlayingAdvert_thenReturnsFalse() {
+        public void whenQueryingIsSetToPlayAdvert_thenReturnsFalse() {
 
-            boolean isPlaying = facade.isPlayingAdvert();
+            boolean isPlaying = facade.isSetToPlayAdvert();
 
             assertThat(isPlaying).isFalse();
         }
 
         @Test
-        public void whenQueryingisPlayingContent_thenReturnsFalse() {
+        public void whenQueryingIsSetToPlayContent_thenReturnsFalse() {
 
-            boolean isPlaying = facade.isPlayingContent();
+            boolean isPlaying = facade.isSetToPlayContent();
 
             assertThat(isPlaying).isFalse();
         }
@@ -457,41 +454,37 @@ public class ExoPlayerFacadeTest {
         }
 
         @Test
-        public void givenExoPlayerIsReadyToPlayAndIsPlayingAd_whenQueryingIsPlayingAdvert_thenReturnsTrue() {
-            given(exoPlayer.getPlayWhenReady()).willReturn(IS_PLAYING);
+        public void givenExoPlayerIsPlayingAd_whenQueryingIsSetToPlayAdvert_thenReturnsTrue() {
             given(exoPlayer.isPlayingAd()).willReturn(IS_PLAYING);
 
-            boolean isPlaying = facade.isPlayingAdvert();
+            boolean isPlaying = facade.isSetToPlayAdvert();
 
             assertThat(isPlaying).isTrue();
         }
 
         @Test
-        public void givenExoPlayerIsReadyToPlayAndIsNotPlayingAd_whenQueryingIsPlayingAdvert_thenReturnsFalse() {
-            given(exoPlayer.getPlayWhenReady()).willReturn(IS_PLAYING);
+        public void givenExoPlayerIsNotPlayingAd_whenQueryingIsSetToPlayAdvert_thenReturnsFalse() {
             given(exoPlayer.isPlayingAd()).willReturn(IS_NOT_PLAYING);
 
-            boolean isPlaying = facade.isPlayingAdvert();
+            boolean isPlaying = facade.isSetToPlayAdvert();
 
             assertThat(isPlaying).isFalse();
         }
 
         @Test
-        public void givenExoPlayerIsReadyToPlayAndIsPlayingAd_whenQueryingIsPlayingContent_thenReturnsFalse() {
-            given(exoPlayer.getPlayWhenReady()).willReturn(IS_PLAYING);
+        public void givenExoPlayerIsPlayingAd_whenQueryingIsSetToPlayContent_thenReturnsFalse() {
             given(exoPlayer.isPlayingAd()).willReturn(IS_PLAYING);
 
-            boolean isPlaying = facade.isPlayingContent();
+            boolean isPlaying = facade.isSetToPlayContent();
 
             assertThat(isPlaying).isFalse();
         }
 
         @Test
-        public void givenExoPlayerIsReadyToPlayAndIsNotPlayingAd_whenQueryingIsPlayingContent_thenReturnsTrue() {
-            given(exoPlayer.getPlayWhenReady()).willReturn(IS_PLAYING);
+        public void givenExoPlayerIsNotPlayingAd_whenQueryingIsSetToPlayContent_thenReturnsTrue() {
             given(exoPlayer.isPlayingAd()).willReturn(IS_NOT_PLAYING);
 
-            boolean isPlaying = facade.isPlayingContent();
+            boolean isPlaying = facade.isSetToPlayContent();
 
             assertThat(isPlaying).isTrue();
         }


### PR DESCRIPTION
## Problem

`isPlayingAdvert` and `isPlayingContent` methods were only returning the correct value when the player was already playing. That made it impossible to know what is the player about to play when we get the callback in `PreparedListener.onPrepared()`.

## Solution

I removed the `isPlaying` check from `isPlayingContent` and `isPlayingAdvert` in `ExoPlayerFacade` since ExoPlayer already returns the correct value of what it's about to play in `isPlayingAd` even when it's not playing yet.

Then I had to change the names of the methods since it wasn't true anymore that 
`isPlaying() == isPlayingAdvert() || isPlayingContent()`.

And since I was modifying the `PlayerState` I decided to add some missing javadoc (I was not forced to it by @Mecharyry at all, it was entirely my own decision).

### Test(s) added 

updated existing tests of the facade

### Screenshots
no UI changes

### Paired with 

nobody
