### PR TITLE
Mark adverts as skipped before content resume position

### DIFF
--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
@@ -32,7 +32,7 @@ import java.util.List;
 class ExoPlayerFacade {
 
     private static final boolean DO_NOT_RESET_STATE = false;
-    private static final long NO_AD_RESUME_POSITION = 0L;
+    private static final long NO_RESUME_POSITION = 0L;
 
     private final BandwidthMeterCreator bandwidthMeterCreator;
     private final AndroidDeviceVersion androidDeviceVersion;
@@ -206,8 +206,13 @@ class ExoPlayerFacade {
         setMovieAudioAttributes(exoPlayer);
 
         if (adsLoader.isPresent()) {
-            long advertBreakInitialPositionMillis = options.getInitialAdvertBreakPositionInMillis().or(NO_AD_RESUME_POSITION);
-            adsLoader.get().bind(forwarder.advertListener(), advertBreakInitialPositionMillis);
+            long advertBreakInitialPositionMillis = options.getInitialAdvertBreakPositionInMillis().or(NO_RESUME_POSITION);
+            long contentInitialPositionMillis = options.getInitialPositionInMillis().or(NO_RESUME_POSITION);
+            adsLoader.get().bind(
+                    forwarder.advertListener(),
+                    advertBreakInitialPositionMillis,
+                    contentInitialPositionMillis
+            );
         }
 
         MediaSource mediaSource = mediaSourceFactory.create(

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/SkippedAdverts.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/SkippedAdverts.java
@@ -43,15 +43,15 @@ final class SkippedAdverts {
     static AdPlaybackState markAllPastAvailableAdvertsAsSkipped(long currentPositionInMillis,
                                                                 List<AdvertBreak> advertBreaks,
                                                                 AdPlaybackState adPlaybackState) {
-        AdPlaybackState adPlaybackStateWithSkippedAdGroups = adPlaybackState;
+        AdPlaybackState updatedPlaybackState = adPlaybackState;
         for (int i = advertBreaks.size() - 1; i >= 0; i--) {
             AdvertBreak advertBreak = advertBreaks.get(i);
-            AdPlaybackState.AdGroup adGroup = adPlaybackState.adGroups[i];
+            AdPlaybackState.AdGroup adGroup = updatedPlaybackState.adGroups[i];
             if (advertBreak.startTimeInMillis() < currentPositionInMillis && adGroup.hasUnplayedAds()) {
-                adPlaybackStateWithSkippedAdGroups = adPlaybackState.withSkippedAdGroup(i);
+                updatedPlaybackState = updatedPlaybackState.withSkippedAdGroup(i);
             }
         }
-        return adPlaybackStateWithSkippedAdGroups;
+        return updatedPlaybackState;
     }
 
 }

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacadeTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacadeTest.java
@@ -129,7 +129,7 @@ public class ExoPlayerFacadeTest {
 
             facade.loadVideo(surfaceViewHolder, drmSessionCreator, uri, OPTIONS, exoPlayerForwarder, mediaCodecSelector);
 
-            verify(adsLoader).bind(optionalAdvertListener, NO_RESUME_POSITION);
+            verify(adsLoader).bind(optionalAdvertListener, NO_RESUME_POSITION, NO_RESUME_POSITION);
         }
 
         @Test
@@ -140,7 +140,7 @@ public class ExoPlayerFacadeTest {
 
             facade.loadVideo(surfaceViewHolder, drmSessionCreator, uri, OPTIONS, exoPlayerForwarder, mediaCodecSelector);
 
-            verify(adsLoader).bind(exoPlayerForwarder.advertListener(), NO_RESUME_POSITION);
+            verify(adsLoader).bind(exoPlayerForwarder.advertListener(), NO_RESUME_POSITION, NO_RESUME_POSITION);
         }
 
         @Test
@@ -169,7 +169,7 @@ public class ExoPlayerFacadeTest {
 
             facade.loadVideo(surfaceViewHolder, drmSessionCreator, uri, OPTIONS, exoPlayerForwarder, mediaCodecSelector);
 
-            verify(adsLoader, never()).bind(exoPlayerForwarder.advertListener(), NO_RESUME_POSITION);
+            verify(adsLoader, never()).bind(exoPlayerForwarder.advertListener(), NO_RESUME_POSITION, NO_RESUME_POSITION);
         }
 
         @Test
@@ -177,7 +177,7 @@ public class ExoPlayerFacadeTest {
 
             facade.loadVideo(surfaceViewHolder, drmSessionCreator, uri, OPTIONS, exoPlayerForwarder, mediaCodecSelector);
 
-            verify(adsLoader, never()).bind(exoPlayerForwarder.advertListener(), NO_RESUME_POSITION);
+            verify(adsLoader, never()).bind(exoPlayerForwarder.advertListener(), NO_RESUME_POSITION, NO_RESUME_POSITION);
         }
 
         @Test
@@ -190,7 +190,20 @@ public class ExoPlayerFacadeTest {
 
             facade.loadVideo(surfaceViewHolder, drmSessionCreator, uri, options, exoPlayerForwarder, mediaCodecSelector);
 
-            verify(adsLoader).bind(exoPlayerForwarder.advertListener(), TWENTY_FIVE_SECONDS_IN_MILLIS);
+            verify(adsLoader).bind(exoPlayerForwarder.advertListener(), TWENTY_FIVE_SECONDS_IN_MILLIS, NO_RESUME_POSITION);
+        }
+
+        @Test
+        public void givenInitialContentPosition_whenLoadingVideo_thenBindsAdvertListenerWithInitialContentPosition() {
+            Options options = OPTIONS.toOptionsBuilder()
+                    .withInitialPositionInMillis(TWENTY_FIVE_SECONDS_IN_MILLIS)
+                    .build();
+            given(optionalAdsLoader.isPresent()).willReturn(true);
+            given(optionalAdsLoader.get()).willReturn(adsLoader);
+
+            facade.loadVideo(surfaceViewHolder, drmSessionCreator, uri, options, exoPlayerForwarder, mediaCodecSelector);
+
+            verify(adsLoader).bind(exoPlayerForwarder.advertListener(), NO_RESUME_POSITION, TWENTY_FIVE_SECONDS_IN_MILLIS);
         }
 
         @Test

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoaderTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoaderTest.java
@@ -77,7 +77,7 @@ public class NoPlayerAdsLoaderTest {
     @Test
     public void notifiesAdvertListenerWhenAdvertLoadingFails() {
         IOException error = new IOException("some error");
-        noPlayerAdsLoader.bind(Optional.of(advertListener), NO_AD_RESUME_POSITION);
+        noPlayerAdsLoader.bind(Optional.of(advertListener), NO_AD_RESUME_POSITION, NO_AD_RESUME_POSITION);
         noPlayerAdsLoader.start(eventListener, adViewProvider);
 
         invokeCallback().onAdvertsError(error);
@@ -87,7 +87,7 @@ public class NoPlayerAdsLoaderTest {
 
     @Test
     public void notifiesAdvertListenerWhenAdvertLoadingSucceeds() {
-        noPlayerAdsLoader.bind(Optional.of(advertListener), NO_AD_RESUME_POSITION);
+        noPlayerAdsLoader.bind(Optional.of(advertListener), NO_AD_RESUME_POSITION, NO_AD_RESUME_POSITION);
 
         noPlayerAdsLoader.start(eventListener, adViewProvider);
         invokeCallback().onAdvertsLoaded(Arrays.asList(FIRST_ADVERT_BREAK, SECOND_ADVERT_BREAK));
@@ -145,7 +145,7 @@ public class NoPlayerAdsLoaderTest {
 
     @Test
     public void notifiesAdvertListenerWhenAdvertPreparingFails() {
-        noPlayerAdsLoader.bind(Optional.of(advertListener), NO_AD_RESUME_POSITION);
+        noPlayerAdsLoader.bind(Optional.of(advertListener), NO_AD_RESUME_POSITION, NO_AD_RESUME_POSITION);
         noPlayerAdsLoader.start(eventListener, adViewProvider);
         invokeCallback().onAdvertsLoaded(Arrays.asList(FIRST_ADVERT_BREAK, SECOND_ADVERT_BREAK));
 

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/SkippedAdvertsTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/SkippedAdvertsTest.java
@@ -2,15 +2,12 @@ package com.novoda.noplayer.internal.exoplayer;
 
 import com.google.android.exoplayer2.source.ads.AdPlaybackState;
 import com.novoda.noplayer.AdvertBreak;
+import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.Test;
-
-import static com.google.android.exoplayer2.source.ads.AdPlaybackState.AD_STATE_AVAILABLE;
-import static com.google.android.exoplayer2.source.ads.AdPlaybackState.AD_STATE_PLAYED;
-import static com.google.android.exoplayer2.source.ads.AdPlaybackState.AD_STATE_SKIPPED;
+import static com.google.android.exoplayer2.source.ads.AdPlaybackState.*;
 import static com.novoda.noplayer.AdvertBreakFixtures.anAdvertBreak;
 import static com.novoda.noplayer.AdvertFixtures.anAdvert;
 import static org.fest.assertions.api.Assertions.assertThat;
@@ -66,10 +63,10 @@ public class SkippedAdvertsTest {
     @Test
     public void makesAvailableAdvertsBeforeCurrentPositionSkipped() {
         AdPlaybackState initialAvailableAdPlaybackState = AdvertPlaybackState.from(ADVERT_BREAKS).adPlaybackState();
-        AdPlaybackState adPlaybackState = SkippedAdverts.markAllPastAvailableAdvertsAsSkipped(TWENTY_SECONDS_IN_MILLIS, ADVERT_BREAKS, initialAvailableAdPlaybackState);
+        AdPlaybackState adPlaybackState = SkippedAdverts.markAllPastAvailableAdvertsAsSkipped(TWENTY_SECONDS_IN_MILLIS + 1, ADVERT_BREAKS, initialAvailableAdPlaybackState);
 
         assertThatGroupContains(adPlaybackState.adGroups[0], new int[]{AD_STATE_SKIPPED});
-        assertThatGroupContains(adPlaybackState.adGroups[1], new int[]{AD_STATE_AVAILABLE});
+        assertThatGroupContains(adPlaybackState.adGroups[1], new int[]{AD_STATE_SKIPPED});
         assertThatGroupContains(adPlaybackState.adGroups[2], new int[]{AD_STATE_AVAILABLE});
         assertThatGroupContains(adPlaybackState.adGroups[3], new int[]{AD_STATE_AVAILABLE});
     }


### PR DESCRIPTION
## Problem

When a content is started with a resume position then the player always plays the advert that is before the initial position (same issue as #243).

## Solution

The fix is the same as in (#243), that is using the initial content position in the same way as seek position was used before. For that we need to pass the initial position to the `NoPlayerAdsLoader`.

I also fixed a bug where only the earliest advert block would be marked as skipped.

### Test(s) added 

updated where necessary to include the new changes, and I also modified the existing test to reveal the bug

### Screenshots

n/a

### Paired with 

nobody
