### PR TITLE
Notify Track Changes

### DIFF
--- a/core/src/main/java/com/novoda/noplayer/Listeners.java
+++ b/core/src/main/java/com/novoda/noplayer/Listeners.java
@@ -158,4 +158,18 @@ public interface Listeners {
      * @param advertListener to remove.
      */
     void removeAdvertListener(NoPlayer.AdvertListener advertListener);
+
+    /**
+     * Add a given {@link com.novoda.noplayer.NoPlayer.TracksChangedListener} to be notified when track changes occur.
+     *
+     * @param tracksChangedListener to notify.
+     */
+    void addTracksChangedListener(NoPlayer.TracksChangedListener tracksChangedListener);
+
+    /**
+     * Remove a given {@link com.novoda.noplayer.NoPlayer.TracksChangedListener}.
+     *
+     * @param tracksChangedListener to remove.
+     */
+    void removeTracksChangedListener(NoPlayer.TracksChangedListener tracksChangedListener);
 }

--- a/core/src/main/java/com/novoda/noplayer/NoPlayer.java
+++ b/core/src/main/java/com/novoda/noplayer/NoPlayer.java
@@ -2,8 +2,6 @@ package com.novoda.noplayer;
 
 import android.net.Uri;
 
-import androidx.annotation.FloatRange;
-
 import com.novoda.noplayer.internal.exoplayer.NoPlayerAdsLoader;
 import com.novoda.noplayer.internal.utils.Optional;
 import com.novoda.noplayer.model.AudioTracks;
@@ -14,8 +12,11 @@ import com.novoda.noplayer.model.PlayerVideoTrack;
 import com.novoda.noplayer.model.Timeout;
 
 import java.io.IOException;
+import java.lang.IllegalStateException;
 import java.util.List;
 import java.util.Map;
+
+import androidx.annotation.FloatRange;
 
 // There are a lot of features for playing and monitoring video.
 @SuppressWarnings("PMD.ExcessivePublicCount")
