### PR TITLE
Show adverts even on seek

### DIFF
--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/AvailableAdverts.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/AvailableAdverts.java
@@ -18,19 +18,16 @@ final class AvailableAdverts {
      * as the exo-player {@link AdPlaybackState} does not allow transitioning from
      * Skipped to Available adverts.
      *
-     * @param currentPositionInMillis The position after which all adverts will transition from Skipped to Available.
-     * @param advertBreaks            The client representation of the adverts, our source of truth.
-     * @param adPlaybackState         The {@link AdPlaybackState} to mutate with the new states.
+     * @param advertBreaks    The client representation of the adverts, our source of truth.
+     * @param adPlaybackState The {@link AdPlaybackState} to mutate with the new states.
      */
-    static void markAllFutureAdvertsAsAvailable(long currentPositionInMillis, List<AdvertBreak> advertBreaks, AdPlaybackState adPlaybackState) {
+    static void markSkippedAdvertsAsAvailable(List<AdvertBreak> advertBreaks, AdPlaybackState adPlaybackState) {
         for (int i = advertBreaks.size() - 1; i >= 0; i--) {
             AdvertBreak advertBreak = advertBreaks.get(i);
             AdPlaybackState.AdGroup adGroup = adPlaybackState.adGroups[i];
-            if (advertBreak.startTimeInMillis() >= currentPositionInMillis) {
-                for (int stateIndex = 0; stateIndex < adGroup.states.length; stateIndex++) {
-                    if (adGroup.states[stateIndex] == AdPlaybackState.AD_STATE_SKIPPED) {
-                        adGroup.states[stateIndex] = AdPlaybackState.AD_STATE_AVAILABLE;
-                    }
+            for (int stateIndex = 0; stateIndex < adGroup.states.length; stateIndex++) {
+                if (adGroup.states[stateIndex] == AdPlaybackState.AD_STATE_SKIPPED) {
+                    adGroup.states[stateIndex] = AdPlaybackState.AD_STATE_AVAILABLE;
                 }
             }
         }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/AvailableAdverts.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/AvailableAdverts.java
@@ -23,7 +23,6 @@ final class AvailableAdverts {
      */
     static void markSkippedAdvertsAsAvailable(List<AdvertBreak> advertBreaks, AdPlaybackState adPlaybackState) {
         for (int i = advertBreaks.size() - 1; i >= 0; i--) {
-            AdvertBreak advertBreak = advertBreaks.get(i);
             AdPlaybackState.AdGroup adGroup = adPlaybackState.adGroups[i];
             for (int stateIndex = 0; stateIndex < adGroup.states.length; stateIndex++) {
                 if (adGroup.states[stateIndex] == AdPlaybackState.AD_STATE_SKIPPED) {

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
@@ -208,11 +208,9 @@ class ExoPlayerFacade {
 
         if (adsLoader.isPresent()) {
             long advertBreakInitialPositionMillis = options.getInitialAdvertBreakPositionInMillis().or(NO_RESUME_POSITION);
-            long contentInitialPositionMillis = options.getInitialPositionInMillis().or(NO_RESUME_POSITION);
             adsLoader.get().bind(
                     forwarder.advertListener(),
-                    advertBreakInitialPositionMillis,
-                    contentInitialPositionMillis
+                    advertBreakInitialPositionMillis
             );
         }
 

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerExoPlayerCreator.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerExoPlayerCreator.java
@@ -108,9 +108,6 @@ public class NoPlayerExoPlayerCreator {
             );
 
             PlayerListenersHolder listenersHolder = new PlayerListenersHolder();
-            if (adsLoader.isPresent()) {
-                listenersHolder.addHeartbeatCallback(adsLoader.get());
-            }
             ExoPlayerForwarder exoPlayerForwarder = new ExoPlayerForwarder();
             LoadTimeout loadTimeout = new LoadTimeout(new SystemClock(), handler);
             Heart heart = Heart.newInstance(handler);

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/AvailableAdvertsTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/AvailableAdvertsTest.java
@@ -10,19 +10,16 @@ import org.junit.Test;
 
 import static com.google.android.exoplayer2.source.ads.AdPlaybackState.AD_STATE_AVAILABLE;
 import static com.google.android.exoplayer2.source.ads.AdPlaybackState.AD_STATE_PLAYED;
-import static com.google.android.exoplayer2.source.ads.AdPlaybackState.AD_STATE_SKIPPED;
 import static com.novoda.noplayer.AdvertBreakFixtures.anAdvertBreak;
 import static com.novoda.noplayer.AdvertFixtures.anAdvert;
 import static org.fest.assertions.api.Assertions.assertThat;
 
 public class AvailableAdvertsTest {
 
-    private static final int BEGINNING = 0;
     private static final int TEN_SECONDS_IN_MILLIS = 10000;
     private static final int TWENTY_SECONDS_IN_MILLIS = 20000;
     private static final int THIRTY_SECONDS_IN_MILLIS = 30000;
     private static final int FORTY_SECONDS_IN_MILLIS = 40000;
-    private static final int END = 40001;
 
     private static final AdvertBreak FIRST_ADVERT_BREAK = anAdvertBreak()
             .withStartTimeInMillis(TEN_SECONDS_IN_MILLIS)
@@ -43,18 +40,7 @@ public class AvailableAdvertsTest {
     private static final List<AdvertBreak> ADVERT_BREAKS = Arrays.asList(FIRST_ADVERT_BREAK, SECOND_ADVERT_BREAK, THIRD_ADVERT_BREAK, FOURTH_ADVERT_BREAK);
 
     @Test
-    public void makesSkippedAdvertsAfterCurrentOrAtCurrentPositionAvailable() {
-        AdPlaybackState adPlaybackState = adPlaybackStateWithSkippedAdverts();
-        AvailableAdverts.markSkippedAdvertsAsAvailable(ADVERT_BREAKS, adPlaybackState);
-
-        assertThatGroupContains(adPlaybackState.adGroups[0], new int[]{AD_STATE_SKIPPED});
-        assertThatGroupContains(adPlaybackState.adGroups[1], new int[]{AD_STATE_SKIPPED});
-        assertThatGroupContains(adPlaybackState.adGroups[2], new int[]{AD_STATE_AVAILABLE});
-        assertThatGroupContains(adPlaybackState.adGroups[3], new int[]{AD_STATE_AVAILABLE});
-    }
-
-    @Test
-    public void marksAllAsAvailableWhenPositionIsBeginning() {
+    public void marksSkippedAdvertsAsAvailable() {
         AdPlaybackState adPlaybackState = adPlaybackStateWithSkippedAdverts();
         AvailableAdverts.markSkippedAdvertsAsAvailable(ADVERT_BREAKS, adPlaybackState);
 
@@ -73,17 +59,6 @@ public class AvailableAdvertsTest {
         assertThatGroupContains(adPlaybackState.adGroups[1], new int[]{AD_STATE_PLAYED});
         assertThatGroupContains(adPlaybackState.adGroups[2], new int[]{AD_STATE_PLAYED});
         assertThatGroupContains(adPlaybackState.adGroups[3], new int[]{AD_STATE_PLAYED});
-    }
-
-    @Test
-    public void leavesAsSkippedWhenPositionIsAfterAllAdvertStartPositions() {
-        AdPlaybackState adPlaybackState = adPlaybackStateWithSkippedAdverts();
-        AvailableAdverts.markSkippedAdvertsAsAvailable(ADVERT_BREAKS, adPlaybackState);
-
-        assertThatGroupContains(adPlaybackState.adGroups[0], new int[]{AD_STATE_SKIPPED});
-        assertThatGroupContains(adPlaybackState.adGroups[1], new int[]{AD_STATE_SKIPPED});
-        assertThatGroupContains(adPlaybackState.adGroups[2], new int[]{AD_STATE_SKIPPED});
-        assertThatGroupContains(adPlaybackState.adGroups[3], new int[]{AD_STATE_SKIPPED});
     }
 
     private AdPlaybackState adPlaybackStateWithSkippedAdverts() {

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/AvailableAdvertsTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/AvailableAdvertsTest.java
@@ -45,7 +45,7 @@ public class AvailableAdvertsTest {
     @Test
     public void makesSkippedAdvertsAfterCurrentOrAtCurrentPositionAvailable() {
         AdPlaybackState adPlaybackState = adPlaybackStateWithSkippedAdverts();
-        AvailableAdverts.markAllFutureAdvertsAsAvailable(THIRTY_SECONDS_IN_MILLIS, ADVERT_BREAKS, adPlaybackState);
+        AvailableAdverts.markSkippedAdvertsAsAvailable(ADVERT_BREAKS, adPlaybackState);
 
         assertThatGroupContains(adPlaybackState.adGroups[0], new int[]{AD_STATE_SKIPPED});
         assertThatGroupContains(adPlaybackState.adGroups[1], new int[]{AD_STATE_SKIPPED});
@@ -56,7 +56,7 @@ public class AvailableAdvertsTest {
     @Test
     public void marksAllAsAvailableWhenPositionIsBeginning() {
         AdPlaybackState adPlaybackState = adPlaybackStateWithSkippedAdverts();
-        AvailableAdverts.markAllFutureAdvertsAsAvailable(BEGINNING, ADVERT_BREAKS, adPlaybackState);
+        AvailableAdverts.markSkippedAdvertsAsAvailable(ADVERT_BREAKS, adPlaybackState);
 
         assertThatGroupContains(adPlaybackState.adGroups[0], new int[]{AD_STATE_AVAILABLE});
         assertThatGroupContains(adPlaybackState.adGroups[1], new int[]{AD_STATE_AVAILABLE});
@@ -67,7 +67,7 @@ public class AvailableAdvertsTest {
     @Test
     public void leavesAsCurrentStateWhenNotPreviouslySkipped() {
         AdPlaybackState adPlaybackState = adPlaybackStateWithPlayedAdverts();
-        AvailableAdverts.markAllFutureAdvertsAsAvailable(BEGINNING, ADVERT_BREAKS, adPlaybackState);
+        AvailableAdverts.markSkippedAdvertsAsAvailable(ADVERT_BREAKS, adPlaybackState);
 
         assertThatGroupContains(adPlaybackState.adGroups[0], new int[]{AD_STATE_PLAYED});
         assertThatGroupContains(adPlaybackState.adGroups[1], new int[]{AD_STATE_PLAYED});
@@ -78,7 +78,7 @@ public class AvailableAdvertsTest {
     @Test
     public void leavesAsSkippedWhenPositionIsAfterAllAdvertStartPositions() {
         AdPlaybackState adPlaybackState = adPlaybackStateWithSkippedAdverts();
-        AvailableAdverts.markAllFutureAdvertsAsAvailable(END, ADVERT_BREAKS, adPlaybackState);
+        AvailableAdverts.markSkippedAdvertsAsAvailable(ADVERT_BREAKS, adPlaybackState);
 
         assertThatGroupContains(adPlaybackState.adGroups[0], new int[]{AD_STATE_SKIPPED});
         assertThatGroupContains(adPlaybackState.adGroups[1], new int[]{AD_STATE_SKIPPED});

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacadeTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacadeTest.java
@@ -4,6 +4,7 @@ import android.net.Uri;
 import android.view.SurfaceHolder;
 import android.view.SurfaceView;
 import android.view.TextureView;
+
 import com.google.android.exoplayer2.C;
 import com.google.android.exoplayer2.Player;
 import com.google.android.exoplayer2.SimpleExoPlayer;
@@ -34,6 +35,10 @@ import com.novoda.noplayer.model.PlayerAudioTrackFixture;
 import com.novoda.noplayer.model.PlayerSubtitleTrack;
 import com.novoda.noplayer.model.PlayerVideoTrack;
 import com.novoda.noplayer.model.PlayerVideoTrackFixture;
+
+import java.util.Collections;
+import java.util.List;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -44,10 +49,8 @@ import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
-import utils.ExceptionMatcher;
 
-import java.util.Collections;
-import java.util.List;
+import utils.ExceptionMatcher;
 
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -129,7 +132,7 @@ public class ExoPlayerFacadeTest {
 
             facade.loadVideo(surfaceViewHolder, drmSessionCreator, uri, OPTIONS, exoPlayerForwarder, mediaCodecSelector);
 
-            verify(adsLoader).bind(optionalAdvertListener, NO_RESUME_POSITION, NO_RESUME_POSITION);
+            verify(adsLoader).bind(optionalAdvertListener, NO_RESUME_POSITION);
         }
 
         @Test
@@ -140,7 +143,7 @@ public class ExoPlayerFacadeTest {
 
             facade.loadVideo(surfaceViewHolder, drmSessionCreator, uri, OPTIONS, exoPlayerForwarder, mediaCodecSelector);
 
-            verify(adsLoader).bind(exoPlayerForwarder.advertListener(), NO_RESUME_POSITION, NO_RESUME_POSITION);
+            verify(adsLoader).bind(exoPlayerForwarder.advertListener(), NO_RESUME_POSITION);
         }
 
         @Test
@@ -169,7 +172,7 @@ public class ExoPlayerFacadeTest {
 
             facade.loadVideo(surfaceViewHolder, drmSessionCreator, uri, OPTIONS, exoPlayerForwarder, mediaCodecSelector);
 
-            verify(adsLoader, never()).bind(exoPlayerForwarder.advertListener(), NO_RESUME_POSITION, NO_RESUME_POSITION);
+            verify(adsLoader, never()).bind(exoPlayerForwarder.advertListener(), NO_RESUME_POSITION);
         }
 
         @Test
@@ -177,7 +180,7 @@ public class ExoPlayerFacadeTest {
 
             facade.loadVideo(surfaceViewHolder, drmSessionCreator, uri, OPTIONS, exoPlayerForwarder, mediaCodecSelector);
 
-            verify(adsLoader, never()).bind(exoPlayerForwarder.advertListener(), NO_RESUME_POSITION, NO_RESUME_POSITION);
+            verify(adsLoader, never()).bind(exoPlayerForwarder.advertListener(), NO_RESUME_POSITION);
         }
 
         @Test
@@ -190,7 +193,7 @@ public class ExoPlayerFacadeTest {
 
             facade.loadVideo(surfaceViewHolder, drmSessionCreator, uri, options, exoPlayerForwarder, mediaCodecSelector);
 
-            verify(adsLoader).bind(exoPlayerForwarder.advertListener(), TWENTY_FIVE_SECONDS_IN_MILLIS, NO_RESUME_POSITION);
+            verify(adsLoader).bind(exoPlayerForwarder.advertListener(), TWENTY_FIVE_SECONDS_IN_MILLIS);
         }
 
         @Test
@@ -203,7 +206,7 @@ public class ExoPlayerFacadeTest {
 
             facade.loadVideo(surfaceViewHolder, drmSessionCreator, uri, options, exoPlayerForwarder, mediaCodecSelector);
 
-            verify(adsLoader).bind(exoPlayerForwarder.advertListener(), NO_RESUME_POSITION, TWENTY_FIVE_SECONDS_IN_MILLIS);
+            verify(adsLoader).bind(exoPlayerForwarder.advertListener(), NO_RESUME_POSITION);
         }
 
         @Test

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoaderTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoaderTest.java
@@ -1,12 +1,17 @@
 package com.novoda.noplayer.internal.exoplayer;
 
 import android.os.Handler;
+
 import com.google.android.exoplayer2.source.ads.AdsLoader;
 import com.novoda.noplayer.Advert;
 import com.novoda.noplayer.AdvertBreak;
 import com.novoda.noplayer.AdvertsLoader;
 import com.novoda.noplayer.NoPlayer;
 import com.novoda.noplayer.internal.utils.Optional;
+
+import java.io.IOException;
+import java.util.Arrays;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -15,10 +20,8 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
-import utils.ExceptionMatcher;
 
-import java.io.IOException;
-import java.util.Arrays;
+import utils.ExceptionMatcher;
 
 import static com.novoda.noplayer.AdvertBreakFixtures.anAdvertBreak;
 import static com.novoda.noplayer.AdvertFixtures.anAdvert;
@@ -77,7 +80,7 @@ public class NoPlayerAdsLoaderTest {
     @Test
     public void notifiesAdvertListenerWhenAdvertLoadingFails() {
         IOException error = new IOException("some error");
-        noPlayerAdsLoader.bind(Optional.of(advertListener), NO_AD_RESUME_POSITION, NO_AD_RESUME_POSITION);
+        noPlayerAdsLoader.bind(Optional.of(advertListener), NO_AD_RESUME_POSITION);
         noPlayerAdsLoader.start(eventListener, adViewProvider);
 
         invokeCallback().onAdvertsError(error);
@@ -87,7 +90,7 @@ public class NoPlayerAdsLoaderTest {
 
     @Test
     public void notifiesAdvertListenerWhenAdvertLoadingSucceeds() {
-        noPlayerAdsLoader.bind(Optional.of(advertListener), NO_AD_RESUME_POSITION, NO_AD_RESUME_POSITION);
+        noPlayerAdsLoader.bind(Optional.of(advertListener), NO_AD_RESUME_POSITION);
 
         noPlayerAdsLoader.start(eventListener, adViewProvider);
         invokeCallback().onAdvertsLoaded(Arrays.asList(FIRST_ADVERT_BREAK, SECOND_ADVERT_BREAK));
@@ -145,7 +148,7 @@ public class NoPlayerAdsLoaderTest {
 
     @Test
     public void notifiesAdvertListenerWhenAdvertPreparingFails() {
-        noPlayerAdsLoader.bind(Optional.of(advertListener), NO_AD_RESUME_POSITION, NO_AD_RESUME_POSITION);
+        noPlayerAdsLoader.bind(Optional.of(advertListener), NO_AD_RESUME_POSITION);
         noPlayerAdsLoader.start(eventListener, adViewProvider);
         invokeCallback().onAdvertsLoaded(Arrays.asList(FIRST_ADVERT_BREAK, SECOND_ADVERT_BREAK));
 


### PR DESCRIPTION
## Problem
We have been attempting to stop adverts from playing when a user performs a seek but isn't passing through an advert marker. Instead we are now going to allow the content to be gated. Users have to watch an advert in order to watch a section of content. 

## Solution
Mainly removing code around the seek. Also made it so that skipped adverts are all re-enabled when enabling adverts, rather than just those in the future. 

### Test(s) added 
Updated where necessary.

### Paired with 
Nobody.
