### PR TITLE
Revert codec selection changes

### DIFF
--- a/core/src/main/java/com/novoda/noplayer/PlayerBuilder.java
+++ b/core/src/main/java/com/novoda/noplayer/PlayerBuilder.java
@@ -107,7 +107,8 @@ public class PlayerBuilder {
     }
 
     /**
-     * Allows the selection of an insecure decoder when the device does not support a secure decoder.
+     * Forces secure decoder selection to be ignored in favour of using an insecure decoder.
+     * e.g. Forcing an L3 stream to play with an L3 decoder instead of an L1 secure decoder by default.
      *
      * @return {@link PlayerBuilder}
      */

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/SecurityDowngradingCodecSelector.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/SecurityDowngradingCodecSelector.java
@@ -4,7 +4,6 @@ import com.google.android.exoplayer2.mediacodec.MediaCodecInfo;
 import com.google.android.exoplayer2.mediacodec.MediaCodecSelector;
 import com.google.android.exoplayer2.mediacodec.MediaCodecUtil;
 
-import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -13,8 +12,7 @@ import java.util.List;
  */
 class SecurityDowngradingCodecSelector implements MediaCodecSelector {
 
-    private static final boolean DECODER_REQUIRES_SECURE_DECRYPTION = true;
-    private static final boolean DECODER_DOES_NOT_REQUIRE_SECURE_DECRYPTION = false;
+    private static final boolean USE_INSECURE_DECODER = false;
 
     private final InternalMediaCodecUtil internalMediaCodecUtil;
 
@@ -33,21 +31,7 @@ class SecurityDowngradingCodecSelector implements MediaCodecSelector {
             boolean requiresSecureDecoder,
             boolean requiresTunnelingDecoder
     ) throws MediaCodecUtil.DecoderQueryException {
-        List<MediaCodecInfo> decoderInfos = new ArrayList<>(internalMediaCodecUtil.getDecoderInfos(
-                mimeType,
-                DECODER_REQUIRES_SECURE_DECRYPTION,
-                requiresTunnelingDecoder
-        ));
-
-        decoderInfos.addAll(
-                internalMediaCodecUtil.getDecoderInfos(
-                        mimeType,
-                        DECODER_DOES_NOT_REQUIRE_SECURE_DECRYPTION,
-                        requiresTunnelingDecoder
-                )
-        );
-
-        return decoderInfos;
+        return internalMediaCodecUtil.getDecoderInfos(mimeType, USE_INSECURE_DECODER, requiresTunnelingDecoder);
     }
 
     @Override

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/SecurityDowngradingCodecSelectorTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/SecurityDowngradingCodecSelectorTest.java
@@ -49,13 +49,13 @@ public class SecurityDowngradingCodecSelectorTest {
         return Arrays.asList(
                 new Object[]{CONTENT_SECURE, NO_CODECS, NO_CODECS, NO_CODECS},
                 new Object[]{CONTENT_SECURE, NO_CODECS, UNSECURE_CODECS, UNSECURE_CODECS},
-                new Object[]{CONTENT_SECURE, SECURE_CODECS, NO_CODECS, SECURE_CODECS},
-                new Object[]{CONTENT_SECURE, SECURE_CODECS, UNSECURE_CODECS, BOTH_CODECS},
+                new Object[]{CONTENT_SECURE, SECURE_CODECS, NO_CODECS, NO_CODECS},
+                new Object[]{CONTENT_SECURE, SECURE_CODECS, UNSECURE_CODECS, UNSECURE_CODECS},
 
                 new Object[]{CONTENT_INSECURE, NO_CODECS, NO_CODECS, NO_CODECS},
                 new Object[]{CONTENT_INSECURE, NO_CODECS, UNSECURE_CODECS, UNSECURE_CODECS},
-                new Object[]{CONTENT_INSECURE, SECURE_CODECS, NO_CODECS, SECURE_CODECS},
-                new Object[]{CONTENT_INSECURE, SECURE_CODECS, UNSECURE_CODECS, BOTH_CODECS}
+                new Object[]{CONTENT_INSECURE, SECURE_CODECS, NO_CODECS, NO_CODECS},
+                new Object[]{CONTENT_INSECURE, SECURE_CODECS, UNSECURE_CODECS, UNSECURE_CODECS}
         );
     }
 


### PR DESCRIPTION
## Problem
In #252 #250 we introduced some codec selection changes to pick a secure codec and then fallback to an un-secure version when the initialization fails. Unfortunately we have seen some fatal native level crashes when using the secure codec for content that doesn't really support it. 

## Solution
Revert until we can debug and come up with a better solution. 

### Paired with 
Nobody.
