### PR TITLE
Allow secure and non-secure decoders

### DIFF
--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/SecurityDowngradingCodecSelector.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/SecurityDowngradingCodecSelector.java
@@ -4,6 +4,7 @@ import com.google.android.exoplayer2.mediacodec.MediaCodecInfo;
 import com.google.android.exoplayer2.mediacodec.MediaCodecSelector;
 import com.google.android.exoplayer2.mediacodec.MediaCodecUtil;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -32,19 +33,20 @@ class SecurityDowngradingCodecSelector implements MediaCodecSelector {
             boolean requiresSecureDecoder,
             boolean requiresTunnelingDecoder
     ) throws MediaCodecUtil.DecoderQueryException {
-        List<MediaCodecInfo> decoderInfos = internalMediaCodecUtil.getDecoderInfos(
+        List<MediaCodecInfo> decoderInfos = new ArrayList<>(internalMediaCodecUtil.getDecoderInfos(
                 mimeType,
                 DECODER_REQUIRES_SECURE_DECRYPTION,
                 requiresTunnelingDecoder
+        ));
+
+        decoderInfos.addAll(
+                internalMediaCodecUtil.getDecoderInfos(
+                        mimeType,
+                        DECODER_DOES_NOT_REQUIRE_SECURE_DECRYPTION,
+                        requiresTunnelingDecoder
+                )
         );
 
-        if (decoderInfos.isEmpty()) {
-            decoderInfos = internalMediaCodecUtil.getDecoderInfos(
-                    mimeType,
-                    DECODER_DOES_NOT_REQUIRE_SECURE_DECRYPTION,
-                    requiresTunnelingDecoder
-            );
-        }
         return decoderInfos;
     }
 

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/SecurityDowngradingCodecSelectorTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/SecurityDowngradingCodecSelectorTest.java
@@ -4,14 +4,14 @@ import com.google.android.exoplayer2.mediacodec.MediaCodecInfo;
 import com.google.android.exoplayer2.mediacodec.MediaCodecUtil;
 import com.novoda.noplayer.internal.exoplayer.SecurityDowngradingCodecSelector.InternalMediaCodecUtil;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
@@ -25,8 +25,12 @@ public class SecurityDowngradingCodecSelectorTest {
     private static final boolean DOES_NOT_REQUIRE_TUNNELING_DECODER = false;
 
     private static final String MIMETYPE = "mimetype";
-    private static final List<MediaCodecInfo> SECURE_CODECS = Collections.singletonList(MediaCodecInfo.newInstance("secure-codec", MIMETYPE, null));
-    private static final List<MediaCodecInfo> UNSECURE_CODECS = Collections.singletonList(MediaCodecInfo.newInstance("unsecure-codec", "mimetype", null));
+    private static final MediaCodecInfo SECURE_CODEC = MediaCodecInfo.newInstance("secure-codec", MIMETYPE, null);
+    private static final MediaCodecInfo UNSECURE_CODEC = MediaCodecInfo.newInstance("unsecure-codec", "mimetype", null);
+
+    private static final List<MediaCodecInfo> SECURE_CODECS = Collections.singletonList(SECURE_CODEC);
+    private static final List<MediaCodecInfo> UNSECURE_CODECS = Collections.singletonList(UNSECURE_CODEC);
+    private static final List<MediaCodecInfo> BOTH_CODECS = Arrays.asList(SECURE_CODEC, UNSECURE_CODEC);
     private static final List<MediaCodecInfo> NO_CODECS = Collections.emptyList();
 
     private final InternalMediaCodecUtil internalMediaCodecUtil = mock(InternalMediaCodecUtil.class);
@@ -46,12 +50,12 @@ public class SecurityDowngradingCodecSelectorTest {
                 new Object[]{CONTENT_SECURE, NO_CODECS, NO_CODECS, NO_CODECS},
                 new Object[]{CONTENT_SECURE, NO_CODECS, UNSECURE_CODECS, UNSECURE_CODECS},
                 new Object[]{CONTENT_SECURE, SECURE_CODECS, NO_CODECS, SECURE_CODECS},
-                new Object[]{CONTENT_SECURE, SECURE_CODECS, UNSECURE_CODECS, SECURE_CODECS},
+                new Object[]{CONTENT_SECURE, SECURE_CODECS, UNSECURE_CODECS, BOTH_CODECS},
 
                 new Object[]{CONTENT_INSECURE, NO_CODECS, NO_CODECS, NO_CODECS},
                 new Object[]{CONTENT_INSECURE, NO_CODECS, UNSECURE_CODECS, UNSECURE_CODECS},
                 new Object[]{CONTENT_INSECURE, SECURE_CODECS, NO_CODECS, SECURE_CODECS},
-                new Object[]{CONTENT_INSECURE, SECURE_CODECS, UNSECURE_CODECS, SECURE_CODECS}
+                new Object[]{CONTENT_INSECURE, SECURE_CODECS, UNSECURE_CODECS, BOTH_CODECS}
         );
     }
 


### PR DESCRIPTION
## Problem
Tried the changes in #250 on a client application, my pixel stopped playing content 😭 

## Solution
Turns out that we should probably try to use a secure decoder first and then switch to the non-secure version if it fails. 

### Paired with 
Nobody. 
