### PR TITLE
Manually fallback insecure decoder

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,9 +14,9 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.0'
+        classpath 'com.android.tools.build:gradle:3.4.1'
         classpath 'com.novoda:bintray-release:0.9.1'
-        classpath 'com.novoda:gradle-static-analysis-plugin:0.8.1'
+        classpath 'com.novoda:gradle-static-analysis-plugin:1.0'
         classpath 'com.novoda:gradle-build-properties-plugin:0.4.1'
         classpath "com.github.ben-manes:gradle-versions-plugin:0.21.0"
     }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -60,7 +60,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.google.android.exoplayer:exoplayer:2.10.0'
+    implementation 'com.google.android.exoplayer:exoplayer:2.10.1'
 
     implementation 'androidx.annotation:annotation:1.1.0'
 

--- a/core/src/main/java/com/novoda/noplayer/PlayerBuilder.java
+++ b/core/src/main/java/com/novoda/noplayer/PlayerBuilder.java
@@ -107,8 +107,7 @@ public class PlayerBuilder {
     }
 
     /**
-     * Forces secure decoder selection to be ignored in favour of using an insecure decoder.
-     * e.g. Forcing an L3 stream to play with an L3 decoder instead of an L1 secure decoder by default.
+     * Allows the selection of a insecure decoder when the device does not support a secure decoder.
      *
      * @return {@link PlayerBuilder}
      */

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/SecurityDowngradingCodecSelector.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/SecurityDowngradingCodecSelector.java
@@ -6,9 +6,14 @@ import com.google.android.exoplayer2.mediacodec.MediaCodecUtil;
 
 import java.util.List;
 
+/**
+ * This class will try and get a decoder that requires secure decryption and fallback
+ * to a decoder that does not require secure decryption if there is non available
+ */
 class SecurityDowngradingCodecSelector implements MediaCodecSelector {
 
-    private static final boolean USE_INSECURE_DECODER = false;
+    private static final boolean DECODER_REQUIRES_SECURE_DECRYPTION = true;
+    private static final boolean DECODER_DOES_NOT_REQUIRE_SECURE_DECRYPTION = false;
 
     private final InternalMediaCodecUtil internalMediaCodecUtil;
 
@@ -22,11 +27,25 @@ class SecurityDowngradingCodecSelector implements MediaCodecSelector {
     }
 
     @Override
-    public List<MediaCodecInfo> getDecoderInfos(String mimeType,
-                                                boolean requiresSecureDecoder,
-                                                boolean requiresTunnelingDecoder)
-            throws MediaCodecUtil.DecoderQueryException {
-        return internalMediaCodecUtil.getDecoderInfos(mimeType, USE_INSECURE_DECODER, requiresTunnelingDecoder);
+    public List<MediaCodecInfo> getDecoderInfos(
+            String mimeType,
+            boolean requiresSecureDecoder,
+            boolean requiresTunnelingDecoder
+    ) throws MediaCodecUtil.DecoderQueryException {
+        List<MediaCodecInfo> decoderInfos = internalMediaCodecUtil.getDecoderInfos(
+                mimeType,
+                DECODER_REQUIRES_SECURE_DECRYPTION,
+                requiresTunnelingDecoder
+        );
+
+        if (decoderInfos.isEmpty()) {
+            decoderInfos = internalMediaCodecUtil.getDecoderInfos(
+                    mimeType,
+                    DECODER_DOES_NOT_REQUIRE_SECURE_DECRYPTION,
+                    requiresTunnelingDecoder
+            );
+        }
+        return decoderInfos;
     }
 
     @Override
@@ -36,10 +55,11 @@ class SecurityDowngradingCodecSelector implements MediaCodecSelector {
 
     static class InternalMediaCodecUtil {
 
-        List<MediaCodecInfo> getDecoderInfos(String mimeType,
-                                             boolean requiresSecureDecoder,
-                                             boolean requiresTunnelingDecoder)
-                throws MediaCodecUtil.DecoderQueryException {
+        List<MediaCodecInfo> getDecoderInfos(
+                String mimeType,
+                boolean requiresSecureDecoder,
+                boolean requiresTunnelingDecoder
+        ) throws MediaCodecUtil.DecoderQueryException {
             return MediaCodecUtil.getDecoderInfos(mimeType, requiresSecureDecoder, requiresTunnelingDecoder);
         }
 


### PR DESCRIPTION
## Problem

There is a performance issue with Huawei P20 and other devices.

## Solution

Huawei P20 requires a secure decoder while Intel devices do not support secure decoders. In order to solve this for those two scenarios, when we require a downgrade of the decoder, we are going to try to request if the device supports a secure decoder if it this we will return a secure one. If the device does not have any, then we will request an unsecured list of decoders.

### Test(s) added 

Manually tested in different devices

### Screenshots

No UI changes

### Paired with 

Nobody
