### PR TITLE
Advert resume position

### DIFF
--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/AdvertPlaybackState.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/AdvertPlaybackState.java
@@ -15,10 +15,6 @@ final class AdvertPlaybackState {
     private final List<AdvertBreak> advertBreaks;
 
     static AdvertPlaybackState from(List<AdvertBreak> advertBreaks) {
-        return from(advertBreaks, 0);
-    }
-
-    static AdvertPlaybackState from(List<AdvertBreak> advertBreaks, long advertBreakResumePositionMillis) {
         List<AdvertBreak> sortedAdvertBreaks = sortAdvertBreaksByStartTime(advertBreaks);
 
         long[] advertOffsets = advertBreakOffset(sortedAdvertBreaks);
@@ -46,35 +42,7 @@ final class AdvertPlaybackState {
         }
 
         adPlaybackState = adPlaybackState.withAdDurationsUs(advertBreaksWithAdvertDurations);
-        adPlaybackState = updateResumePositionInFirstGroup(adPlaybackState, advertBreakResumePositionMillis);
         return new AdvertPlaybackState(adPlaybackState, sortedAdvertBreaks);
-    }
-
-    private static AdPlaybackState updateResumePositionInFirstGroup(AdPlaybackState state, long positionMillis) {
-        if (state.adGroupCount <= 0 || state.adGroups[0].count <= 0) {
-            return state;
-        }
-        long groupResumePosition = C.msToUs(positionMillis);
-        AdPlaybackState.AdGroup firstAdGroup = state.adGroups[0];
-
-        AdPlaybackState updatedState = state;
-        long playedAdvertDuration = 0;
-        for (int index = 0; index < firstAdGroup.count; index++) {
-            long durationWithCurrentAd = playedAdvertDuration + firstAdGroup.durationsUs[index];
-            if (durationWithCurrentAd <= groupResumePosition) {
-                updatedState = updatedState.withPlayedAd(0, index);
-                playedAdvertDuration += firstAdGroup.durationsUs[index];
-            }
-            if (groupResumePosition <= playedAdvertDuration) {
-                break;
-            }
-
-        }
-        if (updatedState.adGroups[0].hasUnplayedAds()) {
-            updatedState = updatedState.withAdResumePositionUs(groupResumePosition - playedAdvertDuration);
-        }
-
-        return updatedState;
     }
 
     private AdvertPlaybackState(AdPlaybackState adPlaybackState, List<AdvertBreak> advertBreaks) {

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
@@ -86,9 +86,9 @@ public class NoPlayerAdsLoader implements AdsLoader, Player.EventListener, Adver
         @Override
         public void onAdvertsLoaded(List<AdvertBreak> breaks) {
             loadingAds = null;
-            AdvertPlaybackState advertPlaybackState = AdvertPlaybackState.from(breaks, advertBreakResumePosition);
+            AdvertPlaybackState advertPlaybackState = AdvertPlaybackState.from(breaks);
             advertBreaks = advertPlaybackState.advertBreaks();
-            adPlaybackState = advertPlaybackState.adPlaybackState();
+            adPlaybackState = ResumeableAdverts.markAsResumeableFrom(advertPlaybackState.adPlaybackState(), advertBreakResumePosition);
 
             handler.post(new Runnable() {
                 @Override

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ResumeableAdverts.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ResumeableAdverts.java
@@ -1,0 +1,39 @@
+package com.novoda.noplayer.internal.exoplayer;
+
+import com.google.android.exoplayer2.C;
+import com.google.android.exoplayer2.source.ads.AdPlaybackState;
+
+final class ResumeableAdverts {
+
+    private ResumeableAdverts() {
+        // Utility class.
+    }
+
+    static AdPlaybackState markAsResumeableFrom(AdPlaybackState adPlaybackState, long positionInMillis) {
+        if (adPlaybackState.adGroupCount <= 0 || adPlaybackState.adGroups[0].count <= 0) {
+            return adPlaybackState;
+        }
+        long groupResumePosition = C.msToUs(positionInMillis);
+        AdPlaybackState.AdGroup firstAdGroup = adPlaybackState.adGroups[0];
+
+        AdPlaybackState updatedState = adPlaybackState;
+        long playedAdvertDuration = 0;
+        for (int index = 0; index < firstAdGroup.count; index++) {
+            long durationWithCurrentAd = playedAdvertDuration + firstAdGroup.durationsUs[index];
+            if (durationWithCurrentAd <= groupResumePosition) {
+                updatedState = updatedState.withPlayedAd(0, index);
+                playedAdvertDuration += firstAdGroup.durationsUs[index];
+            }
+            if (groupResumePosition <= playedAdvertDuration) {
+                break;
+            }
+
+        }
+        if (updatedState.adGroups[0].hasUnplayedAds()) {
+            updatedState = updatedState.withAdResumePositionUs(groupResumePosition - playedAdvertDuration);
+        }
+
+        return updatedState;
+    }
+
+}

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ResumeableAdverts.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ResumeableAdverts.java
@@ -20,14 +20,12 @@ final class ResumeableAdverts {
         long playedAdvertDuration = 0;
         for (int index = 0; index < firstAdGroup.count; index++) {
             long durationWithCurrentAd = playedAdvertDuration + firstAdGroup.durationsUs[index];
-            if (durationWithCurrentAd <= groupResumePosition) {
+            if (groupResumePosition >= durationWithCurrentAd) {
                 updatedState = updatedState.withPlayedAd(0, index);
                 playedAdvertDuration += firstAdGroup.durationsUs[index];
-            }
-            if (groupResumePosition <= playedAdvertDuration) {
+            } else {
                 break;
             }
-
         }
         if (updatedState.adGroups[0].hasUnplayedAds()) {
             updatedState = updatedState.withAdResumePositionUs(groupResumePosition - playedAdvertDuration);

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/AdvertPlaybackStateTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/AdvertPlaybackStateTest.java
@@ -1,15 +1,17 @@
 package com.novoda.noplayer.internal.exoplayer;
 
 import android.net.Uri;
+
 import com.google.android.exoplayer2.C;
 import com.google.android.exoplayer2.source.ads.AdPlaybackState;
 import com.novoda.noplayer.Advert;
 import com.novoda.noplayer.AdvertBreak;
-import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+
+import org.junit.Test;
 
 import static com.novoda.noplayer.AdvertBreakFixtures.anAdvertBreak;
 import static com.novoda.noplayer.AdvertFixtures.anAdvert;
@@ -72,7 +74,7 @@ public class AdvertPlaybackStateTest {
     public void createsEmptyStateWhenAdvertBreaksAreEmpty() {
         List<AdvertBreak> advertBreaks = Collections.emptyList();
 
-        AdvertPlaybackState advertPlaybackState = AdvertPlaybackState.from(advertBreaks, HALF_SECOND_IN_MILLIS);
+        AdvertPlaybackState advertPlaybackState = AdvertPlaybackState.from(advertBreaks);
         AdPlaybackState adPlaybackState = advertPlaybackState.adPlaybackState();
 
         assertThat(adPlaybackState.adGroupCount).isEqualTo(0);
@@ -80,58 +82,6 @@ public class AdvertPlaybackStateTest {
         assertThat(adPlaybackState.adGroups).isEmpty();
         assertThat(adPlaybackState.adResumePositionUs).isEqualTo(0L);
         assertThat(adPlaybackState.contentDurationUs).isEqualTo(C.TIME_UNSET);
-    }
-
-    @Test
-    public void createsAdvertPlaybackStateWithResumePositionInMicroseconds() {
-        List<AdvertBreak> advertBreaks = Collections.singletonList(FIRST_ADVERT_BREAK);
-
-        AdvertPlaybackState advertPlaybackState = AdvertPlaybackState.from(advertBreaks, HALF_SECOND_IN_MILLIS);
-        AdPlaybackState adPlaybackState = advertPlaybackState.adPlaybackState();
-
-        assertThat(adPlaybackState.adResumePositionUs).isEqualTo(HALF_SECOND_IN_MICROS);
-    }
-
-    @Test
-    public void marksAdvertsInAdvertBreakAsPlayedWhenResumePositionIsMoreThanEachAdvertDuration() {
-        List<AdvertBreak> advertBreaks = Collections.singletonList(THIRD_ADVERT_BREAK);
-        AdPlaybackState.AdGroup expectedAdGroup = thirdAdGroupFixture()
-                .withPlayedStateAt(0)
-                .withPlayedStateAt(1)
-                .build();
-        long resumePosition = FIRST_ADVERT.durationInMillis() + SECOND_ADVERT.durationInMillis() + HALF_SECOND_IN_MILLIS;
-
-        AdvertPlaybackState advertPlaybackState = AdvertPlaybackState.from(advertBreaks, resumePosition);
-        AdPlaybackState adPlaybackState = advertPlaybackState.adPlaybackState();
-
-        assertThat(adPlaybackState.adGroups).containsExactly(expectedAdGroup);
-        assertThat(adPlaybackState.adResumePositionUs).isEqualTo(HALF_SECOND_IN_MICROS);
-    }
-
-    @Test
-    public void marksAllAdvertsInAdvertBreakPlayedWhenResumePositionIsBiggerThanTotalLengthOfFirstAdvertBreak() {
-        List<AdvertBreak> advertBreaks = Arrays.asList(THIRD_ADVERT_BREAK, SECOND_ADVERT_BREAK);
-        AdPlaybackState.AdGroup expectedAdGroup = secondAdGroupFixture()
-                .withPlayedStateAt(0)
-                .withPlayedStateAt(1)
-                .build();
-
-        int resumePosition = TWO_SECONDS_IN_MILLIS + THREE_SECONDS_IN_MILLIS;
-        AdvertPlaybackState advertPlaybackState = AdvertPlaybackState.from(advertBreaks, resumePosition);
-        AdPlaybackState adPlaybackState = advertPlaybackState.adPlaybackState();
-
-        assertThat(adPlaybackState.adGroups).containsExactly(expectedAdGroup, THIRD_AD_GROUP);
-    }
-
-    @Test
-    public void doesNotSetResumePositionWhenBiggerThanTotalLengthOfFirstAdvertBreak() {
-        List<AdvertBreak> advertBreaks = Arrays.asList(THIRD_ADVERT_BREAK, SECOND_ADVERT_BREAK);
-
-        int resumePosition = THREE_SECONDS_IN_MILLIS * 2;
-        AdvertPlaybackState advertPlaybackState = AdvertPlaybackState.from(advertBreaks, resumePosition);
-        AdPlaybackState adPlaybackState = advertPlaybackState.adPlaybackState();
-
-        assertThat(adPlaybackState.adResumePositionUs).isEqualTo(0);
     }
 
     @Test

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ResumeableAdvertsTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ResumeableAdvertsTest.java
@@ -20,19 +20,15 @@ import static org.fest.assertions.api.Assertions.assertThat;
 public class ResumeableAdvertsTest {
 
     private static final int ZERO = 0;
-    private static final int HALF_SECOND_IN_MICROS = 500000;
     private static final int FIVE_SECONDS_IN_MICROS = 5000000;
     private static final int TEN_SECONDS_IN_MICROS = 10000000;
     private static final int TWENTY_SECONDS_IN_MICROS = 20000000;
-    private static final int THIRTY_SECONDS_IN_MICROS = 30000000;
 
     private static final int HALF_SECOND_IN_MILLIS = 500;
     private static final int FIVE_SECONDS_IN_MILLIS = 5000;
     private static final int TEN_SECONDS_IN_MILLIS = 10000;
     private static final int TWENTY_SECONDS_IN_MILLIS = 20000;
     private static final int THIRTY_SECONDS_IN_MILLIS = 30000;
-
-    // Make resume position greater than first advert duration but less than second advert duration.
 
     private static final Advert FIRST_ADVERT = anAdvert()
             .withDurationInMillis(TWENTY_SECONDS_IN_MILLIS)
@@ -53,7 +49,6 @@ public class ResumeableAdvertsTest {
             .withAdverts(THIRD_ADVERT)
             .build();
     private static final List<AdvertBreak> ADVERT_BREAKS = Arrays.asList(FIRST_ADVERT_BREAK, SECOND_ADVERT_BREAK);
-    private static final AdPlaybackState.AdGroup FIRST_AD_GROUP = firstAdGroupFixture().build();
     private static final AdPlaybackState.AdGroup SECOND_AD_GROUP = secondAdGroupFixture().build();
 
     @Test

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ResumeableAdvertsTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ResumeableAdvertsTest.java
@@ -1,0 +1,130 @@
+package com.novoda.noplayer.internal.exoplayer;
+
+import android.net.Uri;
+
+import com.google.android.exoplayer2.source.ads.AdPlaybackState;
+import com.novoda.noplayer.Advert;
+import com.novoda.noplayer.AdvertBreak;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+
+import static com.novoda.noplayer.AdvertBreakFixtures.anAdvertBreak;
+import static com.novoda.noplayer.AdvertFixtures.anAdvert;
+import static com.novoda.noplayer.internal.exoplayer.AdGroupFixture.anAdGroup;
+import static org.fest.assertions.api.Assertions.assertThat;
+
+public class ResumeableAdvertsTest {
+
+    private static final int ZERO = 0;
+    private static final int HALF_SECOND_IN_MICROS = 500000;
+    private static final int FIVE_SECONDS_IN_MICROS = 5000000;
+    private static final int TEN_SECONDS_IN_MICROS = 10000000;
+    private static final int TWENTY_SECONDS_IN_MICROS = 20000000;
+    private static final int THIRTY_SECONDS_IN_MICROS = 30000000;
+
+    private static final int HALF_SECOND_IN_MILLIS = 500;
+    private static final int FIVE_SECONDS_IN_MILLIS = 5000;
+    private static final int TEN_SECONDS_IN_MILLIS = 10000;
+    private static final int TWENTY_SECONDS_IN_MILLIS = 20000;
+    private static final int THIRTY_SECONDS_IN_MILLIS = 30000;
+
+    // Make resume position greater than first advert duration but less than second advert duration.
+
+    private static final Advert FIRST_ADVERT = anAdvert()
+            .withDurationInMillis(TWENTY_SECONDS_IN_MILLIS)
+            .build();
+    private static final Advert SECOND_ADVERT = anAdvert()
+            .withDurationInMillis(FIVE_SECONDS_IN_MILLIS)
+            .build();
+    private static final Advert THIRD_ADVERT = anAdvert()
+            .withDurationInMillis(TEN_SECONDS_IN_MILLIS)
+            .build();
+
+    private static final AdvertBreak FIRST_ADVERT_BREAK = anAdvertBreak()
+            .withStartTimeInMillis(TEN_SECONDS_IN_MILLIS)
+            .withAdverts(FIRST_ADVERT, SECOND_ADVERT)
+            .build();
+    private static final AdvertBreak SECOND_ADVERT_BREAK = anAdvertBreak()
+            .withStartTimeInMillis(TWENTY_SECONDS_IN_MILLIS)
+            .withAdverts(THIRD_ADVERT)
+            .build();
+    private static final List<AdvertBreak> ADVERT_BREAKS = Arrays.asList(FIRST_ADVERT_BREAK, SECOND_ADVERT_BREAK);
+    private static final AdPlaybackState.AdGroup FIRST_AD_GROUP = firstAdGroupFixture().build();
+    private static final AdPlaybackState.AdGroup SECOND_AD_GROUP = secondAdGroupFixture().build();
+
+    @Test
+    public void createsAdvertPlaybackStateWithResumePositionInMicroseconds() {
+        List<AdvertBreak> advertBreaks = Collections.singletonList(FIRST_ADVERT_BREAK);
+
+        AdvertPlaybackState advertPlaybackState = AdvertPlaybackState.from(advertBreaks);
+        AdPlaybackState adPlaybackState = ResumeableAdverts.markAsResumeableFrom(advertPlaybackState.adPlaybackState(), TEN_SECONDS_IN_MILLIS);
+
+        assertThat(adPlaybackState.adResumePositionUs).isEqualTo(TEN_SECONDS_IN_MICROS);
+    }
+
+    @Test
+    public void marksAdvertsInAdvertBreakAsPlayedWhenResumePositionIsMoreThanEachAdvertDuration() {
+        AdvertPlaybackState advertPlaybackState = AdvertPlaybackState.from(ADVERT_BREAKS);
+        long resumePosition = FIRST_ADVERT.durationInMillis() + SECOND_ADVERT.durationInMillis() + HALF_SECOND_IN_MILLIS;
+        AdPlaybackState adPlaybackState = ResumeableAdverts.markAsResumeableFrom(advertPlaybackState.adPlaybackState(), resumePosition);
+
+        AdPlaybackState.AdGroup expectedAdGroup = firstAdGroupFixture()
+                .withPlayedStateAt(0)
+                .withPlayedStateAt(1)
+                .build();
+
+        assertThat(adPlaybackState.adGroups).containsExactly(expectedAdGroup, SECOND_AD_GROUP);
+        assertThat(adPlaybackState.adResumePositionUs).isEqualTo(ZERO);
+    }
+
+    @Test
+    public void marksAllAdvertsInAdvertBreakPlayedWhenResumePositionIsBiggerThanTotalLengthOfFirstAdvertBreak() {
+        AdvertPlaybackState advertPlaybackState = AdvertPlaybackState.from(ADVERT_BREAKS);
+        AdPlaybackState adPlaybackState = ResumeableAdverts.markAsResumeableFrom(advertPlaybackState.adPlaybackState(), THIRTY_SECONDS_IN_MILLIS + HALF_SECOND_IN_MILLIS);
+
+        AdPlaybackState.AdGroup expectedAdGroup = firstAdGroupFixture()
+                .withPlayedStateAt(0)
+                .withPlayedStateAt(1)
+                .build();
+        assertThat(adPlaybackState.adGroups).containsExactly(expectedAdGroup, SECOND_AD_GROUP);
+    }
+
+    @Test
+    public void marksAllAdvertsInAdvertBreakPlayedWhenResumePositionIsSameASTotalLengthOfFirstAdvertBreak() {
+        AdvertPlaybackState advertPlaybackState = AdvertPlaybackState.from(ADVERT_BREAKS);
+        AdPlaybackState adPlaybackState = ResumeableAdverts.markAsResumeableFrom(advertPlaybackState.adPlaybackState(), THIRTY_SECONDS_IN_MILLIS);
+
+        AdPlaybackState.AdGroup expectedAdGroup = firstAdGroupFixture()
+                .withPlayedStateAt(0)
+                .withPlayedStateAt(1)
+                .build();
+        assertThat(adPlaybackState.adGroups).containsExactly(expectedAdGroup, SECOND_AD_GROUP);
+    }
+
+    @Test
+    public void doesNotSetResumePositionWhenBiggerThanTotalLengthOfFirstAdvertBreak() {
+        AdvertPlaybackState advertPlaybackState = AdvertPlaybackState.from(ADVERT_BREAKS);
+        AdPlaybackState adPlaybackState = ResumeableAdverts.markAsResumeableFrom(advertPlaybackState.adPlaybackState(), THIRTY_SECONDS_IN_MILLIS + HALF_SECOND_IN_MILLIS);
+
+        assertThat(adPlaybackState.adResumePositionUs).isEqualTo(0);
+    }
+
+    private static AdGroupFixture firstAdGroupFixture() {
+        return anAdGroup()
+                .withAdCount(2)
+                .withAdDurationsUs(new long[]{TWENTY_SECONDS_IN_MICROS, FIVE_SECONDS_IN_MICROS})
+                .withAdUris(new Uri[]{FIRST_ADVERT.uri(), SECOND_ADVERT.uri()});
+    }
+
+    private static AdGroupFixture secondAdGroupFixture() {
+        return anAdGroup()
+                .withAdCount(1)
+                .withAdDurationsUs(new long[]{TEN_SECONDS_IN_MICROS})
+                .withAdUris(new Uri[]{THIRD_ADVERT.uri()});
+    }
+
+}


### PR DESCRIPTION
## Problem
We've seen adverts resuming from the beginning or at odd times when resuming playback 😬 Seems to occur when the first advert duration is greater than the resume position BUT the second advert is less than the resume position. 

**Resume: 2000**
**Advert 1: 3000**
**Advert 2: 1000**

Resume is less than 3000 so we don't update the `played advert duration` BUT we also don't break out because the check is against the `played advert duration` which we didn't update 😬 

So:

Resume is greater than 1000 so we do update the `played advert duration`

At which point we the do `resume - duration` which would be `2000 - 1000` which would not match the original position 😬 

## Solution
I've moved the `ResumeableAdverts` away from the `AdvertPlaybackState`, it felt like a separate operation that can be performed after the base creation has been performed. It also made testing a little easier because I only needed to be concerned with a single part. 

The actual solution is just ensuring that we perform one operation. Either we update the duration and continue through the adverts until out criteria is met OR our criteria is already met, in which case, we break out. At least one of these operations must occur each time we try to resume. 

### Test(s) added 
Yes, moved to a separate class and updated the tests to show the error case.

### Paired with 
Nobody.
