### PR TITLE
Seeking backwards plays adverts

### DIFF
--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerExoPlayerCreator.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerExoPlayerCreator.java
@@ -108,6 +108,9 @@ public class NoPlayerExoPlayerCreator {
             );
 
             PlayerListenersHolder listenersHolder = new PlayerListenersHolder();
+            if (adsLoader.isPresent()) {
+                listenersHolder.addHeartbeatCallback(adsLoader.get());
+            }
             ExoPlayerForwarder exoPlayerForwarder = new ExoPlayerForwarder();
             LoadTimeout loadTimeout = new LoadTimeout(new SystemClock(), handler);
             Heart heart = Heart.newInstance(handler);

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/SkippedAdverts.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/SkippedAdverts.java
@@ -40,7 +40,9 @@ final class SkippedAdverts {
      * @param adPlaybackState         The {@link AdPlaybackState} to alter advert state on.
      * @return The {@link AdPlaybackState} with the new Skipped states.
      */
-    static AdPlaybackState markAllPastAvailableAdvertsAsSkipped(long currentPositionInMillis, List<AdvertBreak> advertBreaks, AdPlaybackState adPlaybackState) {
+    static AdPlaybackState markAllPastAvailableAdvertsAsSkipped(long currentPositionInMillis,
+                                                                List<AdvertBreak> advertBreaks,
+                                                                AdPlaybackState adPlaybackState) {
         AdPlaybackState adPlaybackStateWithSkippedAdGroups = adPlaybackState;
         for (int i = advertBreaks.size() - 1; i >= 0; i--) {
             AdvertBreak advertBreak = advertBreaks.get(i);

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/SkippedAdverts.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/SkippedAdverts.java
@@ -32,4 +32,24 @@ final class SkippedAdverts {
         return adPlaybackStateWithSkippedAdGroups;
     }
 
+    /**
+     * Transforms all available adverts before a given position to skipped adverts.
+     *
+     * @param currentPositionInMillis The position before which all adverts will transition from Available to Skipped.
+     * @param advertBreaks            The client representation of the adverts, our source of truth.
+     * @param adPlaybackState         The {@link AdPlaybackState} to alter advert state on.
+     * @return The {@link AdPlaybackState} with the new Skipped states.
+     */
+    static AdPlaybackState markAllPastAvailableAdvertsAsSkipped(long currentPositionInMillis, List<AdvertBreak> advertBreaks, AdPlaybackState adPlaybackState) {
+        AdPlaybackState adPlaybackStateWithSkippedAdGroups = adPlaybackState;
+        for (int i = advertBreaks.size() - 1; i >= 0; i--) {
+            AdvertBreak advertBreak = advertBreaks.get(i);
+            AdPlaybackState.AdGroup adGroup = adPlaybackState.adGroups[i];
+            if (advertBreak.startTimeInMillis() < currentPositionInMillis && adGroup.hasUnplayedAds()) {
+                adPlaybackStateWithSkippedAdGroups = adPlaybackState.withSkippedAdGroup(i);
+            }
+        }
+        return adPlaybackStateWithSkippedAdGroups;
+    }
+
 }

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/SkippedAdvertsTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/SkippedAdvertsTest.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 import org.junit.Test;
 
+import static com.google.android.exoplayer2.source.ads.AdPlaybackState.AD_STATE_AVAILABLE;
 import static com.google.android.exoplayer2.source.ads.AdPlaybackState.AD_STATE_PLAYED;
 import static com.google.android.exoplayer2.source.ads.AdPlaybackState.AD_STATE_SKIPPED;
 import static com.novoda.noplayer.AdvertBreakFixtures.anAdvertBreak;
@@ -62,7 +63,38 @@ public class SkippedAdvertsTest {
         assertThatGroupContains(adPlaybackState.adGroups[3], new int[]{AD_STATE_SKIPPED});
     }
 
+    @Test
+    public void makesAvailableAdvertsBeforeCurrentPositionSkipped() {
+        AdPlaybackState initialAvailableAdPlaybackState = AdvertPlaybackState.from(ADVERT_BREAKS).adPlaybackState();
+        AdPlaybackState adPlaybackState = SkippedAdverts.markAllPastAvailableAdvertsAsSkipped(TWENTY_SECONDS_IN_MILLIS, ADVERT_BREAKS, initialAvailableAdPlaybackState);
+
+        assertThatGroupContains(adPlaybackState.adGroups[0], new int[]{AD_STATE_SKIPPED});
+        assertThatGroupContains(adPlaybackState.adGroups[1], new int[]{AD_STATE_AVAILABLE});
+        assertThatGroupContains(adPlaybackState.adGroups[2], new int[]{AD_STATE_AVAILABLE});
+        assertThatGroupContains(adPlaybackState.adGroups[3], new int[]{AD_STATE_AVAILABLE});
+    }
+
+    @Test
+    public void doesNotMarkAdvertsAlreadyPlayedAsSkipped() {
+        AdPlaybackState initialAvailableAdPlaybackState = adPlaybackStateWithPlayedAdverts();
+        AdPlaybackState adPlaybackState = SkippedAdverts.markAllPastAvailableAdvertsAsSkipped(TWENTY_SECONDS_IN_MILLIS, ADVERT_BREAKS, initialAvailableAdPlaybackState);
+
+        assertThatGroupContains(adPlaybackState.adGroups[0], new int[]{AD_STATE_PLAYED});
+        assertThatGroupContains(adPlaybackState.adGroups[1], new int[]{AD_STATE_PLAYED});
+        assertThatGroupContains(adPlaybackState.adGroups[2], new int[]{AD_STATE_PLAYED});
+        assertThatGroupContains(adPlaybackState.adGroups[3], new int[]{AD_STATE_PLAYED});
+    }
+
     private void assertThatGroupContains(AdPlaybackState.AdGroup adGroup, int[] states) {
         assertThat(adGroup.states).containsOnly(states);
+    }
+
+    private AdPlaybackState adPlaybackStateWithPlayedAdverts() {
+        AdPlaybackState adPlaybackState = AdvertPlaybackState.from(ADVERT_BREAKS).adPlaybackState();
+        adPlaybackState = adPlaybackState.withPlayedAd(0, 0);
+        adPlaybackState = adPlaybackState.withPlayedAd(1, 0);
+        adPlaybackState = adPlaybackState.withPlayedAd(2, 0);
+        adPlaybackState = adPlaybackState.withPlayedAd(3, 0);
+        return adPlaybackState;
     }
 }


### PR DESCRIPTION
## Problem
Suppose we have 3 advert breaks at 2, 4 and 6mins respectively. A user seeks to 4.5mins. The advert at 4mins is shown. Now the user scrubs back to 3.59mins, they are now presented with the advert at 2mins. This "problem" presents itself because adverts are treated as gateways to content. You cannot view a section of content without first viewing its associated gateway advert.

## Solution
When performing a seek backwards, temporarily disable the gateway advert for that piece of content.

### Test(s) added 
Added some tests to ensure that the correct adverts are `SKIPPED`.

### Paired with 
Nobody.
