### PR TITLE
Update androidx annotation

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -62,7 +62,7 @@ android {
 dependencies {
     implementation 'com.google.android.exoplayer:exoplayer:2.10.0'
 
-    implementation 'androidx.annotation:annotation:1.0.2'
+    implementation 'androidx.annotation:annotation:1.1.0'
 
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:2.28.2'


### PR DESCRIPTION
## Problem

A newer version of a library is found (we should turn off the lint error that breaks the build because of that). 

## Solution

I just updated the library because it's too early to argue with lint but one day I'm gonna turn it off 😄 .
