### PR TITLE
Set advert break initial position

### DIFF
--- a/core/src/main/java/com/novoda/noplayer/Options.java
+++ b/core/src/main/java/com/novoda/noplayer/Options.java
@@ -12,6 +12,7 @@ public class Options {
     private final int maxInitialBitrate;
     private final int maxVideoBitrate;
     private final Optional<Long> initialPositionInMillis;
+    private final Optional<Long> initialAdvertBreakPositionInMillis;
 
     /**
      * Creates a {@link OptionsBuilder} from this Options.
@@ -26,7 +27,10 @@ public class Options {
                 .withMaxVideoBitrate(maxVideoBitrate);
 
         if (initialPositionInMillis.isPresent()) {
-            optionsBuilder = optionsBuilder.withInitialPositionInMillis(initialPositionInMillis.get());
+            optionsBuilder.withInitialPositionInMillis(initialPositionInMillis.get());
+        }
+        if (initialAdvertBreakPositionInMillis.isPresent()) {
+            optionsBuilder.withInitialAdvertBreakPositionInMillis(initialAdvertBreakPositionInMillis.get());
         }
         return optionsBuilder;
     }
@@ -35,12 +39,14 @@ public class Options {
             int minDurationBeforeQualityIncreaseInMillis,
             int maxInitialBitrate,
             int maxVideoBitrate,
-            Optional<Long> initialPositionInMillis) {
+            Optional<Long> initialPositionInMillis,
+            Optional<Long> initialAdvertBreakPositionInMillis) {
         this.contentType = contentType;
         this.minDurationBeforeQualityIncreaseInMillis = minDurationBeforeQualityIncreaseInMillis;
         this.maxInitialBitrate = maxInitialBitrate;
         this.maxVideoBitrate = maxVideoBitrate;
         this.initialPositionInMillis = initialPositionInMillis;
+        this.initialAdvertBreakPositionInMillis = initialAdvertBreakPositionInMillis;
     }
 
     public ContentType contentType() {
@@ -61,6 +67,10 @@ public class Options {
 
     public Optional<Long> getInitialPositionInMillis() {
         return initialPositionInMillis;
+    }
+
+    public Optional<Long> getInitialAdvertBreakPositionInMillis() {
+        return initialAdvertBreakPositionInMillis;
     }
 
     @Override
@@ -86,8 +96,14 @@ public class Options {
         if (contentType != options.contentType) {
             return false;
         }
-        return initialPositionInMillis != null
-                ? initialPositionInMillis.equals(options.initialPositionInMillis) : options.initialPositionInMillis == null;
+        if (initialPositionInMillis != null
+                ? !initialPositionInMillis.equals(options.initialPositionInMillis)
+                : options.initialPositionInMillis != null) {
+            return false;
+        }
+        return initialAdvertBreakPositionInMillis != null
+                ? initialAdvertBreakPositionInMillis.equals(options.initialAdvertBreakPositionInMillis)
+                : options.initialAdvertBreakPositionInMillis == null;
     }
 
     @Override
@@ -97,6 +113,7 @@ public class Options {
         result = 31 * result + maxInitialBitrate;
         result = 31 * result + maxVideoBitrate;
         result = 31 * result + (initialPositionInMillis != null ? initialPositionInMillis.hashCode() : 0);
+        result = 31 * result + (initialAdvertBreakPositionInMillis != null ? initialAdvertBreakPositionInMillis.hashCode() : 0);
         return result;
     }
 

--- a/core/src/main/java/com/novoda/noplayer/OptionsBuilder.java
+++ b/core/src/main/java/com/novoda/noplayer/OptionsBuilder.java
@@ -18,6 +18,7 @@ public class OptionsBuilder {
     private int maxInitialBitrate = DEFAULT_MAX_INITIAL_BITRATE;
     private int maxVideoBitrate = DEFAULT_MAX_VIDEO_BITRATE;
     private Optional<Long> initialPositionInMillis = Optional.absent();
+    private Optional<Long> initialAdvertBreakPositionInMillis = Optional.absent();
 
     /**
      * Sets {@link OptionsBuilder} to build {@link Options} with a given {@link ContentType}.
@@ -83,6 +84,18 @@ public class OptionsBuilder {
     }
 
     /**
+     * Sets {@link OptionsBuilder} to build {@link Options} with given initial position in millis in order
+     * to specify the start position of the first advert break that will be played.
+     *
+     * @param initialAdvertBreakPositionInMillis position that the first advert break should begin playback at.
+     * @return {@link OptionsBuilder}.
+     */
+    public OptionsBuilder withInitialAdvertBreakPositionInMillis(long initialAdvertBreakPositionInMillis) {
+        this.initialAdvertBreakPositionInMillis = Optional.of(initialAdvertBreakPositionInMillis);
+        return this;
+    }
+
+    /**
      * Builds a new {@link Options} instance.
      *
      * @return a {@link Options} instance.
@@ -93,7 +106,7 @@ public class OptionsBuilder {
                 minDurationBeforeQualityIncreaseInMillis,
                 maxInitialBitrate,
                 maxVideoBitrate,
-                initialPositionInMillis
-        );
+                initialPositionInMillis,
+                initialAdvertBreakPositionInMillis);
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/AdvertPlaybackState.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/AdvertPlaybackState.java
@@ -14,14 +14,11 @@ final class AdvertPlaybackState {
     private final AdPlaybackState adPlaybackState;
     private final List<AdvertBreak> advertBreaks;
 
-    static AdvertPlaybackState from(List<AdvertBreak> advertBreaks, long advertBreakResumePositionMillis) {
-        AdvertPlaybackState advertPlaybackState = from(advertBreaks);
-        AdPlaybackState adPlaybackState = advertPlaybackState.adPlaybackState;
-        adPlaybackState = updateResumePositionInFirstGroup(adPlaybackState, advertBreakResumePositionMillis);
-        return new AdvertPlaybackState(adPlaybackState, advertPlaybackState.advertBreaks);
+    static AdvertPlaybackState from(List<AdvertBreak> advertBreaks) {
+        return from(advertBreaks, 0);
     }
 
-    static AdvertPlaybackState from(List<AdvertBreak> advertBreaks) {
+    static AdvertPlaybackState from(List<AdvertBreak> advertBreaks, long advertBreakResumePositionMillis) {
         List<AdvertBreak> sortedAdvertBreaks = sortAdvertBreaksByStartTime(advertBreaks);
 
         long[] advertOffsets = advertBreakOffset(sortedAdvertBreaks);
@@ -49,6 +46,7 @@ final class AdvertPlaybackState {
         }
 
         adPlaybackState = adPlaybackState.withAdDurationsUs(advertBreaksWithAdvertDurations);
+        adPlaybackState = updateResumePositionInFirstGroup(adPlaybackState, advertBreakResumePositionMillis);
         return new AdvertPlaybackState(adPlaybackState, sortedAdvertBreaks);
     }
 

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
@@ -33,6 +33,7 @@ import java.util.List;
 class ExoPlayerFacade {
 
     private static final boolean DO_NOT_RESET_STATE = false;
+    private static final long NO_AD_RESUME_POSITION = 0L;
 
     private final BandwidthMeterCreator bandwidthMeterCreator;
     private final AndroidDeviceVersion androidDeviceVersion;
@@ -199,7 +200,8 @@ class ExoPlayerFacade {
         setMovieAudioAttributes(exoPlayer);
 
         if (adsLoader.isPresent()) {
-            adsLoader.get().bind(forwarder.advertListener());
+            long advertBreakInitialPositionMillis = options.getInitialAdvertBreakPositionInMillis().or(NO_AD_RESUME_POSITION);
+            adsLoader.get().bind(forwarder.advertListener(), advertBreakInitialPositionMillis);
         }
 
         MediaSource mediaSource = mediaSourceFactory.create(

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
@@ -2,9 +2,7 @@ package com.novoda.noplayer.internal.exoplayer;
 
 import android.os.Handler;
 import android.os.Looper;
-
 import androidx.annotation.Nullable;
-
 import com.google.android.exoplayer2.C;
 import com.google.android.exoplayer2.Player;
 import com.google.android.exoplayer2.Timeline;
@@ -40,6 +38,7 @@ public class NoPlayerAdsLoader implements AdsLoader, Player.EventListener, Adver
     private AdvertsLoader.Cancellable loadingAds;
 
     private NoPlayer.AdvertListener advertListener = NoOpAdvertListener.INSTANCE;
+    private long advertBreakResumePosition = 0;
     private List<AdvertBreak> advertBreaks = Collections.emptyList();
     private int adIndexInGroup = -1;
     private int adGroupIndex = -1;
@@ -54,8 +53,9 @@ public class NoPlayerAdsLoader implements AdsLoader, Player.EventListener, Adver
         this.handler = handler;
     }
 
-    public void bind(Optional<NoPlayer.AdvertListener> advertListener) {
+    public void bind(Optional<NoPlayer.AdvertListener> advertListener, long advertBreakResumePositionMillis) {
         this.advertListener = advertListener.isPresent() ? advertListener.get() : NoOpAdvertListener.INSTANCE;
+        this.advertBreakResumePosition = advertBreakResumePositionMillis;
     }
 
     @Override
@@ -81,7 +81,7 @@ public class NoPlayerAdsLoader implements AdsLoader, Player.EventListener, Adver
         @Override
         public void onAdvertsLoaded(List<AdvertBreak> breaks) {
             loadingAds = null;
-            AdvertPlaybackState advertPlaybackState = AdvertPlaybackState.from(breaks);
+            AdvertPlaybackState advertPlaybackState = AdvertPlaybackState.from(breaks, advertBreakResumePosition);
             advertBreaks = advertPlaybackState.advertBreaks();
             adPlaybackState = advertPlaybackState.adPlaybackState();
             handler.post(new Runnable() {

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
@@ -38,11 +38,11 @@ public class NoPlayerAdsLoader implements AdsLoader, Player.EventListener, Adver
     private AdvertsLoader.Cancellable loadingAds;
 
     private NoPlayer.AdvertListener advertListener = NoOpAdvertListener.INSTANCE;
-    private long advertBreakResumePosition = 0;
     private List<AdvertBreak> advertBreaks = Collections.emptyList();
     private int adIndexInGroup = -1;
     private int adGroupIndex = -1;
     private boolean advertsDisabled;
+    private long advertBreakResumePosition;
 
     static NoPlayerAdsLoader create(AdvertsLoader loader) {
         return new NoPlayerAdsLoader(loader, new Handler(Looper.getMainLooper()));

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/AdGroupFixture.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/AdGroupFixture.java
@@ -1,0 +1,53 @@
+package com.novoda.noplayer.internal.exoplayer;
+
+import android.net.Uri;
+import com.google.android.exoplayer2.source.ads.AdPlaybackState;
+
+import java.util.HashMap;
+import java.util.Map;
+
+class AdGroupFixture {
+
+    private final Map<Integer, Integer> positionStateMapping = new HashMap<>();
+    private long[] advertDurations;
+    private Uri[] advertUris;
+    private int adCount;
+
+    static AdGroupFixture anAdGroup() {
+        return new AdGroupFixture();
+    }
+
+    AdGroupFixture withAdCount(int adCount) {
+        this.adCount = adCount;
+        return this;
+    }
+
+    AdGroupFixture withAdDurationsUs(long[] advertDurations) {
+        this.advertDurations = advertDurations;
+        return this;
+    }
+
+    AdGroupFixture withAdUris(Uri[] advertUris) {
+        this.advertUris = advertUris;
+        return this;
+    }
+
+    AdGroupFixture withPlayedStateAt(int position) {
+        positionStateMapping.put(position, AdPlaybackState.AD_STATE_PLAYED);
+        return this;
+    }
+
+    AdPlaybackState.AdGroup build() {
+        AdPlaybackState.AdGroup group = new AdPlaybackState.AdGroup();
+        group = group.withAdCount(adCount);
+        group = group.withAdDurationsUs(advertDurations);
+        for (int i = 0; i < advertUris.length; i++) {
+            Uri uri = advertUris[i];
+            group = group.withAdUri(uri, i);
+        }
+        for (Integer position : positionStateMapping.keySet()) {
+            group = group.withAdState(positionStateMapping.get(position), position);
+        }
+        return group;
+    }
+}

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/AdvertPlaybackStateTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/AdvertPlaybackStateTest.java
@@ -1,18 +1,17 @@
 package com.novoda.noplayer.internal.exoplayer;
 
 import android.net.Uri;
-
 import com.google.android.exoplayer2.source.ads.AdPlaybackState;
 import com.novoda.noplayer.Advert;
 import com.novoda.noplayer.AdvertBreak;
+import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.Test;
-
 import static com.novoda.noplayer.AdvertBreakFixtures.anAdvertBreak;
 import static com.novoda.noplayer.AdvertFixtures.anAdvert;
+import static com.novoda.noplayer.internal.exoplayer.AdGroupFixture.anAdGroup;
 import static org.fest.assertions.api.Assertions.assertThat;
 
 public class AdvertPlaybackStateTest {
@@ -47,6 +46,21 @@ public class AdvertPlaybackStateTest {
             .withStartTimeInMillis(THREE_SECONDS_IN_MILLIS)
             .withAdverts(FIRST_ADVERT, SECOND_ADVERT, THIRD_ADVERT)
             .build();
+    private static final AdPlaybackState.AdGroup FIRST_AD_GROUP = anAdGroup()
+            .withAdCount(1)
+            .withAdDurationsUs(new long[]{ONE_SECOND_IN_MICROS})
+            .withAdUris(new Uri[]{FIRST_ADVERT.uri()})
+            .build();
+    private static final AdPlaybackState.AdGroup SECOND_AD_GROUP = anAdGroup()
+            .withAdCount(2)
+            .withAdDurationsUs(new long[]{ONE_SECOND_IN_MICROS, TWO_SECONDS_IN_MICROS})
+            .withAdUris(new Uri[]{FIRST_ADVERT.uri(), SECOND_ADVERT.uri()})
+            .build();
+    private static final AdPlaybackState.AdGroup THIRD_AD_GROUP = anAdGroup()
+            .withAdCount(3)
+            .withAdDurationsUs(new long[]{ONE_SECOND_IN_MICROS, TWO_SECONDS_IN_MICROS, THREE_SECONDS_IN_MICROS})
+            .withAdUris(new Uri[]{FIRST_ADVERT.uri(), SECOND_ADVERT.uri(), THIRD_ADVERT.uri()})
+            .build();
 
     @Test
     public void createsCorrectAdvertPlaybackState() {
@@ -57,9 +71,7 @@ public class AdvertPlaybackStateTest {
 
         assertThat(adPlaybackState.adGroupCount).isEqualTo(3);
         assertThat(adPlaybackState.adGroupTimesUs).containsSequence(ONE_SECOND_IN_MICROS, TWO_SECONDS_IN_MICROS, THREE_SECONDS_IN_MICROS);
-        assertThatGroupContains(adPlaybackState.adGroups[0], 1, new long[]{ONE_SECOND_IN_MICROS}, new Uri[]{FIRST_ADVERT.uri()});
-        assertThatGroupContains(adPlaybackState.adGroups[1], 2, new long[]{ONE_SECOND_IN_MICROS, TWO_SECONDS_IN_MICROS}, new Uri[]{FIRST_ADVERT.uri(), SECOND_ADVERT.uri()});
-        assertThatGroupContains(adPlaybackState.adGroups[2], 3, new long[]{ONE_SECOND_IN_MICROS, TWO_SECONDS_IN_MICROS, THREE_SECONDS_IN_MICROS}, new Uri[]{FIRST_ADVERT.uri(), SECOND_ADVERT.uri(), THIRD_ADVERT.uri()});
+        assertThat(adPlaybackState.adGroups).containsExactly(FIRST_AD_GROUP, SECOND_AD_GROUP, THIRD_AD_GROUP);
     }
 
     @Test
@@ -81,9 +93,4 @@ public class AdvertPlaybackStateTest {
         assertThat(advertBreaks).containsExactly(THIRD_ADVERT_BREAK, SECOND_ADVERT_BREAK, FIRST_ADVERT_BREAK);
     }
 
-    private void assertThatGroupContains(AdPlaybackState.AdGroup adGroup, int numberOfAdverts, long[] advertDurations, Uri[] advertUris) {
-        assertThat(adGroup.count).isEqualTo(numberOfAdverts);
-        assertThat(adGroup.durationsUs).containsSequence(advertDurations);
-        assertThat(adGroup.uris).containsExactly(advertUris);
-    }
 }

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/AdvertPlaybackStateTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/AdvertPlaybackStateTest.java
@@ -1,6 +1,7 @@
 package com.novoda.noplayer.internal.exoplayer;
 
 import android.net.Uri;
+import com.google.android.exoplayer2.C;
 import com.google.android.exoplayer2.source.ads.AdPlaybackState;
 import com.novoda.noplayer.Advert;
 import com.novoda.noplayer.AdvertBreak;
@@ -72,6 +73,8 @@ public class AdvertPlaybackStateTest {
         assertThat(adPlaybackState.adGroupCount).isEqualTo(3);
         assertThat(adPlaybackState.adGroupTimesUs).containsSequence(ONE_SECOND_IN_MICROS, TWO_SECONDS_IN_MICROS, THREE_SECONDS_IN_MICROS);
         assertThat(adPlaybackState.adGroups).containsExactly(FIRST_AD_GROUP, SECOND_AD_GROUP, THIRD_AD_GROUP);
+        assertThat(adPlaybackState.adResumePositionUs).isEqualTo(0L);
+        assertThat(adPlaybackState.contentDurationUs).isEqualTo(C.TIME_UNSET);
     }
 
     @Test

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacadeTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacadeTest.java
@@ -70,6 +70,7 @@ public class ExoPlayerFacadeTest {
     private static final long TEN_MINUTES_IN_MILLIS = 600000;
     private static final long MICROS = 1000;
     private static final long[] ADVERT_DURATIONS = {10 * MICROS, 20 * MICROS, 30 * MICROS, 40 * MICROS};
+    private static final long NO_RESUME_POSITION = 0;
 
     private static final int TEN_PERCENT = 10;
 
@@ -127,7 +128,7 @@ public class ExoPlayerFacadeTest {
 
             facade.loadVideo(surfaceViewHolder, drmSessionCreator, uri, OPTIONS, exoPlayerForwarder, mediaCodecSelector);
 
-            verify(adsLoader).bind(optionalAdvertListener);
+            verify(adsLoader).bind(optionalAdvertListener, NO_RESUME_POSITION);
         }
 
         @Test
@@ -138,7 +139,7 @@ public class ExoPlayerFacadeTest {
 
             facade.loadVideo(surfaceViewHolder, drmSessionCreator, uri, OPTIONS, exoPlayerForwarder, mediaCodecSelector);
 
-            verify(adsLoader).bind(exoPlayerForwarder.advertListener());
+            verify(adsLoader).bind(exoPlayerForwarder.advertListener(), NO_RESUME_POSITION);
         }
 
         @Test
@@ -167,7 +168,7 @@ public class ExoPlayerFacadeTest {
 
             facade.loadVideo(surfaceViewHolder, drmSessionCreator, uri, OPTIONS, exoPlayerForwarder, mediaCodecSelector);
 
-            verify(adsLoader, never()).bind(exoPlayerForwarder.advertListener());
+            verify(adsLoader, never()).bind(exoPlayerForwarder.advertListener(), NO_RESUME_POSITION);
         }
 
         @Test
@@ -175,7 +176,20 @@ public class ExoPlayerFacadeTest {
 
             facade.loadVideo(surfaceViewHolder, drmSessionCreator, uri, OPTIONS, exoPlayerForwarder, mediaCodecSelector);
 
-            verify(adsLoader, never()).bind(exoPlayerForwarder.advertListener());
+            verify(adsLoader, never()).bind(exoPlayerForwarder.advertListener(), NO_RESUME_POSITION);
+        }
+
+        @Test
+        public void givenInitialAdvertBreakPosition_whenLoadingVideo_thenBindsAdvertListenerWithResumePosition() {
+            Options options = OPTIONS.toOptionsBuilder()
+                    .withInitialAdvertBreakPositionInMillis(TWENTY_FIVE_SECONDS_IN_MILLIS)
+                    .build();
+            given(optionalAdsLoader.isPresent()).willReturn(true);
+            given(optionalAdsLoader.get()).willReturn(adsLoader);
+
+            facade.loadVideo(surfaceViewHolder, drmSessionCreator, uri, options, exoPlayerForwarder, mediaCodecSelector);
+
+            verify(adsLoader).bind(exoPlayerForwarder.advertListener(), TWENTY_FIVE_SECONDS_IN_MILLIS);
         }
 
         @Test

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoaderTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoaderTest.java
@@ -1,17 +1,12 @@
 package com.novoda.noplayer.internal.exoplayer;
 
 import android.os.Handler;
-
 import com.google.android.exoplayer2.source.ads.AdsLoader;
 import com.novoda.noplayer.Advert;
 import com.novoda.noplayer.AdvertBreak;
 import com.novoda.noplayer.AdvertsLoader;
 import com.novoda.noplayer.NoPlayer;
 import com.novoda.noplayer.internal.utils.Optional;
-
-import java.io.IOException;
-import java.util.Arrays;
-
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -20,8 +15,10 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
-
 import utils.ExceptionMatcher;
+
+import java.io.IOException;
+import java.util.Arrays;
 
 import static com.novoda.noplayer.AdvertBreakFixtures.anAdvertBreak;
 import static com.novoda.noplayer.AdvertFixtures.anAdvert;
@@ -51,6 +48,8 @@ public class NoPlayerAdsLoaderTest {
             .withAdvert(anAdvert().withDurationInMillis(5000).build())
             .withAdvert(anAdvert().withDurationInMillis(6000).build())
             .build();
+    private static final long NO_AD_RESUME_POSITION = 0;
+
     private final AdvertsLoader advertsLoader = mock(AdvertsLoader.class);
     private final Handler handler = mock(Handler.class);
 
@@ -78,7 +77,7 @@ public class NoPlayerAdsLoaderTest {
     @Test
     public void notifiesAdvertListenerWhenAdvertLoadingFails() {
         IOException error = new IOException("some error");
-        noPlayerAdsLoader.bind(Optional.of(advertListener));
+        noPlayerAdsLoader.bind(Optional.of(advertListener), NO_AD_RESUME_POSITION);
         noPlayerAdsLoader.start(eventListener, adViewProvider);
 
         invokeCallback().onAdvertsError(error);
@@ -88,7 +87,7 @@ public class NoPlayerAdsLoaderTest {
 
     @Test
     public void notifiesAdvertListenerWhenAdvertLoadingSucceeds() {
-        noPlayerAdsLoader.bind(Optional.of(advertListener));
+        noPlayerAdsLoader.bind(Optional.of(advertListener), NO_AD_RESUME_POSITION);
 
         noPlayerAdsLoader.start(eventListener, adViewProvider);
         invokeCallback().onAdvertsLoaded(Arrays.asList(FIRST_ADVERT_BREAK, SECOND_ADVERT_BREAK));
@@ -146,7 +145,7 @@ public class NoPlayerAdsLoaderTest {
 
     @Test
     public void notifiesAdvertListenerWhenAdvertPreparingFails() {
-        noPlayerAdsLoader.bind(Optional.of(advertListener));
+        noPlayerAdsLoader.bind(Optional.of(advertListener), NO_AD_RESUME_POSITION);
         noPlayerAdsLoader.start(eventListener, adViewProvider);
         invokeCallback().onAdvertsLoaded(Arrays.asList(FIRST_ADVERT_BREAK, SECOND_ADVERT_BREAK));
 


### PR DESCRIPTION
## Problem

There was no way to set the initial position of an advert break so when the video would be reloaded from the position of the advert break, the advert break would always start from beginning.

## Solution

This adds `initialAdvertBreakPositionInMillis` to `Options` that are passed in when the video is loaded. This API matches the `PlayerState.positionInAdvertBreakInMillis()` method. 

Internally we then iterate over the adverts inside the first advert break and mark them as played if their duration is smaller than the progress in advert break. Once we reach the advert that would finish after the provided position, we set the remaining time to be the `adResumePositionUs` in `AdPlaybackState`.

At the moment the marking of adverts as played happens on the first group. I was wondering if it would make sense to tie this marking to the `initialPositionInMillis` and only modify the advert break which start time is the same as the initial position. That way we would be able to ensure that the progress inside an advert break is only modified if the advert break is the first thing that's being played when the content starts.

### Test(s) added 

added tests for the creation of `AdvertPlaybackState` and modified and added where necessary to match the change in `Options`. I also create `AdGroupFixture` to make it easier to create `AdGroup`s in tests.


### Paired with 

nobody
