### PR TITLE
Guard agains null when accessing track info

### DIFF
--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
@@ -56,6 +56,7 @@ public class NoPlayerAdsLoader implements AdsLoader, Player.EventListener, Adver
     public void bind(Optional<NoPlayer.AdvertListener> advertListener, long advertBreakResumePositionMillis) {
         this.advertListener = advertListener.isPresent() ? advertListener.get() : NoOpAdvertListener.INSTANCE;
         this.advertBreakResumePosition = advertBreakResumePositionMillis;
+        resetAdvertPosition();
     }
 
     @Override

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
@@ -56,7 +56,6 @@ public class NoPlayerAdsLoader implements AdsLoader, Player.EventListener, Adver
     public void bind(Optional<NoPlayer.AdvertListener> advertListener, long advertBreakResumePositionMillis) {
         this.advertListener = advertListener.isPresent() ? advertListener.get() : NoOpAdvertListener.INSTANCE;
         this.advertBreakResumePosition = advertBreakResumePositionMillis;
-        resetAdvertPosition();
     }
 
     @Override

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/mediasource/ExoPlayerTrackSelector.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/mediasource/ExoPlayerTrackSelector.java
@@ -52,7 +52,12 @@ public class ExoPlayerTrackSelector {
     }
 
     private int mappedTrackInfoLength() {
-        return trackSelector.getCurrentMappedTrackInfo().length;
+        MappingTrackSelector.MappedTrackInfo trackInfo = trackSelector.getCurrentMappedTrackInfo();
+        if (trackInfo == null) {
+            return 0;
+        } else {
+            return trackInfo.getRendererCount();
+        }
     }
 
     boolean setSelectionOverride(TrackType trackType,


### PR DESCRIPTION
## Problem

`getCurrentMappedTrackInfo()` returns a `Nullable` value that was not guarded. This was causing crashes in some cases (I'm not exactly sure why) when accessed in `NoPlayer.TracksChangedListener.onTracksChanged()` .

## Solution

Now we check if the track info is `null` and return `0`. I also replaced the `length` access with `getRendererCount()` because the `length` was deprecated.

### Test(s) added 

no tests, the class was not tested

### Screenshots

no UI changes

### Paired with 

nobody
