### PR TITLE
Ignore track changes when seek and track groups are empty

### DIFF
--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/TracksChangedForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/TracksChangedForwarder.java
@@ -11,6 +11,7 @@ import com.novoda.noplayer.NoPlayer;
 class TracksChangedForwarder implements Player.EventListener {
 
     private final NoPlayer.TracksChangedListener tracksChangedListener;
+    private int discontinuityReason = -1;
 
     TracksChangedForwarder(NoPlayer.TracksChangedListener tracksChangedListener) {
         this.tracksChangedListener = tracksChangedListener;
@@ -38,7 +39,11 @@ class TracksChangedForwarder implements Player.EventListener {
 
     @Override
     public void onTracksChanged(TrackGroupArray trackGroups, TrackSelectionArray trackSelections) {
-        tracksChangedListener.onTracksChanged();
+        if (discontinuityReason == Player.TIMELINE_CHANGE_REASON_RESET && trackGroups.isEmpty()) {
+            // ignore internal resets with empty track groups
+        } else {
+            tracksChangedListener.onTracksChanged();
+        }
     }
 
     @Override
@@ -53,7 +58,7 @@ class TracksChangedForwarder implements Player.EventListener {
 
     @Override
     public void onPositionDiscontinuity(int reason) {
-        // no-op.
+        discontinuityReason = reason;
     }
 
     @Override

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/TracksChangedForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/TracksChangedForwarder.java
@@ -39,8 +39,8 @@ class TracksChangedForwarder implements Player.EventListener {
 
     @Override
     public void onTracksChanged(TrackGroupArray trackGroups, TrackSelectionArray trackSelections) {
-        if (discontinuityReason == Player.TIMELINE_CHANGE_REASON_RESET && trackGroups.isEmpty()) {
-            // ignore internal resets with empty track groups
+        if (discontinuityReason == Player.DISCONTINUITY_REASON_SEEK && trackGroups.isEmpty()) {
+            // ignore changes to empty track groups after seek
         } else {
             tracksChangedListener.onTracksChanged();
         }

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/forwarder/TracksChangedForwarderTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/forwarder/TracksChangedForwarderTest.java
@@ -1,0 +1,107 @@
+package com.novoda.noplayer.internal.exoplayer.forwarder;
+
+import com.google.android.exoplayer2.C;
+import com.google.android.exoplayer2.Format;
+import com.google.android.exoplayer2.Player;
+import com.google.android.exoplayer2.source.TrackGroup;
+import com.google.android.exoplayer2.source.TrackGroupArray;
+import com.google.android.exoplayer2.trackselection.TrackSelectionArray;
+import com.novoda.noplayer.NoPlayer;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+public class TracksChangedForwarderTest {
+
+    private static final TrackGroupArray EMPTY_TRACK_GROUPS = TrackGroupArray.EMPTY;
+    private static final TrackGroupArray NOT_EMPTY_TRACK_GROUPS = new TrackGroupArray(
+            new TrackGroup(
+                    Format.createTextContainerFormat(
+                            null,
+                            null,
+                            null,
+                            null,
+                            null,
+                            0,
+                            C.SELECTION_FLAG_DEFAULT,
+                            C.ROLE_FLAG_MAIN,
+                            null)
+            )
+    );
+    private static final TrackSelectionArray EMPTY_SELECTION_ARRAY = new TrackSelectionArray();
+    private final NoPlayer.TracksChangedListener tracksChangedListener = mock(NoPlayer.TracksChangedListener.class);
+
+    private final TracksChangedForwarder tracksChangedForwarder = new TracksChangedForwarder(tracksChangedListener);
+
+    @Test
+    public void forwardsOnTrackChangedWhenTrackGroupsAreNotEmpty() {
+
+        tracksChangedForwarder.onTracksChanged(NOT_EMPTY_TRACK_GROUPS, EMPTY_SELECTION_ARRAY);
+
+        verify(tracksChangedListener).onTracksChanged();
+    }
+
+    @Test
+    public void forwardsOnTrackChangedWhenTrackGroupsAreEmpty() {
+
+        tracksChangedForwarder.onTracksChanged(EMPTY_TRACK_GROUPS, EMPTY_SELECTION_ARRAY);
+
+        verify(tracksChangedListener).onTracksChanged();
+    }
+
+    @Test
+    public void doesNotforwardOnTrackChangedAfterSeekDiscontinuityWhenTrackGroupsAreEmpty() {
+        tracksChangedForwarder.onPositionDiscontinuity(Player.DISCONTINUITY_REASON_SEEK);
+
+        tracksChangedForwarder.onTracksChanged(EMPTY_TRACK_GROUPS, EMPTY_SELECTION_ARRAY);
+
+        verify(tracksChangedListener, never()).onTracksChanged();
+    }
+
+    @Test
+    public void forwardsOnTrackChangedAfterSeekDiscontinuityWhenTrackGroupsAreNotEmpty() {
+        tracksChangedForwarder.onPositionDiscontinuity(Player.DISCONTINUITY_REASON_SEEK);
+
+        tracksChangedForwarder.onTracksChanged(NOT_EMPTY_TRACK_GROUPS, EMPTY_SELECTION_ARRAY);
+
+        verify(tracksChangedListener).onTracksChanged();
+    }
+
+    @Test
+    public void forwardsOnTrackChangedAfterPeriodTransitionDiscontinuityWhenTrackGroupsAreNotEmpty() {
+        tracksChangedForwarder.onPositionDiscontinuity(Player.DISCONTINUITY_REASON_PERIOD_TRANSITION);
+
+        tracksChangedForwarder.onTracksChanged(NOT_EMPTY_TRACK_GROUPS, EMPTY_SELECTION_ARRAY);
+
+        verify(tracksChangedListener).onTracksChanged();
+    }
+
+    @Test
+    public void forwardsOnTrackChangedAfterSeekAdjustmentDiscontinuityWhenTrackGroupsAreNotEmpty() {
+        tracksChangedForwarder.onPositionDiscontinuity(Player.DISCONTINUITY_REASON_SEEK_ADJUSTMENT);
+
+        tracksChangedForwarder.onTracksChanged(NOT_EMPTY_TRACK_GROUPS, EMPTY_SELECTION_ARRAY);
+
+        verify(tracksChangedListener).onTracksChanged();
+    }
+
+    @Test
+    public void forwardsOnTrackChangedAfterAdInsertionDiscontinuityWhenTrackGroupsAreNotEmpty() {
+        tracksChangedForwarder.onPositionDiscontinuity(Player.DISCONTINUITY_REASON_AD_INSERTION);
+
+        tracksChangedForwarder.onTracksChanged(NOT_EMPTY_TRACK_GROUPS, EMPTY_SELECTION_ARRAY);
+
+        verify(tracksChangedListener).onTracksChanged();
+    }
+
+    @Test
+    public void forwardsOnTrackChangedAfterInternalDiscontinuityWhenTrackGroupsAreNotEmpty() {
+        tracksChangedForwarder.onPositionDiscontinuity(Player.DISCONTINUITY_REASON_INTERNAL);
+
+        tracksChangedForwarder.onTracksChanged(NOT_EMPTY_TRACK_GROUPS, EMPTY_SELECTION_ARRAY);
+
+        verify(tracksChangedListener).onTracksChanged();
+    }
+}


### PR DESCRIPTION
## Problem

ExoPlayer notifies about incorrect track changes after seeking when adverts were disabled.

The issue is that if we disable adverts and then seek, we get 2 `onTracksChanged()` notifications. The first one is with empty tracks, and only the second one contains the tracks we had before. If we propagate that to the client they might incorrectly assume that there is an error with the tracks they should be seeing.

## Solution
Save the reason passed into `onPositionDiscontinuity()` and use it to understand what if we should filter out the `onTracksChanged()` notification. We also need to check for empty tracks because otherwise we wouldn't propagate the `onTracksChanged()` when the video starts.

### Test(s) added 

yes, for the modified forwarder

### Paired with 

nobody
