### PR TITLE
Allow no-player to skip a given advert break

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -65,7 +65,7 @@ dependencies {
     implementation 'androidx.annotation:annotation:1.0.2'
 
     testImplementation 'junit:junit:4.12'
-    testImplementation 'org.mockito:mockito-core:2.27.0'
+    testImplementation 'org.mockito:mockito-core:2.28.2'
     testImplementation 'org.easytesting:fest-assert-core:2.0M10'
 }
 

--- a/core/src/main/java/com/novoda/noplayer/NoPlayer.java
+++ b/core/src/main/java/com/novoda/noplayer/NoPlayer.java
@@ -136,7 +136,7 @@ public interface NoPlayer extends PlayerState {
 
     void disableAdverts();
 
-    void skipAdverts(@NonNull AdvertBreak advertBreak);
+    void skipAdvertBreak(@NonNull AdvertBreak advertBreak);
 
     void enableAdverts();
 

--- a/core/src/main/java/com/novoda/noplayer/NoPlayer.java
+++ b/core/src/main/java/com/novoda/noplayer/NoPlayer.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Map;
 
 import androidx.annotation.FloatRange;
+import androidx.annotation.NonNull;
 
 // There are a lot of features for playing and monitoring video.
 @SuppressWarnings("PMD.ExcessivePublicCount")
@@ -134,6 +135,8 @@ public interface NoPlayer extends PlayerState {
     void detach(AdvertView advertView);
 
     void disableAdverts();
+
+    void skipAdverts(@NonNull AdvertBreak advertBreak);
 
     void enableAdverts();
 
@@ -393,6 +396,12 @@ public interface NoPlayer extends PlayerState {
          */
         void onAdvertsEnabled(List<AdvertBreak> advertBreaks);
 
+        /**
+         * Called when advert break is skipped or prior to being skipped
+         *
+         * @param advertBreak that is being skipped.
+         */
+        void onAdvertsSkipped(AdvertBreak advertBreak);
     }
 
     /**

--- a/core/src/main/java/com/novoda/noplayer/NoPlayer.java
+++ b/core/src/main/java/com/novoda/noplayer/NoPlayer.java
@@ -16,7 +16,6 @@ import java.util.List;
 import java.util.Map;
 
 import androidx.annotation.FloatRange;
-import androidx.annotation.NonNull;
 
 // There are a lot of features for playing and monitoring video.
 @SuppressWarnings("PMD.ExcessivePublicCount")
@@ -136,7 +135,9 @@ public interface NoPlayer extends PlayerState {
 
     void disableAdverts();
 
-    void skipAdvertBreak(@NonNull AdvertBreak advertBreak);
+    void skipAdvertBreak();
+
+    void skipAdvert();
 
     void enableAdverts();
 
@@ -401,7 +402,14 @@ public interface NoPlayer extends PlayerState {
          *
          * @param advertBreak that is being skipped.
          */
-        void onAdvertsSkipped(AdvertBreak advertBreak);
+        void onAdvertBreakSkipped(AdvertBreak advertBreak);
+
+        /**
+         * Called when advert is skipped or prior to being skipped
+         *
+         * @param advert that is being skipped.
+         */
+        void onAdvertSkipped(Advert advert);
     }
 
     /**

--- a/core/src/main/java/com/novoda/noplayer/SimpleAdvertListener.java
+++ b/core/src/main/java/com/novoda/noplayer/SimpleAdvertListener.java
@@ -55,4 +55,9 @@ public class SimpleAdvertListener implements NoPlayer.AdvertListener {
         // no-op
     }
 
+    @Override
+    public void onAdvertsSkipped(AdvertBreak advertBreak) {
+        // no-op
+    }
+
 }

--- a/core/src/main/java/com/novoda/noplayer/SimpleAdvertListener.java
+++ b/core/src/main/java/com/novoda/noplayer/SimpleAdvertListener.java
@@ -56,7 +56,12 @@ public class SimpleAdvertListener implements NoPlayer.AdvertListener {
     }
 
     @Override
-    public void onAdvertsSkipped(AdvertBreak advertBreak) {
+    public void onAdvertBreakSkipped(AdvertBreak advertBreak) {
+        // no-op
+    }
+
+    @Override
+    public void onAdvertSkipped(Advert advert) {
         // no-op
     }
 

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/AvailableAdverts.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/AvailableAdverts.java
@@ -35,4 +35,16 @@ final class AvailableAdverts {
             }
         }
     }
+
+    static void markAllFutureAdvertsAsPlayed(long currentPositionInMillis, List<AdvertBreak> advertBreaks, AdPlaybackState adPlaybackState) {
+        for (int i = advertBreaks.size() - 1; i >= 0; i--) {
+            AdvertBreak advertBreak = advertBreaks.get(i);
+            AdPlaybackState.AdGroup adGroup = adPlaybackState.adGroups[i];
+            if (advertBreak.startTimeInMillis() >= currentPositionInMillis) {
+                for (int stateIndex = 0; stateIndex < adGroup.states.length; stateIndex++) {
+                    adGroup.states[stateIndex] = AdPlaybackState.AD_STATE_PLAYED;
+                }
+            }
+        }
+    }
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/AvailableAdverts.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/AvailableAdverts.java
@@ -36,15 +36,4 @@ final class AvailableAdverts {
         }
     }
 
-    static void markAllFutureAdvertsAsPlayed(long currentPositionInMillis, List<AdvertBreak> advertBreaks, AdPlaybackState adPlaybackState) {
-        for (int i = advertBreaks.size() - 1; i >= 0; i--) {
-            AdvertBreak advertBreak = advertBreaks.get(i);
-            AdPlaybackState.AdGroup adGroup = adPlaybackState.adGroups[i];
-            if (advertBreak.startTimeInMillis() >= currentPositionInMillis) {
-                for (int stateIndex = 0; stateIndex < adGroup.states.length; stateIndex++) {
-                    adGroup.states[stateIndex] = AdPlaybackState.AD_STATE_PLAYED;
-                }
-            }
-        }
-    }
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
@@ -11,7 +11,6 @@ import com.google.android.exoplayer2.mediacodec.MediaCodecSelector;
 import com.google.android.exoplayer2.source.MediaSource;
 import com.google.android.exoplayer2.source.ads.SinglePeriodAdTimeline;
 import com.google.android.exoplayer2.upstream.DefaultBandwidthMeter;
-import com.novoda.noplayer.AdvertBreak;
 import com.novoda.noplayer.AdvertView;
 import com.novoda.noplayer.Options;
 import com.novoda.noplayer.PlayerState;
@@ -367,10 +366,17 @@ class ExoPlayerFacade {
         }
     }
 
-    void skipAdvertBreak(AdvertBreak advertBreak) {
+    void skipAdvertBreak() {
         if (adsLoader.isPresent()) {
             NoPlayerAdsLoader adsLoader = this.adsLoader.get();
-            adsLoader.skipAdvertBreak(advertBreak);
+            adsLoader.skipAdvertBreak();
+        }
+    }
+
+    void skipAdvert() {
+        if (adsLoader.isPresent()) {
+            NoPlayerAdsLoader adsLoader = this.adsLoader.get();
+            adsLoader.skipAdvert();
         }
     }
 

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
@@ -28,7 +28,6 @@ import com.novoda.noplayer.model.PlayerVideoTrack;
 
 import java.util.List;
 
-import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 // Not much we can do, wrapping ExoPlayer is a lot of work
@@ -368,10 +367,10 @@ class ExoPlayerFacade {
         }
     }
 
-    void skipAdverts(@NonNull AdvertBreak advertBreak) {
+    void skipAdvertBreak(AdvertBreak advertBreak) {
         if (adsLoader.isPresent()) {
             NoPlayerAdsLoader adsLoader = this.adsLoader.get();
-            adsLoader.skipAdverts(advertBreak);
+            adsLoader.skipAdvertBreak(advertBreak);
         }
     }
 

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
@@ -1,7 +1,7 @@
 package com.novoda.noplayer.internal.exoplayer;
 
 import android.net.Uri;
-import androidx.annotation.Nullable;
+
 import com.google.android.exoplayer2.C;
 import com.google.android.exoplayer2.Player;
 import com.google.android.exoplayer2.SimpleExoPlayer;
@@ -11,6 +11,7 @@ import com.google.android.exoplayer2.mediacodec.MediaCodecSelector;
 import com.google.android.exoplayer2.source.MediaSource;
 import com.google.android.exoplayer2.source.ads.SinglePeriodAdTimeline;
 import com.google.android.exoplayer2.upstream.DefaultBandwidthMeter;
+import com.novoda.noplayer.AdvertBreak;
 import com.novoda.noplayer.AdvertView;
 import com.novoda.noplayer.Options;
 import com.novoda.noplayer.PlayerState;
@@ -26,6 +27,9 @@ import com.novoda.noplayer.model.PlayerSubtitleTrack;
 import com.novoda.noplayer.model.PlayerVideoTrack;
 
 import java.util.List;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 // Not much we can do, wrapping ExoPlayer is a lot of work
 @SuppressWarnings("PMD.GodClass")
@@ -127,7 +131,6 @@ class ExoPlayerFacade {
     private boolean isSetToPlayAdvert() {
         return videoType() == PlayerState.VideoType.ADVERT;
     }
-
 
     private long combinedAdvertDurationInGroup(Timeline.Period period, int numberOfAdvertsToInclude) {
         int adGroupIndex = exoPlayer.getCurrentAdGroupIndex();
@@ -362,6 +365,13 @@ class ExoPlayerFacade {
         if (adsLoader.isPresent()) {
             NoPlayerAdsLoader adsLoader = this.adsLoader.get();
             adsLoader.disableAdverts();
+        }
+    }
+
+    void skipAdverts(@NonNull AdvertBreak advertBreak) {
+        if (adsLoader.isPresent()) {
+            NoPlayerAdsLoader adsLoader = this.adsLoader.get();
+            adsLoader.skipAdverts(advertBreak);
         }
     }
 

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImpl.java
@@ -294,8 +294,8 @@ class ExoPlayerTwoImpl implements NoPlayer {
     }
 
     @Override
-    public void skipAdverts(@NonNull AdvertBreak advertBreak) {
-        exoPlayer.skipAdverts(advertBreak);
+    public void skipAdvertBreak(@NonNull AdvertBreak advertBreak) {
+        exoPlayer.skipAdvertBreak(advertBreak);
     }
 
     @Override

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImpl.java
@@ -4,7 +4,6 @@ import android.net.Uri;
 import android.view.View;
 
 import com.google.android.exoplayer2.mediacodec.MediaCodecSelector;
-import com.novoda.noplayer.AdvertBreak;
 import com.novoda.noplayer.AdvertView;
 import com.novoda.noplayer.Listeners;
 import com.novoda.noplayer.NoPlayer;
@@ -26,7 +25,6 @@ import com.novoda.noplayer.model.Timeout;
 
 import java.util.List;
 
-import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 // Not much we can do, wrapping ExoPlayer is a lot of work
@@ -294,8 +292,13 @@ class ExoPlayerTwoImpl implements NoPlayer {
     }
 
     @Override
-    public void skipAdvertBreak(@NonNull AdvertBreak advertBreak) {
-        exoPlayer.skipAdvertBreak(advertBreak);
+    public void skipAdvertBreak() {
+        exoPlayer.skipAdvertBreak();
+    }
+
+    @Override
+    public void skipAdvert() {
+        exoPlayer.skipAdvert();
     }
 
     @Override

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImpl.java
@@ -2,8 +2,9 @@ package com.novoda.noplayer.internal.exoplayer;
 
 import android.net.Uri;
 import android.view.View;
-import androidx.annotation.Nullable;
+
 import com.google.android.exoplayer2.mediacodec.MediaCodecSelector;
+import com.novoda.noplayer.AdvertBreak;
 import com.novoda.noplayer.AdvertView;
 import com.novoda.noplayer.Listeners;
 import com.novoda.noplayer.NoPlayer;
@@ -24,6 +25,9 @@ import com.novoda.noplayer.model.PlayerVideoTrack;
 import com.novoda.noplayer.model.Timeout;
 
 import java.util.List;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 // Not much we can do, wrapping ExoPlayer is a lot of work
 @SuppressWarnings("PMD.GodClass")
@@ -287,6 +291,11 @@ class ExoPlayerTwoImpl implements NoPlayer {
     @Override
     public void disableAdverts() {
         exoPlayer.disableAdverts();
+    }
+
+    @Override
+    public void skipAdverts(@NonNull AdvertBreak advertBreak) {
+        exoPlayer.skipAdverts(advertBreak);
     }
 
     @Override

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImpl.java
@@ -28,7 +28,7 @@ import java.util.List;
 import androidx.annotation.Nullable;
 
 // Not much we can do, wrapping ExoPlayer is a lot of work
-@SuppressWarnings("PMD.GodClass")
+@SuppressWarnings({"PMD.GodClass", "PMD.ExcessivePublicCount"})
 class ExoPlayerTwoImpl implements NoPlayer {
 
     private final ExoPlayerFacade exoPlayer;

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoOpAdvertListener.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoOpAdvertListener.java
@@ -60,4 +60,9 @@ enum NoOpAdvertListener implements NoPlayer.AdvertListener {
         // no-op
     }
 
+    @Override
+    public void onAdvertsSkipped(AdvertBreak advertBreak) {
+        // no-op
+    }
+
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoOpAdvertListener.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoOpAdvertListener.java
@@ -61,7 +61,12 @@ enum NoOpAdvertListener implements NoPlayer.AdvertListener {
     }
 
     @Override
-    public void onAdvertsSkipped(AdvertBreak advertBreak) {
+    public void onAdvertBreakSkipped(AdvertBreak advertBreak) {
+        // no-op
+    }
+
+    @Override
+    public void onAdvertSkipped(Advert advert) {
         // no-op
     }
 

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
@@ -21,7 +21,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 // Not much we can do, orchestrating adverts is a lot of work.
@@ -289,19 +288,19 @@ public class NoPlayerAdsLoader implements AdsLoader, Player.EventListener, Adver
             return;
         }
 
-        adPlaybackState = SkippedAdverts.markAllNonPlayedAdvertsAsSkipped(advertBreaks, adPlaybackState);
+        adPlaybackState = SkippedAdverts.markAdvertBreakAsSkipped(advertBreaks, adPlaybackState);
         updateAdPlaybackState();
         advertListener.onAdvertsDisabled();
         resetAdvertPosition();
         advertsDisabled = true;
     }
 
-    void skipAdverts(@NonNull AdvertBreak advertBreak) {
+    void skipAdvertBreak(AdvertBreak advertBreak) {
         if (adPlaybackState == null || player == null || advertsDisabled) {
             return;
         }
 
-        adPlaybackState = SkippedAdverts.markAllNonPlayedAdvertsAsSkipped(advertBreak, advertBreaks, adPlaybackState);
+        adPlaybackState = SkippedAdverts.markAdvertBreakAsSkipped(advertBreak, advertBreaks, adPlaybackState);
         updateAdPlaybackState();
         advertListener.onAdvertsSkipped(advertBreak);
         resetAdvertPosition();

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
@@ -2,7 +2,7 @@ package com.novoda.noplayer.internal.exoplayer;
 
 import android.os.Handler;
 import android.os.Looper;
-import androidx.annotation.Nullable;
+
 import com.google.android.exoplayer2.C;
 import com.google.android.exoplayer2.Player;
 import com.google.android.exoplayer2.Timeline;
@@ -20,6 +20,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 // Not much we can do, orchestrating adverts is a lot of work.
 @SuppressWarnings("PMD.GodClass")
@@ -291,6 +294,17 @@ public class NoPlayerAdsLoader implements AdsLoader, Player.EventListener, Adver
         advertListener.onAdvertsDisabled();
         resetAdvertPosition();
         advertsDisabled = true;
+    }
+
+    void skipAdverts(@NonNull AdvertBreak advertBreak) {
+        if (adPlaybackState == null || player == null || advertsDisabled) {
+            return;
+        }
+
+        adPlaybackState = SkippedAdverts.markAllNonPlayedAdvertsAsSkipped(advertBreak, advertBreaks, adPlaybackState);
+        updateAdPlaybackState();
+        advertListener.onAdvertsSkipped(advertBreak);
+        resetAdvertPosition();
     }
 
     void enableAdverts() {

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
@@ -295,14 +295,25 @@ public class NoPlayerAdsLoader implements AdsLoader, Player.EventListener, Adver
         advertsDisabled = true;
     }
 
-    void skipAdvertBreak(AdvertBreak advertBreak) {
-        if (adPlaybackState == null || player == null || advertsDisabled) {
+    void skipAdvertBreak() {
+        if (adPlaybackState == null || player == null || advertsDisabled || adGroupIndex < 0) {
             return;
         }
 
-        adPlaybackState = SkippedAdverts.markAdvertBreakAsSkipped(advertBreak, advertBreaks, adPlaybackState);
+        adPlaybackState = SkippedAdverts.markAdvertBreakAsSkipped(adGroupIndex, adPlaybackState);
         updateAdPlaybackState();
-        advertListener.onAdvertsSkipped(advertBreak);
+        advertListener.onAdvertBreakSkipped(advertBreaks.get(adGroupIndex));
+        resetAdvertPosition();
+    }
+
+    void skipAdvert() {
+        if (adPlaybackState == null || player == null || advertsDisabled || adIndexInGroup < 0 || adGroupIndex < 0) {
+            return;
+        }
+
+        adPlaybackState = SkippedAdverts.markAdvertAsSkipped(adIndexInGroup, adGroupIndex, adPlaybackState);
+        updateAdPlaybackState();
+        advertListener.onAdvertSkipped(advertBreaks.get(adGroupIndex).adverts().get(adIndexInGroup));
         resetAdvertPosition();
     }
 

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/SkippedAdverts.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/SkippedAdverts.java
@@ -33,6 +33,21 @@ final class SkippedAdverts {
     }
 
     /**
+     * Transforms all adverts in the given break that are not currently Played to Skipped.
+     *
+     * @param advertBreaks    The client representation of all the adverts break.
+     * @param advertBreak    The client representation of the advert break to be skipped.
+     * @param adPlaybackState The {@link AdPlaybackState} to alter advert state on.
+     * @return The {@link AdPlaybackState} with the new Skipped states.
+     */
+    static AdPlaybackState markAllNonPlayedAdvertsAsSkipped(AdvertBreak advertBreak, List<AdvertBreak> advertBreaks, AdPlaybackState adPlaybackState) {
+        AdPlaybackState adPlaybackStateWithSkippedAdGroups = adPlaybackState;
+        int breakIndex = advertBreaks.indexOf(advertBreak);
+        adPlaybackStateWithSkippedAdGroups = adPlaybackStateWithSkippedAdGroups.withSkippedAdGroup(breakIndex);
+        return adPlaybackStateWithSkippedAdGroups;
+    }
+
+    /**
      * Transforms all available adverts before a given position to skipped adverts.
      *
      * @param currentPositionInMillis The position before which all adverts will transition from Available to Skipped.

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/SkippedAdverts.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/SkippedAdverts.java
@@ -24,7 +24,7 @@ final class SkippedAdverts {
      * @param adPlaybackState The {@link AdPlaybackState} to alter advert state on.
      * @return The {@link AdPlaybackState} with the new Skipped states.
      */
-    static AdPlaybackState markAllNonPlayedAdvertsAsSkipped(List<AdvertBreak> advertBreaks, AdPlaybackState adPlaybackState) {
+    static AdPlaybackState markAdvertBreakAsSkipped(List<AdvertBreak> advertBreaks, AdPlaybackState adPlaybackState) {
         AdPlaybackState adPlaybackStateWithSkippedAdGroups = adPlaybackState;
         for (int i = advertBreaks.size() - 1; i >= 0; i--) {
             adPlaybackStateWithSkippedAdGroups = adPlaybackStateWithSkippedAdGroups.withSkippedAdGroup(i);
@@ -36,15 +36,13 @@ final class SkippedAdverts {
      * Transforms all adverts in the given break that are not currently Played to Skipped.
      *
      * @param advertBreaks    The client representation of all the adverts break.
-     * @param advertBreak    The client representation of the advert break to be skipped.
+     * @param advertBreak     The client representation of the advert break to be skipped.
      * @param adPlaybackState The {@link AdPlaybackState} to alter advert state on.
      * @return The {@link AdPlaybackState} with the new Skipped states.
      */
-    static AdPlaybackState markAllNonPlayedAdvertsAsSkipped(AdvertBreak advertBreak, List<AdvertBreak> advertBreaks, AdPlaybackState adPlaybackState) {
-        AdPlaybackState adPlaybackStateWithSkippedAdGroups = adPlaybackState;
+    static AdPlaybackState markAdvertBreakAsSkipped(AdvertBreak advertBreak, List<AdvertBreak> advertBreaks, AdPlaybackState adPlaybackState) {
         int breakIndex = advertBreaks.indexOf(advertBreak);
-        adPlaybackStateWithSkippedAdGroups = adPlaybackStateWithSkippedAdGroups.withSkippedAdGroup(breakIndex);
-        return adPlaybackStateWithSkippedAdGroups;
+        return adPlaybackState.withSkippedAdGroup(breakIndex);
     }
 
     /**

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/SkippedAdverts.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/SkippedAdverts.java
@@ -35,14 +35,24 @@ final class SkippedAdverts {
     /**
      * Transforms all adverts in the given break that are not currently Played to Skipped.
      *
-     * @param advertBreaks    The client representation of all the adverts break.
-     * @param advertBreak     The client representation of the advert break to be skipped.
+     * @param adGroupIndex    The index of the advert break inside the group to be skipped
      * @param adPlaybackState The {@link AdPlaybackState} to alter advert state on.
      * @return The {@link AdPlaybackState} with the new Skipped states.
      */
-    static AdPlaybackState markAdvertBreakAsSkipped(AdvertBreak advertBreak, List<AdvertBreak> advertBreaks, AdPlaybackState adPlaybackState) {
-        int breakIndex = advertBreaks.indexOf(advertBreak);
-        return adPlaybackState.withSkippedAdGroup(breakIndex);
+    static AdPlaybackState markAdvertBreakAsSkipped(int adGroupIndex, AdPlaybackState adPlaybackState) {
+        return adPlaybackState.withSkippedAdGroup(adGroupIndex);
+    }
+
+    /**
+     * Transforms all adverts in the given break that are not currently Played to Skipped.
+     *
+     * @param adIndexInAdGroup The index of the advert inside the break to be skipped
+     * @param adGroupIndex     The index of the advert break inside the group to be skipped
+     * @param adPlaybackState  The {@link AdPlaybackState} to alter advert state on.
+     * @return The {@link AdPlaybackState} with the new Skipped states.
+     */
+    static AdPlaybackState markAdvertAsSkipped(int adIndexInAdGroup, int adGroupIndex, AdPlaybackState adPlaybackState) {
+        return adPlaybackState.withSkippedAd(adGroupIndex, adIndexInAdGroup);
     }
 
     /**

--- a/core/src/main/java/com/novoda/noplayer/internal/listeners/AdvertListeners.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/listeners/AdvertListeners.java
@@ -98,9 +98,16 @@ class AdvertListeners implements NoPlayer.AdvertListener {
     }
 
     @Override
-    public void onAdvertsSkipped(@NonNull AdvertBreak advertBreak) {
+    public void onAdvertBreakSkipped(@NonNull AdvertBreak advertBreak) {
         for (NoPlayer.AdvertListener listener : listeners) {
-            listener.onAdvertsSkipped(advertBreak);
+            listener.onAdvertBreakSkipped(advertBreak);
+        }
+    }
+
+    @Override
+    public void onAdvertSkipped(Advert advert) {
+        for (NoPlayer.AdvertListener listener : listeners) {
+            listener.onAdvertSkipped(advert);
         }
     }
 

--- a/core/src/main/java/com/novoda/noplayer/internal/listeners/AdvertListeners.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/listeners/AdvertListeners.java
@@ -9,6 +9,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 
+import androidx.annotation.NonNull;
+
 class AdvertListeners implements NoPlayer.AdvertListener {
 
     private final Set<NoPlayer.AdvertListener> listeners = new CopyOnWriteArraySet<>();
@@ -92,6 +94,13 @@ class AdvertListeners implements NoPlayer.AdvertListener {
     public void onAdvertsEnabled(List<AdvertBreak> advertBreaks) {
         for (NoPlayer.AdvertListener listener : listeners) {
             listener.onAdvertsEnabled(advertBreaks);
+        }
+    }
+
+    @Override
+    public void onAdvertsSkipped(@NonNull AdvertBreak advertBreak) {
+        for (NoPlayer.AdvertListener listener : listeners) {
+            listener.onAdvertsSkipped(advertBreak);
         }
     }
 

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerFacade.java
@@ -25,7 +25,6 @@ import java.util.Map;
 
 import androidx.annotation.Nullable;
 
-import static com.novoda.noplayer.internal.mediaplayer.PlaybackStateChecker.PlaybackState.*;
 
 // Not much we can do, wrapping MediaPlayer is a lot of work
 @SuppressWarnings("PMD.GodClass")
@@ -40,7 +39,7 @@ class AndroidMediaPlayerFacade {
     private final PlaybackStateChecker playbackStateChecker;
     private final MediaPlayerCreator mediaPlayerCreator;
 
-    private PlaybackState currentState = IDLE;
+    private PlaybackState currentState = PlaybackState.IDLE;
 
     private int currentBufferPercentage;
     private float volume = 1.0f;
@@ -173,14 +172,14 @@ class AndroidMediaPlayerFacade {
             mediaPlayer.reset();
             mediaPlayer.release();
             mediaPlayer = null;
-            currentState = IDLE;
+            currentState = PlaybackState.IDLE;
         }
     }
 
     void start(Either<Surface, SurfaceHolder> surface) throws IllegalStateException {
         assertIsInPlaybackState();
         attachSurface(mediaPlayer, surface);
-        currentState = PLAYING;
+        currentState = PlaybackState.PLAYING;
         mediaPlayer.start();
     }
 
@@ -205,7 +204,7 @@ class AndroidMediaPlayerFacade {
 
         if (isPlaying()) {
             mediaPlayer.pause();
-            currentState = PAUSED;
+            currentState = PlaybackState.PAUSED;
         }
     }
 

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerFacade.java
@@ -7,8 +7,7 @@ import android.net.Uri;
 import android.view.Surface;
 import android.view.SurfaceHolder;
 
-import androidx.annotation.Nullable;
-
+import com.novoda.noplayer.AdvertBreak;
 import com.novoda.noplayer.AdvertView;
 import com.novoda.noplayer.internal.mediaplayer.PlaybackStateChecker.PlaybackState;
 import com.novoda.noplayer.internal.mediaplayer.forwarder.MediaPlayerForwarder;
@@ -25,9 +24,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import static com.novoda.noplayer.internal.mediaplayer.PlaybackStateChecker.PlaybackState.IDLE;
-import static com.novoda.noplayer.internal.mediaplayer.PlaybackStateChecker.PlaybackState.PAUSED;
-import static com.novoda.noplayer.internal.mediaplayer.PlaybackStateChecker.PlaybackState.PLAYING;
+import androidx.annotation.Nullable;
+
+import static com.novoda.noplayer.internal.mediaplayer.PlaybackStateChecker.PlaybackState.*;
 
 // Not much we can do, wrapping MediaPlayer is a lot of work
 @SuppressWarnings("PMD.GodClass")
@@ -356,5 +355,10 @@ class AndroidMediaPlayerFacade {
     void enableAdverts() {
         assertIsInPlaybackState();
         NoPlayerLog.w("Tried to enable adverts but has not been implemented for MediaPlayer.");
+    }
+
+    void skipAdverts(AdvertBreak advertBreak) {
+        assertIsInPlaybackState();
+        NoPlayerLog.w("Tried to skip advert break but has not been implemented for MediaPlayer.");
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerFacade.java
@@ -357,7 +357,7 @@ class AndroidMediaPlayerFacade {
         NoPlayerLog.w("Tried to enable adverts but has not been implemented for MediaPlayer.");
     }
 
-    void skipAdverts(AdvertBreak advertBreak) {
+    void skipAdvertBreak(AdvertBreak advertBreak) {
         assertIsInPlaybackState();
         NoPlayerLog.w("Tried to skip advert break but has not been implemented for MediaPlayer.");
     }

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerFacade.java
@@ -7,7 +7,6 @@ import android.net.Uri;
 import android.view.Surface;
 import android.view.SurfaceHolder;
 
-import com.novoda.noplayer.AdvertBreak;
 import com.novoda.noplayer.AdvertView;
 import com.novoda.noplayer.internal.mediaplayer.PlaybackStateChecker.PlaybackState;
 import com.novoda.noplayer.internal.mediaplayer.forwarder.MediaPlayerForwarder;
@@ -357,7 +356,12 @@ class AndroidMediaPlayerFacade {
         NoPlayerLog.w("Tried to enable adverts but has not been implemented for MediaPlayer.");
     }
 
-    void skipAdvertBreak(AdvertBreak advertBreak) {
+    void skipAdvertBreak() {
+        assertIsInPlaybackState();
+        NoPlayerLog.w("Tried to skip advert break but has not been implemented for MediaPlayer.");
+    }
+
+    void skipAdvert() {
         assertIsInPlaybackState();
         NoPlayerLog.w("Tried to skip advert break but has not been implemented for MediaPlayer.");
     }

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImpl.java
@@ -6,7 +6,6 @@ import android.view.Surface;
 import android.view.SurfaceHolder;
 import android.view.View;
 
-import com.novoda.noplayer.AdvertBreak;
 import com.novoda.noplayer.AdvertView;
 import com.novoda.noplayer.Listeners;
 import com.novoda.noplayer.NoPlayer;
@@ -30,8 +29,6 @@ import com.novoda.noplayer.model.Timeout;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import androidx.annotation.NonNull;
 
 // Not much we can do, wrapping MediaPlayer is a lot of work
 @SuppressWarnings({"PMD.GodClass", "PMD.ExcessivePublicCount"})

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImpl.java
@@ -5,6 +5,8 @@ import android.net.Uri;
 import android.view.Surface;
 import android.view.SurfaceHolder;
 import android.view.View;
+
+import com.novoda.noplayer.AdvertBreak;
 import com.novoda.noplayer.AdvertView;
 import com.novoda.noplayer.Listeners;
 import com.novoda.noplayer.NoPlayer;
@@ -28,6 +30,8 @@ import com.novoda.noplayer.model.Timeout;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import androidx.annotation.NonNull;
 
 // Not much we can do, wrapping MediaPlayer is a lot of work
 @SuppressWarnings({"PMD.GodClass", "PMD.ExcessivePublicCount"})
@@ -341,6 +345,11 @@ class AndroidMediaPlayerImpl implements NoPlayer {
     @Override
     public void disableAdverts() {
         mediaPlayer.disableAdverts();
+    }
+
+    @Override
+    public void skipAdverts(@NonNull AdvertBreak advertBreak) {
+        mediaPlayer.skipAdverts(advertBreak);
     }
 
     @Override

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImpl.java
@@ -348,8 +348,8 @@ class AndroidMediaPlayerImpl implements NoPlayer {
     }
 
     @Override
-    public void skipAdverts(@NonNull AdvertBreak advertBreak) {
-        mediaPlayer.skipAdverts(advertBreak);
+    public void skipAdvertBreak(@NonNull AdvertBreak advertBreak) {
+        mediaPlayer.skipAdvertBreak(advertBreak);
     }
 
     @Override

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImpl.java
@@ -348,8 +348,13 @@ class AndroidMediaPlayerImpl implements NoPlayer {
     }
 
     @Override
-    public void skipAdvertBreak(@NonNull AdvertBreak advertBreak) {
-        mediaPlayer.skipAdvertBreak(advertBreak);
+    public void skipAdvertBreak() {
+        mediaPlayer.skipAdvertBreak();
+    }
+
+    @Override
+    public void skipAdvert() {
+        mediaPlayer.skipAdvert();
     }
 
     @Override

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/SkippedAdvertsTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/SkippedAdvertsTest.java
@@ -41,7 +41,7 @@ public class SkippedAdvertsTest {
     @Test
     public void skipsAllAdverts() {
         AdPlaybackState initialAvailableAdPlaybackState = AdvertPlaybackState.from(ADVERT_BREAKS).adPlaybackState();
-        AdPlaybackState adPlaybackState = SkippedAdverts.markAllNonPlayedAdvertsAsSkipped(ADVERT_BREAKS, initialAvailableAdPlaybackState);
+        AdPlaybackState adPlaybackState = SkippedAdverts.markAdvertBreakAsSkipped(ADVERT_BREAKS, initialAvailableAdPlaybackState);
 
         assertThatGroupContains(adPlaybackState.adGroups[0], new int[]{AD_STATE_SKIPPED});
         assertThatGroupContains(adPlaybackState.adGroups[1], new int[]{AD_STATE_SKIPPED});
@@ -52,7 +52,7 @@ public class SkippedAdvertsTest {
     @Test
     public void skipAdvertBreak() {
         AdPlaybackState initialAvailableAdPlaybackState = AdvertPlaybackState.from(ADVERT_BREAKS).adPlaybackState();
-        AdPlaybackState adPlaybackState = SkippedAdverts.markAllNonPlayedAdvertsAsSkipped(ADVERT_BREAKS.get(0), ADVERT_BREAKS, initialAvailableAdPlaybackState);
+        AdPlaybackState adPlaybackState = SkippedAdverts.markAdvertBreakAsSkipped(ADVERT_BREAKS.get(0), ADVERT_BREAKS, initialAvailableAdPlaybackState);
 
         assertThatGroupContains(adPlaybackState.adGroups[0], new int[]{AD_STATE_SKIPPED});
         assertThatGroupContains(adPlaybackState.adGroups[1], new int[]{AD_STATE_AVAILABLE});
@@ -64,7 +64,7 @@ public class SkippedAdvertsTest {
     public void doesNotSkipAdvertThatHasAlreadyPlayed() {
         AdPlaybackState initialAvailableAdPlaybackState = AdvertPlaybackState.from(ADVERT_BREAKS).adPlaybackState();
         initialAvailableAdPlaybackState = initialAvailableAdPlaybackState.withPlayedAd(1, 0);
-        AdPlaybackState adPlaybackState = SkippedAdverts.markAllNonPlayedAdvertsAsSkipped(ADVERT_BREAKS, initialAvailableAdPlaybackState);
+        AdPlaybackState adPlaybackState = SkippedAdverts.markAdvertBreakAsSkipped(ADVERT_BREAKS, initialAvailableAdPlaybackState);
 
         assertThatGroupContains(adPlaybackState.adGroups[0], new int[]{AD_STATE_SKIPPED});
         assertThatGroupContains(adPlaybackState.adGroups[1], new int[]{AD_STATE_PLAYED});

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/SkippedAdvertsTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/SkippedAdvertsTest.java
@@ -2,10 +2,11 @@ package com.novoda.noplayer.internal.exoplayer;
 
 import com.google.android.exoplayer2.source.ads.AdPlaybackState;
 import com.novoda.noplayer.AdvertBreak;
-import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.List;
+
+import org.junit.Test;
 
 import static com.google.android.exoplayer2.source.ads.AdPlaybackState.*;
 import static com.novoda.noplayer.AdvertBreakFixtures.anAdvertBreak;
@@ -46,6 +47,17 @@ public class SkippedAdvertsTest {
         assertThatGroupContains(adPlaybackState.adGroups[1], new int[]{AD_STATE_SKIPPED});
         assertThatGroupContains(adPlaybackState.adGroups[2], new int[]{AD_STATE_SKIPPED});
         assertThatGroupContains(adPlaybackState.adGroups[3], new int[]{AD_STATE_SKIPPED});
+    }
+
+    @Test
+    public void skipAdvertBreak() {
+        AdPlaybackState initialAvailableAdPlaybackState = AdvertPlaybackState.from(ADVERT_BREAKS).adPlaybackState();
+        AdPlaybackState adPlaybackState = SkippedAdverts.markAllNonPlayedAdvertsAsSkipped(ADVERT_BREAKS.get(0), ADVERT_BREAKS, initialAvailableAdPlaybackState);
+
+        assertThatGroupContains(adPlaybackState.adGroups[0], new int[]{AD_STATE_SKIPPED});
+        assertThatGroupContains(adPlaybackState.adGroups[1], new int[]{AD_STATE_AVAILABLE});
+        assertThatGroupContains(adPlaybackState.adGroups[2], new int[]{AD_STATE_AVAILABLE});
+        assertThatGroupContains(adPlaybackState.adGroups[3], new int[]{AD_STATE_AVAILABLE});
     }
 
     @Test

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/SkippedAdvertsTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/SkippedAdvertsTest.java
@@ -23,6 +23,7 @@ public class SkippedAdvertsTest {
     private static final AdvertBreak FIRST_ADVERT_BREAK = anAdvertBreak()
             .withStartTimeInMillis(TEN_SECONDS_IN_MILLIS)
             .withAdvert(anAdvert().build())
+            .withAdvert(anAdvert().build())
             .build();
     private static final AdvertBreak SECOND_ADVERT_BREAK = anAdvertBreak()
             .withStartTimeInMillis(TWENTY_SECONDS_IN_MILLIS)
@@ -43,7 +44,7 @@ public class SkippedAdvertsTest {
         AdPlaybackState initialAvailableAdPlaybackState = AdvertPlaybackState.from(ADVERT_BREAKS).adPlaybackState();
         AdPlaybackState adPlaybackState = SkippedAdverts.markAdvertBreakAsSkipped(ADVERT_BREAKS, initialAvailableAdPlaybackState);
 
-        assertThatGroupContains(adPlaybackState.adGroups[0], new int[]{AD_STATE_SKIPPED});
+        assertThatGroupContains(adPlaybackState.adGroups[0], new int[]{AD_STATE_SKIPPED, AD_STATE_SKIPPED});
         assertThatGroupContains(adPlaybackState.adGroups[1], new int[]{AD_STATE_SKIPPED});
         assertThatGroupContains(adPlaybackState.adGroups[2], new int[]{AD_STATE_SKIPPED});
         assertThatGroupContains(adPlaybackState.adGroups[3], new int[]{AD_STATE_SKIPPED});
@@ -52,9 +53,20 @@ public class SkippedAdvertsTest {
     @Test
     public void skipAdvertBreak() {
         AdPlaybackState initialAvailableAdPlaybackState = AdvertPlaybackState.from(ADVERT_BREAKS).adPlaybackState();
-        AdPlaybackState adPlaybackState = SkippedAdverts.markAdvertBreakAsSkipped(ADVERT_BREAKS.get(0), ADVERT_BREAKS, initialAvailableAdPlaybackState);
+        AdPlaybackState adPlaybackState = SkippedAdverts.markAdvertBreakAsSkipped(0, initialAvailableAdPlaybackState);
 
-        assertThatGroupContains(adPlaybackState.adGroups[0], new int[]{AD_STATE_SKIPPED});
+        assertThatGroupContains(adPlaybackState.adGroups[0], new int[]{AD_STATE_SKIPPED, AD_STATE_SKIPPED});
+        assertThatGroupContains(adPlaybackState.adGroups[1], new int[]{AD_STATE_AVAILABLE});
+        assertThatGroupContains(adPlaybackState.adGroups[2], new int[]{AD_STATE_AVAILABLE});
+        assertThatGroupContains(adPlaybackState.adGroups[3], new int[]{AD_STATE_AVAILABLE});
+    }
+
+    @Test
+    public void skipAdvert() {
+        AdPlaybackState initialAvailableAdPlaybackState = AdvertPlaybackState.from(ADVERT_BREAKS).adPlaybackState();
+        AdPlaybackState adPlaybackState = SkippedAdverts.markAdvertAsSkipped(0, 0, initialAvailableAdPlaybackState);
+
+        assertThatGroupContains(adPlaybackState.adGroups[0], new int[]{AD_STATE_SKIPPED, AD_STATE_AVAILABLE});
         assertThatGroupContains(adPlaybackState.adGroups[1], new int[]{AD_STATE_AVAILABLE});
         assertThatGroupContains(adPlaybackState.adGroups[2], new int[]{AD_STATE_AVAILABLE});
         assertThatGroupContains(adPlaybackState.adGroups[3], new int[]{AD_STATE_AVAILABLE});
@@ -66,7 +78,7 @@ public class SkippedAdvertsTest {
         initialAvailableAdPlaybackState = initialAvailableAdPlaybackState.withPlayedAd(1, 0);
         AdPlaybackState adPlaybackState = SkippedAdverts.markAdvertBreakAsSkipped(ADVERT_BREAKS, initialAvailableAdPlaybackState);
 
-        assertThatGroupContains(adPlaybackState.adGroups[0], new int[]{AD_STATE_SKIPPED});
+        assertThatGroupContains(adPlaybackState.adGroups[0], new int[]{AD_STATE_SKIPPED, AD_STATE_SKIPPED});
         assertThatGroupContains(adPlaybackState.adGroups[1], new int[]{AD_STATE_PLAYED});
         assertThatGroupContains(adPlaybackState.adGroups[2], new int[]{AD_STATE_SKIPPED});
         assertThatGroupContains(adPlaybackState.adGroups[3], new int[]{AD_STATE_SKIPPED});
@@ -77,7 +89,7 @@ public class SkippedAdvertsTest {
         AdPlaybackState initialAvailableAdPlaybackState = AdvertPlaybackState.from(ADVERT_BREAKS).adPlaybackState();
         AdPlaybackState adPlaybackState = SkippedAdverts.markAllPastAvailableAdvertsAsSkipped(TWENTY_SECONDS_IN_MILLIS + 1, ADVERT_BREAKS, initialAvailableAdPlaybackState);
 
-        assertThatGroupContains(adPlaybackState.adGroups[0], new int[]{AD_STATE_SKIPPED});
+        assertThatGroupContains(adPlaybackState.adGroups[0], new int[]{AD_STATE_SKIPPED, AD_STATE_SKIPPED});
         assertThatGroupContains(adPlaybackState.adGroups[1], new int[]{AD_STATE_SKIPPED});
         assertThatGroupContains(adPlaybackState.adGroups[2], new int[]{AD_STATE_AVAILABLE});
         assertThatGroupContains(adPlaybackState.adGroups[3], new int[]{AD_STATE_AVAILABLE});
@@ -88,7 +100,7 @@ public class SkippedAdvertsTest {
         AdPlaybackState initialAvailableAdPlaybackState = adPlaybackStateWithPlayedAdverts();
         AdPlaybackState adPlaybackState = SkippedAdverts.markAllPastAvailableAdvertsAsSkipped(TWENTY_SECONDS_IN_MILLIS, ADVERT_BREAKS, initialAvailableAdPlaybackState);
 
-        assertThatGroupContains(adPlaybackState.adGroups[0], new int[]{AD_STATE_PLAYED});
+        assertThatGroupContains(adPlaybackState.adGroups[0], new int[]{AD_STATE_PLAYED, AD_STATE_PLAYED});
         assertThatGroupContains(adPlaybackState.adGroups[1], new int[]{AD_STATE_PLAYED});
         assertThatGroupContains(adPlaybackState.adGroups[2], new int[]{AD_STATE_PLAYED});
         assertThatGroupContains(adPlaybackState.adGroups[3], new int[]{AD_STATE_PLAYED});
@@ -101,6 +113,7 @@ public class SkippedAdvertsTest {
     private AdPlaybackState adPlaybackStateWithPlayedAdverts() {
         AdPlaybackState adPlaybackState = AdvertPlaybackState.from(ADVERT_BREAKS).adPlaybackState();
         adPlaybackState = adPlaybackState.withPlayedAd(0, 0);
+        adPlaybackState = adPlaybackState.withPlayedAd(0, 1);
         adPlaybackState = adPlaybackState.withPlayedAd(1, 0);
         adPlaybackState = adPlaybackState.withPlayedAd(2, 0);
         adPlaybackState = adPlaybackState.withPlayedAd(3, 0);


### PR DESCRIPTION
## Problem

It is in some case convenient to be able to skip just the current advert break, or the current advert. 

## Solution

Allow `NoPlayer` to `skipAdvert` or `skipAdvertBreak`

### Test(s) added 

Yes, to make sure only the given `AdvertBreak`, or `Advert` is skipped
