### PR TITLE
Move retrieval of Key Set Id to Local DRM Session Manager

### DIFF
--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/drm/DownloadDrmSessionCreator.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/drm/DownloadDrmSessionCreator.java
@@ -22,7 +22,7 @@ class DownloadDrmSessionCreator implements DrmSessionCreator {
     @Override
     public DrmSessionManager<FrameworkMediaCrypto> create(DefaultDrmSessionEventListener eventListener) {
         return new LocalDrmSessionManager(
-                downloadedModularDrm.getKeySetId(),
+                downloadedModularDrm,
                 mediaDrmCreator.create(WIDEVINE_MODULAR_UUID),
                 WIDEVINE_MODULAR_UUID,
                 handler,

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/drm/LocalDrmSessionManager.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/drm/LocalDrmSessionManager.java
@@ -11,24 +11,25 @@ import com.google.android.exoplayer2.drm.DrmSession;
 import com.google.android.exoplayer2.drm.DrmSessionManager;
 import com.google.android.exoplayer2.drm.ExoMediaDrm;
 import com.google.android.exoplayer2.drm.FrameworkMediaCrypto;
+import com.novoda.noplayer.drm.DownloadedModularDrm;
 import com.novoda.noplayer.model.KeySetId;
 
 import java.util.UUID;
 
 class LocalDrmSessionManager implements DrmSessionManager<FrameworkMediaCrypto> {
 
-    private final KeySetId keySetIdToRestore;
+    private final DownloadedModularDrm downloadedModularDrm;
     private final ExoMediaDrm<FrameworkMediaCrypto> mediaDrm;
     private final DefaultDrmSessionEventListener eventListener;
     private final UUID drmScheme;
     private final Handler handler;
 
-    LocalDrmSessionManager(KeySetId keySetIdToRestore,
-                           ExoMediaDrm<FrameworkMediaCrypto> mediaDrm,
-                           UUID drmScheme,
-                           Handler handler,
-                           DefaultDrmSessionEventListener eventListener) {
-        this.keySetIdToRestore = keySetIdToRestore;
+    LocalDrmSessionManager(DownloadedModularDrm downloadedModularDrm,
+                           ExoMediaDrm<com.google.android.exoplayer2.drm.FrameworkMediaCrypto> mediaDrm,
+                           java.util.UUID drmScheme,
+                           android.os.Handler handler,
+                           com.google.android.exoplayer2.drm.DefaultDrmSessionEventListener eventListener) {
+        this.downloadedModularDrm = downloadedModularDrm;
         this.mediaDrm = mediaDrm;
         this.eventListener = eventListener;
         this.drmScheme = drmScheme;
@@ -50,10 +51,10 @@ class LocalDrmSessionManager implements DrmSessionManager<FrameworkMediaCrypto> 
         try {
             SessionId sessionId = SessionId.of(mediaDrm.openSession());
             FrameworkMediaCrypto mediaCrypto = mediaDrm.createMediaCrypto(sessionId.asBytes());
+            KeySetId keySetId = downloadedModularDrm.getKeySetId();
+            mediaDrm.restoreKeys(sessionId.asBytes(), keySetId.asBytes());
 
-            mediaDrm.restoreKeys(sessionId.asBytes(), keySetIdToRestore.asBytes());
-
-            drmSession = new LocalDrmSession(mediaCrypto, keySetIdToRestore, sessionId);
+            drmSession = new LocalDrmSession(mediaCrypto, keySetId, sessionId);
         } catch (Exception exception) {
             drmSession = new InvalidDrmSession(new DrmSession.DrmSessionException(exception));
             notifyErrorListener(drmSession);

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/drm/LocalDrmSessionManager.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/drm/LocalDrmSessionManager.java
@@ -26,9 +26,9 @@ class LocalDrmSessionManager implements DrmSessionManager<FrameworkMediaCrypto> 
 
     LocalDrmSessionManager(DownloadedModularDrm downloadedModularDrm,
                            ExoMediaDrm<com.google.android.exoplayer2.drm.FrameworkMediaCrypto> mediaDrm,
-                           java.util.UUID drmScheme,
-                           android.os.Handler handler,
-                           com.google.android.exoplayer2.drm.DefaultDrmSessionEventListener eventListener) {
+                           UUID drmScheme,
+                           Handler handler,
+                           DefaultDrmSessionEventListener eventListener) {
         this.downloadedModularDrm = downloadedModularDrm;
         this.mediaDrm = mediaDrm;
         this.eventListener = eventListener;

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/drm/LocalDrmSessionManager.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/drm/LocalDrmSessionManager.java
@@ -25,7 +25,7 @@ class LocalDrmSessionManager implements DrmSessionManager<FrameworkMediaCrypto> 
     private final Handler handler;
 
     LocalDrmSessionManager(DownloadedModularDrm downloadedModularDrm,
-                           ExoMediaDrm<com.google.android.exoplayer2.drm.FrameworkMediaCrypto> mediaDrm,
+                           ExoMediaDrm<FrameworkMediaCrypto> mediaDrm,
                            UUID drmScheme,
                            Handler handler,
                            DefaultDrmSessionEventListener eventListener) {

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/drm/LocalDrmSessionManagerTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/drm/LocalDrmSessionManagerTest.java
@@ -7,15 +7,17 @@ import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
 
-import androidx.annotation.RequiresApi;
-
 import com.google.android.exoplayer2.drm.DefaultDrmSessionEventListener;
 import com.google.android.exoplayer2.drm.DrmInitData;
 import com.google.android.exoplayer2.drm.DrmSession;
 import com.google.android.exoplayer2.drm.ExoMediaDrm;
 import com.google.android.exoplayer2.drm.FrameworkMediaCrypto;
 import com.google.android.exoplayer2.drm.FrameworkMediaCryptoFixture;
+import com.novoda.noplayer.drm.DownloadedModularDrm;
 import com.novoda.noplayer.model.KeySetId;
+
+import java.util.Collections;
+import java.util.UUID;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -26,8 +28,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
-import java.util.Collections;
-import java.util.UUID;
+import androidx.annotation.RequiresApi;
 
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -40,6 +41,12 @@ public class LocalDrmSessionManagerTest {
     private static final DrmInitData IGNORED_DRM_DATA = null;
 
     private static final KeySetId KEY_SET_ID_TO_RESTORE = KeySetId.of(new byte[12]);
+    private static final DownloadedModularDrm DOWNLOADED_MODULAR_DRM = new DownloadedModularDrm() {
+        @Override
+        public KeySetId getKeySetId() {
+            return KEY_SET_ID_TO_RESTORE;
+        }
+    };
     private static final SessionId SESSION_ID = SessionId.of(new byte[10]);
     private static final UUID DRM_SCHEME = UUID.randomUUID();
 
@@ -64,7 +71,7 @@ public class LocalDrmSessionManagerTest {
         given(mediaDrm.openSession()).willReturn(SESSION_ID.asBytes());
 
         localDrmSessionManager = new LocalDrmSessionManager(
-                KEY_SET_ID_TO_RESTORE,
+                DOWNLOADED_MODULAR_DRM,
                 mediaDrm,
                 DRM_SCHEME,
                 handler,


### PR DESCRIPTION
## Problem

The retrieval of the `Key Set Id` could be a long running task that at the moment we are performing upon `ExoPlayer` creation. But there is no need of doing it there.
## Solution

Move the retrieval of the `Key Set Id` via `DownloadedModularDrm` to `LocalSessionManager.acquireSession` which should be a thread safe place

### Test(s) added 

Yes, to verify that the `KeySetId` is retrieved correctly when required