### PR TITLE
Advert Error prevents content playing

### DIFF
--- a/core/src/main/java/com/novoda/noplayer/AdvertsLoader.java
+++ b/core/src/main/java/com/novoda/noplayer/AdvertsLoader.java
@@ -16,7 +16,7 @@ public interface AdvertsLoader {
     interface Callback {
         void onAdvertsLoaded(List<AdvertBreak> advertBreaks);
 
-        void onAdvertsError(String message);
+        void onAdvertsError(Exception cause);
     }
 
     interface Cancellable {

--- a/core/src/main/java/com/novoda/noplayer/NoPlayer.java
+++ b/core/src/main/java/com/novoda/noplayer/NoPlayer.java
@@ -312,7 +312,7 @@ public interface NoPlayer extends PlayerState {
 
     interface AdvertListener {
 
-        void onAdvertsLoadError(String message);
+        void onAdvertsLoadError(Exception cause);
 
         void onAdvertsLoaded(List<AdvertBreak> advertBreaks);
 

--- a/core/src/main/java/com/novoda/noplayer/NoPlayer.java
+++ b/core/src/main/java/com/novoda/noplayer/NoPlayer.java
@@ -11,6 +11,7 @@ import com.novoda.noplayer.model.PlayerSubtitleTrack;
 import com.novoda.noplayer.model.PlayerVideoTrack;
 import com.novoda.noplayer.model.Timeout;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
@@ -311,11 +312,15 @@ public interface NoPlayer extends PlayerState {
 
     interface AdvertListener {
 
+        void onAdvertsLoadError(String message);
+
         void onAdvertsLoaded(List<AdvertBreak> advertBreaks);
 
         void onAdvertBreakStart(AdvertBreak advertBreak);
 
         void onAdvertBreakEnd(AdvertBreak advertBreak);
+
+        void onAdvertPrepareError(Advert advert, IOException failedWith);
 
         void onAdvertStart(Advert advert);
 
@@ -328,6 +333,7 @@ public interface NoPlayer extends PlayerState {
         void onAdvertsEnabled(List<AdvertBreak> advertBreaks);
 
         void onAdvertsSkipped(List<AdvertBreak> advertBreaks);
+
     }
 
     /**

--- a/core/src/main/java/com/novoda/noplayer/SimpleAdvertListener.java
+++ b/core/src/main/java/com/novoda/noplayer/SimpleAdvertListener.java
@@ -1,8 +1,14 @@
 package com.novoda.noplayer;
 
+import java.io.IOException;
 import java.util.List;
 
 public class SimpleAdvertListener implements NoPlayer.AdvertListener {
+
+    @Override
+    public void onAdvertsLoadError(String message) {
+        // no-op
+    }
 
     @Override
     public void onAdvertsLoaded(List<AdvertBreak> advertBreaks) {
@@ -16,6 +22,11 @@ public class SimpleAdvertListener implements NoPlayer.AdvertListener {
 
     @Override
     public void onAdvertBreakEnd(AdvertBreak advertBreak) {
+        // no-op
+    }
+
+    @Override
+    public void onAdvertPrepareError(Advert advert, IOException failedWith) {
         // no-op
     }
 

--- a/core/src/main/java/com/novoda/noplayer/SimpleAdvertListener.java
+++ b/core/src/main/java/com/novoda/noplayer/SimpleAdvertListener.java
@@ -6,7 +6,7 @@ import java.util.List;
 public class SimpleAdvertListener implements NoPlayer.AdvertListener {
 
     @Override
-    public void onAdvertsLoadError(String message) {
+    public void onAdvertsLoadError(Exception cause) {
         // no-op
     }
 

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoOpAdvertListener.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoOpAdvertListener.java
@@ -4,10 +4,16 @@ import com.novoda.noplayer.Advert;
 import com.novoda.noplayer.AdvertBreak;
 import com.novoda.noplayer.NoPlayer;
 
+import java.io.IOException;
 import java.util.List;
 
 enum NoOpAdvertListener implements NoPlayer.AdvertListener {
     INSTANCE;
+
+    @Override
+    public void onAdvertsLoadError(String message) {
+        // no-op
+    }
 
     @Override
     public void onAdvertsLoaded(List<AdvertBreak> advertBreaks) {
@@ -21,6 +27,11 @@ enum NoOpAdvertListener implements NoPlayer.AdvertListener {
 
     @Override
     public void onAdvertBreakEnd(AdvertBreak advertBreak) {
+        // no-op
+    }
+
+    @Override
+    public void onAdvertPrepareError(Advert advert, IOException failedWith) {
         // no-op
     }
 

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoOpAdvertListener.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoOpAdvertListener.java
@@ -11,7 +11,7 @@ enum NoOpAdvertListener implements NoPlayer.AdvertListener {
     INSTANCE;
 
     @Override
-    public void onAdvertsLoadError(String message) {
+    public void onAdvertsLoadError(Exception cause) {
         // no-op
     }
 

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
@@ -94,14 +94,14 @@ public class NoPlayerAdsLoader implements AdsLoader, Player.EventListener, Adver
 
         @Override
         public void onAdvertsError(final Exception cause) {
+            loadingAds = null;
+            advertBreaks = Collections.emptyList();
+            adPlaybackState = new AdPlaybackState();
+
             handler.post(new Runnable() {
                 @Override
                 public void run() {
-                    loadingAds = null;
-
-                    adPlaybackState = new AdPlaybackState();
                     updateAdPlaybackState();
-
                     advertListener.onAdvertsLoadError(cause);
                 }
             });

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
@@ -93,10 +93,18 @@ public class NoPlayerAdsLoader implements AdsLoader, Player.EventListener, Adver
         }
 
         @Override
-        public void onAdvertsError(String message) {
-            loadingAds = null;
-            advertListener.onAdvertsLoadError(message);
-            eventListener.onAdPlaybackState(new AdPlaybackState());
+        public void onAdvertsError(final Exception cause) {
+            handler.post(new Runnable() {
+                @Override
+                public void run() {
+                    loadingAds = null;
+
+                    adPlaybackState = new AdPlaybackState();
+                    updateAdPlaybackState();
+
+                    advertListener.onAdvertsLoadError(cause);
+                }
+            });
         }
     };
 

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
@@ -95,7 +95,8 @@ public class NoPlayerAdsLoader implements AdsLoader, Player.EventListener, Adver
         @Override
         public void onAdvertsError(String message) {
             loadingAds = null;
-            eventListener.onAdLoadError(null, null);
+            advertListener.onAdvertsLoadError(message);
+            eventListener.onAdPlaybackState(new AdPlaybackState());
         }
     };
 
@@ -150,6 +151,10 @@ public class NoPlayerAdsLoader implements AdsLoader, Player.EventListener, Adver
     public void handlePrepareError(int adGroupIndex, int adIndexInAdGroup, IOException exception) {
         if (adPlaybackState != null) {
             adPlaybackState = adPlaybackState.withAdLoadError(adGroupIndex, adIndexInAdGroup);
+
+            AdvertBreak advertBreak = advertBreaks.get(adGroupIndex);
+            Advert advert = advertBreak.adverts().get(adIndexInAdGroup);
+            advertListener.onAdvertPrepareError(advert, exception);
         }
     }
 

--- a/core/src/main/java/com/novoda/noplayer/internal/listeners/AdvertListeners.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/listeners/AdvertListeners.java
@@ -4,6 +4,7 @@ import com.novoda.noplayer.Advert;
 import com.novoda.noplayer.AdvertBreak;
 import com.novoda.noplayer.NoPlayer;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
@@ -25,6 +26,13 @@ class AdvertListeners implements NoPlayer.AdvertListener {
     }
 
     @Override
+    public void onAdvertsLoadError(String message) {
+        for (NoPlayer.AdvertListener listener : listeners) {
+            listener.onAdvertsLoadError(message);
+        }
+    }
+
+    @Override
     public void onAdvertsLoaded(List<AdvertBreak> advertBreaks) {
         for (NoPlayer.AdvertListener listener : listeners) {
             listener.onAdvertsLoaded(advertBreaks);
@@ -42,6 +50,13 @@ class AdvertListeners implements NoPlayer.AdvertListener {
     public void onAdvertBreakEnd(AdvertBreak advertBreak) {
         for (NoPlayer.AdvertListener listener : listeners) {
             listener.onAdvertBreakEnd(advertBreak);
+        }
+    }
+
+    @Override
+    public void onAdvertPrepareError(Advert advert, IOException failedWith) {
+        for (NoPlayer.AdvertListener listener : listeners) {
+            listener.onAdvertPrepareError(advert, failedWith);
         }
     }
 

--- a/core/src/main/java/com/novoda/noplayer/internal/listeners/AdvertListeners.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/listeners/AdvertListeners.java
@@ -26,9 +26,9 @@ class AdvertListeners implements NoPlayer.AdvertListener {
     }
 
     @Override
-    public void onAdvertsLoadError(String message) {
+    public void onAdvertsLoadError(Exception cause) {
         for (NoPlayer.AdvertListener listener : listeners) {
-            listener.onAdvertsLoadError(message);
+            listener.onAdvertsLoadError(cause);
         }
     }
 


### PR DESCRIPTION
## Problem
In the event that we receive an error when loading adverts we want to continue playback rather than failing altogether. This issue occurs because the `AdsMediaSource` will not load anything until an `AdPlaybackState` is passed to it. 

## Solution
When an error occurs during loading of adverts emit the error to `NoPlayer.AdvertListener.onAdvertsLoadError(Exception)` and update the `AdPlaybackState`, the latter of which will force content to begin playback. 

In the event that a prepare error occurs, this is when the advert is preparing for playback, forward the advert and any associated exception to `NoPlayer.AdvertListener.onAdvertPrepareError(Advert, IOException)`.

**But Ryan couldn't you just use the `AdsLoader.EventListener` from `exo-player`?** 
Yes I could. This would emit to the rather more obscure `MediaSourceEventListener.onLoadError` from which the client or us, at a different layer, would need to look through the information and decide what to do with it. You get info like: `MediaLoadData`, `IOException`, `wasCanceled` etc. 

### Test(s) added 
Updated the tests for the `NoPlayerAdsLoader` to ensure that the `AdvertListener` is called for error events.

### Paired with 
Nobody.
