### PR TITLE
Video type is lost when error is notified

### DIFF
--- a/core/src/main/java/com/novoda/noplayer/PlayerState.java
+++ b/core/src/main/java/com/novoda/noplayer/PlayerState.java
@@ -10,21 +10,6 @@ public interface PlayerState {
     boolean isPlaying();
 
     /**
-     * Returns {@code true} when player is prepared to start playing and adverts are loaded
-     * (see {@link PlayerBuilder#withAdverts(AdvertsLoader)}).
-     *
-     * @return true when player is prepared to play adverts.
-     */
-    boolean isSetToPlayAdvert();
-
-    /**
-     * Returns {@code true} when player is prepared to start playing content.
-     *
-     * @return true when player is prepared to play content.
-     */
-    boolean isSetToPlayContent();
-
-    /**
      * Returns an enum value that represents the the type of video (content or advert) that the player is playing or about to play.
      *
      * @return {@link VideoType#CONTENT} when player is prepared to start playing content

--- a/core/src/main/java/com/novoda/noplayer/PlayerState.java
+++ b/core/src/main/java/com/novoda/noplayer/PlayerState.java
@@ -11,7 +11,7 @@ public interface PlayerState {
 
     /**
      * Returns {@code true} when player is prepared to start playing and adverts are loaded
-     * (see {@link PlayerBuilder#withAdverts(AdvertsLoader)}.
+     * (see {@link PlayerBuilder#withAdverts(AdvertsLoader)}).
      *
      * @return true when player is prepared to play adverts.
      */
@@ -23,6 +23,15 @@ public interface PlayerState {
      * @return true when player is prepared to play content.
      */
     boolean isSetToPlayContent();
+
+    /**
+     * Returns an enum value that represents the the type of video (content or advert) that the player is playing or about to play.
+     *
+     * @return {@link VideoType#CONTENT} when player is prepared to start playing content
+     * {@link VideoType#ADVERT} when player is prepared to start playing advert (see {@link PlayerBuilder#withAdverts(AdvertsLoader)})
+     * {@link VideoType#UNDEFINED} when player is not ready to play (e.g. before video is loaded or after it was stopped)
+     */
+    VideoType videoType();
 
     /**
      * Width of the video.
@@ -90,4 +99,10 @@ public interface PlayerState {
      * @return percentage value between 0 and 100.
      */
     int bufferPercentage();
+
+    enum VideoType {
+        CONTENT,
+        ADVERT,
+        UNDEFINED
+    }
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
@@ -71,14 +71,6 @@ class ExoPlayerFacade {
         return exoPlayer != null && exoPlayer.getPlayWhenReady();
     }
 
-    boolean isSetToPlayAdvert() {
-        return exoPlayer != null && exoPlayer.isPlayingAd();
-    }
-
-    boolean isSetToPlayContent() {
-        return exoPlayer != null && !isSetToPlayAdvert();
-    }
-
     PlayerState.VideoType videoType() {
         if (exoPlayer == null) {
             return PlayerState.VideoType.UNDEFINED;
@@ -131,6 +123,11 @@ class ExoPlayerFacade {
 
         return 0;
     }
+
+    private boolean isSetToPlayAdvert() {
+        return videoType() == PlayerState.VideoType.ADVERT;
+    }
+
 
     private long combinedAdvertDurationInGroup(Timeline.Period period, int numberOfAdvertsToInclude) {
         int adGroupIndex = exoPlayer.getCurrentAdGroupIndex();

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
@@ -1,9 +1,7 @@
 package com.novoda.noplayer.internal.exoplayer;
 
 import android.net.Uri;
-
 import androidx.annotation.Nullable;
-
 import com.google.android.exoplayer2.C;
 import com.google.android.exoplayer2.Player;
 import com.google.android.exoplayer2.SimpleExoPlayer;
@@ -15,6 +13,7 @@ import com.google.android.exoplayer2.source.ads.SinglePeriodAdTimeline;
 import com.google.android.exoplayer2.upstream.DefaultBandwidthMeter;
 import com.novoda.noplayer.AdvertView;
 import com.novoda.noplayer.Options;
+import com.novoda.noplayer.PlayerState;
 import com.novoda.noplayer.PlayerSurfaceHolder;
 import com.novoda.noplayer.internal.exoplayer.drm.DrmSessionCreator;
 import com.novoda.noplayer.internal.exoplayer.forwarder.ExoPlayerForwarder;
@@ -78,6 +77,16 @@ class ExoPlayerFacade {
 
     boolean isSetToPlayContent() {
         return exoPlayer != null && !isSetToPlayAdvert();
+    }
+
+    PlayerState.VideoType videoType() {
+        if (exoPlayer == null) {
+            return PlayerState.VideoType.UNDEFINED;
+        }
+        if (exoPlayer.isPlayingAd()) {
+            return PlayerState.VideoType.ADVERT;
+        }
+        return PlayerState.VideoType.CONTENT;
     }
 
     long mediaDurationInMillis() throws IllegalStateException {

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImpl.java
@@ -64,7 +64,7 @@ class ExoPlayerTwoImpl implements NoPlayer {
         heart.bind(new Heart.Heartbeat(listenersHolder.getHeartbeatCallbacks(), this));
         forwarder.bind(listenersHolder.getPreparedListeners(), this);
         forwarder.bind(listenersHolder.getCompletionListeners(), listenersHolder.getStateChangedListeners());
-        forwarder.bind(listenersHolder.getErrorListeners(), resetOnErrorListener());
+        forwarder.bind(listenersHolder.getErrorListeners());
         forwarder.bind(listenersHolder.getBufferStateListeners());
         forwarder.bind(listenersHolder.getVideoSizeChangedListeners());
         forwarder.bind(listenersHolder.getBitrateChangedListeners());
@@ -72,6 +72,7 @@ class ExoPlayerTwoImpl implements NoPlayer {
         forwarder.bind(listenersHolder.getDroppedVideoFramesListeners());
         forwarder.bind(listenersHolder.getAdvertListeners());
         forwarder.bind(listenersHolder.getTracksChangedListeners());
+        forwarder.bind(resetOnErrorListener());
         listenersHolder.addPreparedListener(new PreparedListener() {
             @Override
             public void onPrepared(PlayerState playerState) {

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImpl.java
@@ -2,7 +2,7 @@ package com.novoda.noplayer.internal.exoplayer;
 
 import android.net.Uri;
 import android.view.View;
-
+import androidx.annotation.Nullable;
 import com.google.android.exoplayer2.mediacodec.MediaCodecSelector;
 import com.novoda.noplayer.AdvertView;
 import com.novoda.noplayer.Listeners;
@@ -24,8 +24,6 @@ import com.novoda.noplayer.model.PlayerVideoTrack;
 import com.novoda.noplayer.model.Timeout;
 
 import java.util.List;
-
-import androidx.annotation.Nullable;
 
 // Not much we can do, wrapping ExoPlayer is a lot of work
 @SuppressWarnings("PMD.GodClass")
@@ -66,7 +64,7 @@ class ExoPlayerTwoImpl implements NoPlayer {
         heart.bind(new Heart.Heartbeat(listenersHolder.getHeartbeatCallbacks(), this));
         forwarder.bind(listenersHolder.getPreparedListeners(), this);
         forwarder.bind(listenersHolder.getCompletionListeners(), listenersHolder.getStateChangedListeners());
-        forwarder.bind(listenersHolder.getErrorListeners());
+        forwarder.bind(listenersHolder.getErrorListeners(), resetOnErrorListener());
         forwarder.bind(listenersHolder.getBufferStateListeners());
         forwarder.bind(listenersHolder.getVideoSizeChangedListeners());
         forwarder.bind(listenersHolder.getBitrateChangedListeners());
@@ -80,12 +78,6 @@ class ExoPlayerTwoImpl implements NoPlayer {
                 loadTimeout.cancel();
             }
         });
-        listenersHolder.addErrorListener(new ErrorListener() {
-            @Override
-            public void onError(PlayerError error) {
-                reset();
-            }
-        });
         listenersHolder.addVideoSizeChangedListener(new VideoSizeChangedListener() {
             @Override
             public void onVideoSizeChanged(int width, int height, int unappliedRotationDegrees, float pixelWidthHeightRatio) {
@@ -93,6 +85,15 @@ class ExoPlayerTwoImpl implements NoPlayer {
                 videoHeight = height;
             }
         });
+    }
+
+    private ErrorListener resetOnErrorListener() {
+        return new ErrorListener() {
+            @Override
+            public void onError(PlayerError error) {
+                reset();
+            }
+        };
     }
 
     @Override

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImpl.java
@@ -112,6 +112,11 @@ class ExoPlayerTwoImpl implements NoPlayer {
     }
 
     @Override
+    public VideoType videoType() {
+        return exoPlayer.videoType();
+    }
+
+    @Override
     public int videoWidth() {
         return videoWidth;
     }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImpl.java
@@ -102,16 +102,6 @@ class ExoPlayerTwoImpl implements NoPlayer {
     }
 
     @Override
-    public boolean isSetToPlayAdvert() {
-        return exoPlayer.isSetToPlayAdvert();
-    }
-
-    @Override
-    public boolean isSetToPlayContent() {
-        return exoPlayer.isSetToPlayContent();
-    }
-
-    @Override
     public VideoType videoType() {
         return exoPlayer.videoType();
     }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/ExoPlayerForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/ExoPlayerForwarder.java
@@ -58,9 +58,8 @@ public class ExoPlayerForwarder {
         exoPlayerEventListener.add(new OnCompletionStateChangedForwarder(stateChangedListener));
     }
 
-    public void bind(NoPlayer.ErrorListener errorListener, NoPlayer.ErrorListener internalErrorListener) {
+    public void bind(NoPlayer.ErrorListener errorListener) {
         exoPlayerEventListener.add(new PlayerOnErrorForwarder(errorListener));
-        exoPlayerEventListener.add(new PlayerOnErrorForwarder(internalErrorListener));
     }
 
     public void bind(NoPlayer.BufferStateListener bufferStateListener) {

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/ExoPlayerForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/ExoPlayerForwarder.java
@@ -58,8 +58,9 @@ public class ExoPlayerForwarder {
         exoPlayerEventListener.add(new OnCompletionStateChangedForwarder(stateChangedListener));
     }
 
-    public void bind(NoPlayer.ErrorListener errorListener) {
+    public void bind(NoPlayer.ErrorListener errorListener, NoPlayer.ErrorListener internalErrorListener) {
         exoPlayerEventListener.add(new PlayerOnErrorForwarder(errorListener));
+        exoPlayerEventListener.add(new PlayerOnErrorForwarder(internalErrorListener));
     }
 
     public void bind(NoPlayer.BufferStateListener bufferStateListener) {

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImpl.java
@@ -5,7 +5,6 @@ import android.net.Uri;
 import android.view.Surface;
 import android.view.SurfaceHolder;
 import android.view.View;
-
 import com.novoda.noplayer.AdvertView;
 import com.novoda.noplayer.Listeners;
 import com.novoda.noplayer.NoPlayer;
@@ -217,6 +216,14 @@ class AndroidMediaPlayerImpl implements NoPlayer {
     @Override
     public boolean isSetToPlayContent() {
         return mediaPlayer.isPlaying();
+    }
+
+    @Override
+    public VideoType videoType() {
+        if (mediaPlayer.isPlaying()) {
+            return VideoType.CONTENT;
+        }
+        return VideoType.UNDEFINED;
     }
 
     @Override

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImpl.java
@@ -209,16 +209,6 @@ class AndroidMediaPlayerImpl implements NoPlayer {
     }
 
     @Override
-    public boolean isSetToPlayAdvert() {
-        return false;
-    }
-
-    @Override
-    public boolean isSetToPlayContent() {
-        return mediaPlayer.isPlaying();
-    }
-
-    @Override
     public VideoType videoType() {
         if (mediaPlayer.isPlaying()) {
             return VideoType.CONTENT;

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacadeTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacadeTest.java
@@ -21,6 +21,7 @@ import com.novoda.noplayer.ContentType;
 import com.novoda.noplayer.NoPlayer;
 import com.novoda.noplayer.Options;
 import com.novoda.noplayer.OptionsBuilder;
+import com.novoda.noplayer.PlayerState;
 import com.novoda.noplayer.PlayerSurfaceHolder;
 import com.novoda.noplayer.internal.exoplayer.drm.DrmSessionCreator;
 import com.novoda.noplayer.internal.exoplayer.forwarder.ExoPlayerForwarder;
@@ -304,6 +305,14 @@ public class ExoPlayerFacadeTest {
         }
 
         @Test
+        public void whenQueryingVideoType_thenReturnsUndefined() {
+
+            PlayerState.VideoType videoType = facade.videoType();
+
+            assertThat(videoType).isEqualTo(PlayerState.VideoType.UNDEFINED);
+        }
+
+        @Test
         public void whenQueryingPlayheadPosition_thenThrowsIllegalStateException() {
             thrown.expect(ExceptionMatcher.matches("Video must be loaded before trying to interact with the player", IllegalStateException.class));
 
@@ -483,6 +492,24 @@ public class ExoPlayerFacadeTest {
             boolean isPlaying = facade.isSetToPlayAdvert();
 
             assertThat(isPlaying).isFalse();
+        }
+
+        @Test
+        public void givenExoPlayerIsPlayingAd_whenQueryingVideoType_thenReturnsAdvert() {
+            given(exoPlayer.isPlayingAd()).willReturn(IS_PLAYING);
+
+            PlayerState.VideoType videoType = facade.videoType();
+
+            assertThat(videoType).isEqualTo(PlayerState.VideoType.ADVERT);
+        }
+
+        @Test
+        public void givenExoPlayerIsNotPlayingAd_whenQueryingVideoType_thenReturnsContent() {
+            given(exoPlayer.isPlayingAd()).willReturn(IS_NOT_PLAYING);
+
+            PlayerState.VideoType videoType = facade.videoType();
+
+            assertThat(videoType).isEqualTo(PlayerState.VideoType.CONTENT);
         }
 
         @Test

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacadeTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacadeTest.java
@@ -289,22 +289,6 @@ public class ExoPlayerFacadeTest {
         }
 
         @Test
-        public void whenQueryingIsSetToPlayAdvert_thenReturnsFalse() {
-
-            boolean isPlaying = facade.isSetToPlayAdvert();
-
-            assertThat(isPlaying).isFalse();
-        }
-
-        @Test
-        public void whenQueryingIsSetToPlayContent_thenReturnsFalse() {
-
-            boolean isPlaying = facade.isSetToPlayContent();
-
-            assertThat(isPlaying).isFalse();
-        }
-
-        @Test
         public void whenQueryingVideoType_thenReturnsUndefined() {
 
             PlayerState.VideoType videoType = facade.videoType();
@@ -477,24 +461,6 @@ public class ExoPlayerFacadeTest {
         }
 
         @Test
-        public void givenExoPlayerIsPlayingAd_whenQueryingIsSetToPlayAdvert_thenReturnsTrue() {
-            given(exoPlayer.isPlayingAd()).willReturn(IS_PLAYING);
-
-            boolean isPlaying = facade.isSetToPlayAdvert();
-
-            assertThat(isPlaying).isTrue();
-        }
-
-        @Test
-        public void givenExoPlayerIsNotPlayingAd_whenQueryingIsSetToPlayAdvert_thenReturnsFalse() {
-            given(exoPlayer.isPlayingAd()).willReturn(IS_NOT_PLAYING);
-
-            boolean isPlaying = facade.isSetToPlayAdvert();
-
-            assertThat(isPlaying).isFalse();
-        }
-
-        @Test
         public void givenExoPlayerIsPlayingAd_whenQueryingVideoType_thenReturnsAdvert() {
             given(exoPlayer.isPlayingAd()).willReturn(IS_PLAYING);
 
@@ -510,24 +476,6 @@ public class ExoPlayerFacadeTest {
             PlayerState.VideoType videoType = facade.videoType();
 
             assertThat(videoType).isEqualTo(PlayerState.VideoType.CONTENT);
-        }
-
-        @Test
-        public void givenExoPlayerIsPlayingAd_whenQueryingIsSetToPlayContent_thenReturnsFalse() {
-            given(exoPlayer.isPlayingAd()).willReturn(IS_PLAYING);
-
-            boolean isPlaying = facade.isSetToPlayContent();
-
-            assertThat(isPlaying).isFalse();
-        }
-
-        @Test
-        public void givenExoPlayerIsNotPlayingAd_whenQueryingIsSetToPlayContent_thenReturnsTrue() {
-            given(exoPlayer.isPlayingAd()).willReturn(IS_NOT_PLAYING);
-
-            boolean isPlaying = facade.isSetToPlayContent();
-
-            assertThat(isPlaying).isTrue();
         }
 
         @Test

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImplTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImplTest.java
@@ -40,6 +40,7 @@ import java.util.List;
 
 import static android.provider.CalendarContract.CalendarCache.URI;
 import static org.fest.assertions.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doAnswer;
@@ -83,7 +84,7 @@ public class ExoPlayerTwoImplTest {
 
             verify(forwarder).bind(preparedListener, player);
             verify(forwarder).bind(completionListener, stateChangedListener);
-            verify(forwarder).bind(errorListener);
+            verify(forwarder).bind(eq(errorListener), any(NoPlayer.ErrorListener.class));
             verify(forwarder).bind(bufferStateListener);
             verify(forwarder).bind(videoSizeChangedListener);
             verify(forwarder).bind(bitrateChangedListener);
@@ -117,7 +118,7 @@ public class ExoPlayerTwoImplTest {
 
             ArgumentCaptor<NoPlayer.ErrorListener> argumentCaptor = ArgumentCaptor.forClass(NoPlayer.ErrorListener.class);
 
-            verify(listenersHolder).addErrorListener(argumentCaptor.capture());
+            verify(forwarder).bind(any(NoPlayer.ErrorListener.class), argumentCaptor.capture());
             NoPlayer.ErrorListener errorListener = argumentCaptor.getValue();
             errorListener.onError(mock(NoPlayer.PlayerError.class));
 

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImplTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImplTest.java
@@ -40,7 +40,6 @@ import java.util.List;
 
 import static android.provider.CalendarContract.CalendarCache.URI;
 import static org.fest.assertions.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doAnswer;
@@ -84,7 +83,7 @@ public class ExoPlayerTwoImplTest {
 
             verify(forwarder).bind(preparedListener, player);
             verify(forwarder).bind(completionListener, stateChangedListener);
-            verify(forwarder).bind(eq(errorListener), any(NoPlayer.ErrorListener.class));
+            verify(forwarder).bind(errorListener);
             verify(forwarder).bind(bufferStateListener);
             verify(forwarder).bind(videoSizeChangedListener);
             verify(forwarder).bind(bitrateChangedListener);
@@ -118,8 +117,8 @@ public class ExoPlayerTwoImplTest {
 
             ArgumentCaptor<NoPlayer.ErrorListener> argumentCaptor = ArgumentCaptor.forClass(NoPlayer.ErrorListener.class);
 
-            verify(forwarder).bind(any(NoPlayer.ErrorListener.class), argumentCaptor.capture());
-            NoPlayer.ErrorListener errorListener = argumentCaptor.getValue();
+            verify(forwarder, times(2)).bind(argumentCaptor.capture());
+            NoPlayer.ErrorListener errorListener = argumentCaptor.getAllValues().get(1);
             errorListener.onError(mock(NoPlayer.PlayerError.class));
 
             verify(listenersHolder).resetState();

--- a/core/src/test/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImplTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImplTest.java
@@ -10,6 +10,7 @@ import com.novoda.noplayer.NoPlayer;
 import com.novoda.noplayer.Options;
 import com.novoda.noplayer.OptionsBuilder;
 import com.novoda.noplayer.PlayerInformation;
+import com.novoda.noplayer.PlayerState;
 import com.novoda.noplayer.PlayerSurfaceHolder;
 import com.novoda.noplayer.PlayerView;
 import com.novoda.noplayer.SurfaceRequester;
@@ -173,6 +174,24 @@ public class AndroidMediaPlayerImplTest {
             boolean isPlaying = player.isPlaying();
 
             assertThat(isPlaying).isTrue();
+        }
+
+        @Test
+        public void givenAndroidMediaPlayerIsPlaying_whenQueryingVideoType_thenReturnsContent() {
+            given(mediaPlayer.isPlaying()).willReturn(IS_PLAYING);
+
+            PlayerState.VideoType videoType = player.videoType();
+
+            assertThat(videoType).isEqualTo(PlayerState.VideoType.CONTENT);
+        }
+
+        @Test
+        public void givenAndroidMediaPlayerIsNotPlaying_whenQueryingVideoType_thenReturnsUndefined() {
+            given(mediaPlayer.isPlaying()).willReturn(false);
+
+            PlayerState.VideoType videoType = player.videoType();
+
+            assertThat(videoType).isEqualTo(PlayerState.VideoType.UNDEFINED);
         }
 
         @Test


### PR DESCRIPTION
## Problem

Error listener was notified after the player was released which meant that we were not able to decide what type of video the player was playing when the error happened.

## Solution

To fix this I register the listener that resets the player to be called _after_ all the client listeners are called. This is done in the `ExoPlayerForwarder` which binds the internal error listener after the error listeners from the `PlayerListenerHolder`.

I also changed the API to check the `VideoType` that is set to be played. Before we had two separate boolean methods but that makes them a bit hard to work with since the advert and content are mutually exclusive (ie. player can only play either content or advert and not both). But the player can also play nothing if it's not prepared. Having all these states in single method makes is easier to understand all the possible cases.

### Test(s) added 

updated where needed for the new behavior

### Screenshots

no UI changes

### Paired with 

nobody