@@ -310,6 +311,10 @@ public interface NoPlayer extends PlayerState {
     interface VideoSizeChangedListener {
 
         void onVideoSizeChanged(int width, int height, int unappliedRotationDegrees, float pixelWidthHeightRatio);
+    }
+
+    interface TracksChangedListener {
+        void onTracksChanged();
     }
 
     /**

--- a/core/src/main/java/com/novoda/noplayer/NoPlayer.java
+++ b/core/src/main/java/com/novoda/noplayer/NoPlayer.java
@@ -12,7 +12,6 @@ import com.novoda.noplayer.model.PlayerVideoTrack;
 import com.novoda.noplayer.model.Timeout;
 
 import java.io.IOException;
-import java.lang.IllegalStateException;
 import java.util.List;
 import java.util.Map;
 

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImpl.java
@@ -3,8 +3,6 @@ package com.novoda.noplayer.internal.exoplayer;
 import android.net.Uri;
 import android.view.View;
 
-import androidx.annotation.Nullable;
-
 import com.google.android.exoplayer2.mediacodec.MediaCodecSelector;
 import com.novoda.noplayer.AdvertView;
 import com.novoda.noplayer.Listeners;
@@ -26,6 +24,8 @@ import com.novoda.noplayer.model.PlayerVideoTrack;
 import com.novoda.noplayer.model.Timeout;
 
 import java.util.List;
+
+import androidx.annotation.Nullable;
 
 // Not much we can do, wrapping ExoPlayer is a lot of work
 @SuppressWarnings("PMD.GodClass")
@@ -73,6 +73,7 @@ class ExoPlayerTwoImpl implements NoPlayer {
         forwarder.bind(listenersHolder.getInfoListeners());
         forwarder.bind(listenersHolder.getDroppedVideoFramesListeners());
         forwarder.bind(listenersHolder.getAdvertListeners());
+        forwarder.bind(listenersHolder.getTracksChangedListeners());
         listenersHolder.addPreparedListener(new PreparedListener() {
             @Override
             public void onPrepared(PlayerState playerState) {

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/ExoPlayerForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/ExoPlayerForwarder.java
@@ -88,4 +88,8 @@ public class ExoPlayerForwarder {
     public void bind(NoPlayer.AdvertListener advertListeners) {
         this.advertListeners = Optional.of(advertListeners);
     }
+
+    public void bind(NoPlayer.TracksChangedListener tracksChangedListeners) {
+        exoPlayerEventListener.add(new TracksChangedForwarder(tracksChangedListeners));
+    }
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/TracksChangedForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/TracksChangedForwarder.java
@@ -1,0 +1,68 @@
+package com.novoda.noplayer.internal.exoplayer.forwarder;
+
+import com.google.android.exoplayer2.ExoPlaybackException;
+import com.google.android.exoplayer2.PlaybackParameters;
+import com.google.android.exoplayer2.Player;
+import com.google.android.exoplayer2.Timeline;
+import com.google.android.exoplayer2.source.TrackGroupArray;
+import com.google.android.exoplayer2.trackselection.TrackSelectionArray;
+import com.novoda.noplayer.NoPlayer;
+
+class TracksChangedForwarder implements Player.EventListener {
+
+    private final NoPlayer.TracksChangedListener tracksChangedListener;
+
+    TracksChangedForwarder(NoPlayer.TracksChangedListener tracksChangedListener) {
+        this.tracksChangedListener = tracksChangedListener;
+    }
+
+    @Override
+    public void onPlayerStateChanged(boolean playWhenReady, int playbackState) {
+        // no-op.
+    }
+
+    @Override
+    public void onRepeatModeChanged(@Player.RepeatMode int repeatMode) {
+        // no-op.
+    }
+
+    @Override
+    public void onShuffleModeEnabledChanged(boolean shuffleModeEnabled) {
+        // no-op.
+    }
+
+    @Override
+    public void onTimelineChanged(Timeline timeline, Object manifest, @Player.TimelineChangeReason int reason) {
+        // no-op.
+    }
+
+    @Override
+    public void onTracksChanged(TrackGroupArray trackGroups, TrackSelectionArray trackSelections) {
+        tracksChangedListener.onTracksChanged();
+    }
+
+    @Override
+    public void onLoadingChanged(boolean isLoading) {
+        // no-op.
+    }
+
+    @Override
+    public void onPlayerError(ExoPlaybackException error) {
+        // no-op.
+    }
+
+    @Override
+    public void onPositionDiscontinuity(int reason) {
+        // no-op.
+    }
+
+    @Override
+    public void onPlaybackParametersChanged(PlaybackParameters playbackParameters) {
+        // no-op.
+    }
+
+    @Override
+    public void onSeekProcessed() {
+        // no-op.
+    }
+}

--- a/core/src/main/java/com/novoda/noplayer/internal/listeners/PlayerListenersHolder.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/listeners/PlayerListenersHolder.java
@@ -220,5 +220,6 @@ public class PlayerListenersHolder implements Listeners {
         heartbeatCallbacks.clear();
         droppedFramesListeners.clear();
         advertListeners.clear();
+        tracksChangedListeners.clear();
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/listeners/PlayerListenersHolder.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/listeners/PlayerListenersHolder.java
@@ -16,6 +16,7 @@ public class PlayerListenersHolder implements Listeners {
     private final BitrateChangedListeners bitrateChangedListeners;
     private final DroppedFramesListeners droppedFramesListeners;
     private final AdvertListeners advertListeners;
+    private final TracksChangedListeners tracksChangedListeners;
 
     private final HeartbeatCallbacks heartbeatCallbacks;
 
@@ -31,6 +32,7 @@ public class PlayerListenersHolder implements Listeners {
         heartbeatCallbacks = new HeartbeatCallbacks();
         droppedFramesListeners = new DroppedFramesListeners();
         advertListeners = new AdvertListeners();
+        tracksChangedListeners = new TracksChangedListeners();
     }
 
     @Override
@@ -143,6 +145,16 @@ public class PlayerListenersHolder implements Listeners {
         advertListeners.remove(advertListener);
     }
 
+    @Override
+    public void addTracksChangedListener(NoPlayer.TracksChangedListener tracksChangedListener) {
+        tracksChangedListeners.add(tracksChangedListener);
+    }
+
+    @Override
+    public void removeTracksChangedListener(NoPlayer.TracksChangedListener tracksChangedListener) {
+        tracksChangedListeners.remove(tracksChangedListener);
+    }
+
     public NoPlayer.ErrorListener getErrorListeners() {
         return errorListeners;
     }
@@ -185,6 +197,10 @@ public class PlayerListenersHolder implements Listeners {
 
     public NoPlayer.AdvertListener getAdvertListeners() {
         return advertListeners;
+    }
+
+    public NoPlayer.TracksChangedListener getTracksChangedListeners() {
+        return tracksChangedListeners;
     }
 
     public void resetState() {

--- a/core/src/main/java/com/novoda/noplayer/internal/listeners/TracksChangedListeners.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/listeners/TracksChangedListeners.java
@@ -1,0 +1,30 @@
+package com.novoda.noplayer.internal.listeners;
+
+import com.novoda.noplayer.NoPlayer;
+
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
+
+class TracksChangedListeners implements NoPlayer.TracksChangedListener {
+
+    private final Set<NoPlayer.TracksChangedListener> listeners = new CopyOnWriteArraySet<>();
+
+    public void add(NoPlayer.TracksChangedListener listener) {
+        listeners.add(listener);
+    }
+
+    public void remove(NoPlayer.TracksChangedListener listener) {
+        listeners.remove(listener);
+    }
+
+    public void clear() {
+        listeners.clear();
+    }
+
+    @Override
+    public void onTracksChanged() {
+        for (NoPlayer.TracksChangedListener listener : listeners) {
+            listener.onTracksChanged();
+        }
+    }
+}

--- a/demo/src/main/java/com/novoda/demo/MainActivity.java
+++ b/demo/src/main/java/com/novoda/demo/MainActivity.java
@@ -23,7 +23,7 @@ import java.util.List;
 
 public class MainActivity extends Activity {
 
-    private static final String URI_VIDEO_WIDEVINE_EXAMPLE_MODULAR_MPD = "https://storage.googleapis.com/content-samples/multi-audio/manifest.mpd";
+    private static final String URI_VIDEO_WIDEVINE_EXAMPLE_MODULAR_MPD = "https://storage.googleapis.com/wvmedia/cenc/hevc/tears/tears.mpd";
     private static final String EXAMPLE_MODULAR_LICENSE_SERVER_PROXY = "https://proxy.uat.widevine.com/proxy?provider=widevine_test";
     private static final int HALF_A_SECOND_IN_MILLIS = 500;
     private static final int TWO_MEGABITS = 2000000;

--- a/demo/src/main/java/com/novoda/demo/MainActivity.java
+++ b/demo/src/main/java/com/novoda/demo/MainActivity.java
@@ -23,7 +23,7 @@ import java.util.List;
 
 public class MainActivity extends Activity {
 
-    private static final String URI_VIDEO_WIDEVINE_EXAMPLE_MODULAR_MPD = "https://storage.googleapis.com/wvmedia/clear/h264/tears/tears.mpd";
+    private static final String URI_VIDEO_WIDEVINE_EXAMPLE_MODULAR_MPD = "https://storage.googleapis.com/content-samples/multi-audio/manifest.mpd";
     private static final String EXAMPLE_MODULAR_LICENSE_SERVER_PROXY = "https://proxy.uat.widevine.com/proxy?provider=widevine_test";
     private static final int HALF_A_SECOND_IN_MILLIS = 500;
     private static final int TWO_MEGABITS = 2000000;

--- a/demo/src/main/java/com/novoda/demo/MainActivity.java
+++ b/demo/src/main/java/com/novoda/demo/MainActivity.java
@@ -7,7 +7,6 @@ import android.util.Log;
 import android.view.View;
 import android.widget.CheckBox;
 import android.widget.CompoundButton;
-import android.widget.Toast;
 
 import com.novoda.noplayer.ContentType;
 import com.novoda.noplayer.NoPlayer;
@@ -16,6 +15,11 @@ import com.novoda.noplayer.OptionsBuilder;
 import com.novoda.noplayer.PlayerBuilder;
 import com.novoda.noplayer.PlayerView;
 import com.novoda.noplayer.internal.utils.NoPlayerLog;
+import com.novoda.noplayer.model.AudioTracks;
+import com.novoda.noplayer.model.PlayerSubtitleTrack;
+import com.novoda.noplayer.model.PlayerVideoTrack;
+
+import java.util.List;
 
 public class MainActivity extends Activity {
 
@@ -36,9 +40,9 @@ public class MainActivity extends Activity {
         NoPlayerLog.setLoggingEnabled(true);
         setContentView(R.layout.activity_main);
         PlayerView playerView = findViewById(R.id.player_view);
-        View videoSelectionButton = findViewById(R.id.button_video_selection);
-        View audioSelectionButton = findViewById(R.id.button_audio_selection);
-        View subtitleSelectionButton = findViewById(R.id.button_subtitle_selection);
+        final View videoSelectionButton = findViewById(R.id.button_video_selection);
+        final View audioSelectionButton = findViewById(R.id.button_audio_selection);
+        final View subtitleSelectionButton = findViewById(R.id.button_subtitle_selection);
         hdSelectionCheckBox = findViewById(R.id.button_hd_selection);
         ControllerView controllerView = findViewById(R.id.controller_view);
 
@@ -63,6 +67,31 @@ public class MainActivity extends Activity {
             @Override
             public void onDroppedVideoFrames(int droppedFrames, long elapsedMsSinceLastDroppedFrames) {
                 Log.v(getClass().toString(), "dropped frames: " + droppedFrames + " since: " + elapsedMsSinceLastDroppedFrames + "ms");
+            }
+        });
+        player.getListeners().addTracksChangedListener(new NoPlayer.TracksChangedListener() {
+            @Override
+            public void onTracksChanged() {
+                AudioTracks audioTracks = player.getAudioTracks();
+                if (audioTracks.size() > 1) {
+                    audioSelectionButton.setVisibility(View.VISIBLE);
+                } else {
+                    audioSelectionButton.setVisibility(View.GONE);
+                }
+
+                List<PlayerVideoTrack> videoTracks = player.getVideoTracks();
+                if (videoTracks.size() > 1) {
+                    videoSelectionButton.setVisibility(View.VISIBLE);
+                } else {
+                    videoSelectionButton.setVisibility(View.GONE);
+                }
+
+                List<PlayerSubtitleTrack> subtitleTracks = player.getSubtitleTracks();
+                if (subtitleTracks.size() > 1) {
+                    subtitleSelectionButton.setVisibility(View.VISIBLE);
+                } else {
+                    subtitleSelectionButton.setVisibility(View.GONE);
+                }
             }
         });
 
@@ -91,11 +120,7 @@ public class MainActivity extends Activity {
     private final View.OnClickListener showVideoSelectionDialog = new View.OnClickListener() {
         @Override
         public void onClick(View v) {
-            if (player.getVideoTracks().isEmpty()) {
-                Toast.makeText(MainActivity.this, "no additional video tracks available!", Toast.LENGTH_LONG).show();
-            } else {
-                dialogCreator.showVideoSelectionDialog();
-            }
+            dialogCreator.showVideoSelectionDialog();
         }
     };
 
@@ -110,11 +135,7 @@ public class MainActivity extends Activity {
     private final View.OnClickListener showSubtitleSelectionDialog = new View.OnClickListener() {
         @Override
         public void onClick(View v) {
-            if (player.getSubtitleTracks().isEmpty()) {
-                Toast.makeText(MainActivity.this, "no subtitles available!", Toast.LENGTH_LONG).show();
-            } else {
-                dialogCreator.showSubtitleSelectionDialog();
-            }
+            dialogCreator.showSubtitleSelectionDialog();
         }
     };
 


### PR DESCRIPTION
## Problem
It's possible that the tracks for audio, video and subtitles may not be ready by the time we are playing content! This is most apparent when we are switching between adverts, we will receive notifications for adverts ending and starting before the tracks themselves become available!

## Solution
Add a new callback that notifies the client when `tracks` have been changed. Clients can then use this to show and hide any track selector UI they may have. 

### Screenshots

| Audio Only | Video Only |
| ------ | ----- |
![audio_only](https://user-images.githubusercontent.com/3380092/57868456-ed672500-77fa-11e9-9e52-574750e9ce9a.png) | ![asset_video_only](https://user-images.githubusercontent.com/3380092/57868458-ed672500-77fa-11e9-98bb-8844a920129d.png)

## Improvements for future
Ideally from the exo-player:

```
default void onTracksChanged(
        TrackGroupArray trackGroups, TrackSelectionArray trackSelections) {}
```

we would map to a generic `no-player` Track, unfortunately all of our tracks at the moment are dependent on the type of format they are representing i.e. Subtitles vs Video. The first step would be to make these generic and then emit this from this call. 

### Paired with 
Nobody.
