### PR TITLE
Downloaded license

### DIFF
--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -24,6 +24,7 @@ android {
 }
 dependencies {
     implementation project(':core')
+    implementation 'com.google.android.exoplayer:exoplayer:2.10.1'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     implementation 'com.google.android.material:material:1.1.0-alpha07'
     implementation 'androidx.appcompat:appcompat:1.0.2'

--- a/demo/src/main/java/com/novoda/demo/LandingActivity.java
+++ b/demo/src/main/java/com/novoda/demo/LandingActivity.java
@@ -1,7 +1,6 @@
 package com.novoda.demo;
 
 import android.content.Intent;
-import android.net.Uri;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.Button;
@@ -30,14 +29,12 @@ public class LandingActivity extends AppCompatActivity {
         playUsingProperties.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                String customUri = mpdAddress.getText().toString();
+                PlaybackParameters playbackParameters = PlaybackParameters.INSTANCE;
+                playbackParameters.setMpdAddress(mpdAddress.getText().toString());
+                playbackParameters.setLicenseServerAddress(licenseAddress.getText().toString());
+                playbackParameters.setDownloadLicense(downloadLicense.isChecked());
 
-                Intent intent = new Intent(getApplicationContext(), MainActivity.class)
-                        .putExtra(KEY_MPD_ADDRESS, mpdAddress.getText().toString())
-                        .putExtra(KEY_LICENSE_SERVER_ADDRESS, licenseAddress.getText().toString())
-                        .putExtra(KEY_DOWNLOAD_LICENSE, downloadLicense.isChecked())
-                        .setData(Uri.parse(customUri));
-
+                Intent intent = new Intent(getApplicationContext(), MainActivity.class);
                 startActivity(intent);
             }
         });

--- a/demo/src/main/java/com/novoda/demo/MainActivity.java
+++ b/demo/src/main/java/com/novoda/demo/MainActivity.java
@@ -4,21 +4,14 @@ import android.app.Activity;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
-import android.os.Handler;
-import android.os.Looper;
 import android.util.Log;
 import android.view.View;
 import android.widget.CheckBox;
 import android.widget.CompoundButton;
 import android.widget.Toast;
 
-import com.google.android.exoplayer2.drm.DrmInitData;
-import com.google.android.exoplayer2.drm.DrmSession;
 import com.google.android.exoplayer2.drm.OfflineLicenseHelper;
 import com.google.android.exoplayer2.drm.UnsupportedDrmException;
-import com.google.android.exoplayer2.source.dash.DashUtil;
-import com.google.android.exoplayer2.source.dash.manifest.DashManifest;
-import com.google.android.exoplayer2.upstream.DataSource;
 import com.google.android.exoplayer2.upstream.DefaultHttpDataSourceFactory;
 import com.novoda.noplayer.ContentType;
 import com.novoda.noplayer.NoPlayer;
@@ -35,7 +28,6 @@ import com.novoda.noplayer.model.KeySetId;
 import com.novoda.noplayer.model.PlayerSubtitleTrack;
 import com.novoda.noplayer.model.PlayerVideoTrack;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -59,13 +51,25 @@ public class MainActivity extends Activity {
     private String licenseServerAddress;
     private boolean downloadLicense;
 
-    private OfflineLicenseHelper offlineLicenseHelper;
+    private OfflineLicense offlineLicense;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
         extractFromIntent();
+
+        DefaultHttpDataSourceFactory httpDataSourceFactory = new DefaultHttpDataSourceFactory("no-player");
+        try {
+            OfflineLicenseHelper offlineLicenseHelper = OfflineLicenseHelper.newWidevineInstance(
+                    licenseServerAddress,
+                    httpDataSourceFactory
+            );
+            offlineLicense = new OfflineLicense(getApplicationContext(), offlineLicenseHelper, httpDataSourceFactory, mpdAddress);
+        } catch (UnsupportedDrmException e) {
+            Log.e(getClass().getSimpleName(), "UnsupportedDrmException", e);
+            Toast.makeText(this, "UnsupportedDrmException: " + e.getMessage(), Toast.LENGTH_SHORT).show();
+        }
 
         NoPlayerLog.setLoggingEnabled(true);
         setContentView(R.layout.activity_main);
@@ -139,50 +143,6 @@ public class MainActivity extends Activity {
         });
     }
 
-    private void downloadLicense(final DownloadLicenseCallback downloadLicenseCallback) {
-        executorService.submit(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    DefaultHttpDataSourceFactory httpDataSourceFactory = new DefaultHttpDataSourceFactory("no-player");
-
-                    offlineLicenseHelper = OfflineLicenseHelper.newWidevineInstance(
-                            licenseServerAddress,
-                            httpDataSourceFactory
-                    );
-
-                    DataSource dataSource = httpDataSourceFactory.createDataSource();
-                    DashManifest dashManifest = DashUtil.loadManifest(
-                            dataSource,
-                            mpdAddress
-                    );
-                    DrmInitData drmInitData = DashUtil.loadDrmInitData(dataSource, dashManifest.getPeriod(0));
-                    final byte[] offlineKeySetId = offlineLicenseHelper.downloadLicense(drmInitData);
-
-                    Handler handler = new Handler(Looper.getMainLooper());
-                    handler.post(new Runnable() {
-                        @Override
-                        public void run() {
-                            downloadLicenseCallback.onLicenseDownloaded(offlineKeySetId);
-                        }
-                    });
-                } catch (DrmSession.DrmSessionException e) {
-                    Log.e("TAG", "DrmSession.DrmSessionException", e);
-                } catch (IOException e) {
-                    Log.e("TAG", "IOException", e);
-                } catch (InterruptedException e) {
-                    Log.e("TAG", "InterruptedException", e);
-                } catch (UnsupportedDrmException e) {
-                    Log.e("TAG", "UnsupportedDrmException", e);
-                }
-            }
-        });
-    }
-
-    interface DownloadLicenseCallback {
-        void onLicenseDownloaded(byte[] license);
-    }
-
     private void extractFromIntent() {
         Intent intent = getIntent();
         if (intent != null) {
@@ -205,7 +165,7 @@ public class MainActivity extends Activity {
     @Override
     protected void onStart() {
         super.onStart();
-        downloadLicense(new DownloadLicenseCallback() {
+        offlineLicense.download(new OfflineLicense.OfflineLicenseCallback() {
             @Override
             public void onLicenseDownloaded(byte[] license) {
                 offlineKeySetId = license;

--- a/demo/src/main/java/com/novoda/demo/MainActivity.java
+++ b/demo/src/main/java/com/novoda/demo/MainActivity.java
@@ -29,16 +29,12 @@ import com.novoda.noplayer.model.PlayerSubtitleTrack;
 import com.novoda.noplayer.model.PlayerVideoTrack;
 
 import java.util.List;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
 public class MainActivity extends Activity {
 
     private static final int HALF_A_SECOND_IN_MILLIS = 500;
     private static final int TWO_MEGABITS = 2000000;
     private static final int MAX_VIDEO_BITRATE = 800000;
-
-    private final ExecutorService executorService = Executors.newSingleThreadExecutor();
 
     private byte[] offlineKeySetId;
 

--- a/demo/src/main/java/com/novoda/demo/MainActivity.java
+++ b/demo/src/main/java/com/novoda/demo/MainActivity.java
@@ -40,6 +40,9 @@ public class MainActivity extends Activity {
     private NoPlayer player;
     private DemoPresenter demoPresenter;
     private DialogCreator dialogCreator;
+    private View videoSelectionButton;
+    private View audioSelectionButton;
+    private View subtitleSelectionButton;
     private CheckBox hdSelectionCheckBox;
 
     private OfflineLicense offlineLicense;
@@ -71,9 +74,9 @@ public class MainActivity extends Activity {
         NoPlayerLog.setLoggingEnabled(true);
         setContentView(R.layout.activity_main);
         PlayerView playerView = findViewById(R.id.player_view);
-        final View videoSelectionButton = findViewById(R.id.button_video_selection);
-        final View audioSelectionButton = findViewById(R.id.button_audio_selection);
-        final View subtitleSelectionButton = findViewById(R.id.button_subtitle_selection);
+        videoSelectionButton = findViewById(R.id.button_video_selection);
+        audioSelectionButton = findViewById(R.id.button_audio_selection);
+        subtitleSelectionButton = findViewById(R.id.button_subtitle_selection);
         hdSelectionCheckBox = findViewById(R.id.button_hd_selection);
         ControllerView controllerView = findViewById(R.id.controller_view);
 
@@ -113,32 +116,34 @@ public class MainActivity extends Activity {
                 Log.v(getClass().toString(), "dropped frames: " + droppedFrames + " since: " + elapsedMsSinceLastDroppedFrames + "ms");
             }
         });
-        player.getListeners().addTracksChangedListener(new NoPlayer.TracksChangedListener() {
-            @Override
-            public void onTracksChanged() {
-                AudioTracks audioTracks = player.getAudioTracks();
-                if (audioTracks.size() > 1) {
-                    audioSelectionButton.setVisibility(View.VISIBLE);
-                } else {
-                    audioSelectionButton.setVisibility(View.GONE);
-                }
-
-                List<PlayerVideoTrack> videoTracks = player.getVideoTracks();
-                if (videoTracks.size() > 1) {
-                    videoSelectionButton.setVisibility(View.VISIBLE);
-                } else {
-                    videoSelectionButton.setVisibility(View.GONE);
-                }
-
-                List<PlayerSubtitleTrack> subtitleTracks = player.getSubtitleTracks();
-                if (subtitleTracks.size() > 1) {
-                    subtitleSelectionButton.setVisibility(View.VISIBLE);
-                } else {
-                    subtitleSelectionButton.setVisibility(View.GONE);
-                }
-            }
-        });
+        player.getListeners().addTracksChangedListener(tracksChangedListener);
     }
+
+    private final NoPlayer.TracksChangedListener tracksChangedListener = new NoPlayer.TracksChangedListener() {
+        @Override
+        public void onTracksChanged() {
+            AudioTracks audioTracks = player.getAudioTracks();
+            if (audioTracks.size() > 1) {
+                audioSelectionButton.setVisibility(View.VISIBLE);
+            } else {
+                audioSelectionButton.setVisibility(View.GONE);
+            }
+
+            List<PlayerVideoTrack> videoTracks = player.getVideoTracks();
+            if (videoTracks.size() > 1) {
+                videoSelectionButton.setVisibility(View.VISIBLE);
+            } else {
+                videoSelectionButton.setVisibility(View.GONE);
+            }
+
+            List<PlayerSubtitleTrack> subtitleTracks = player.getSubtitleTracks();
+            if (subtitleTracks.size() > 1) {
+                subtitleSelectionButton.setVisibility(View.VISIBLE);
+            } else {
+                subtitleSelectionButton.setVisibility(View.GONE);
+            }
+        }
+    };
 
     @Override
     protected void onStart() {

--- a/demo/src/main/java/com/novoda/demo/MainActivity.java
+++ b/demo/src/main/java/com/novoda/demo/MainActivity.java
@@ -87,7 +87,7 @@ public class MainActivity extends Activity {
             drmHandler = new DownloadedModularDrm() {
                 @Override
                 public KeySetId getKeySetId() {
-                    return KeySetId.of(offlineKeySetId);
+                    return offlineKeySetId == null ? null : KeySetId.of(offlineKeySetId);
                 }
             };
             drmType = DrmType.WIDEVINE_MODULAR_DOWNLOAD;

--- a/demo/src/main/java/com/novoda/demo/OfflineLicense.java
+++ b/demo/src/main/java/com/novoda/demo/OfflineLicense.java
@@ -1,0 +1,78 @@
+package com.novoda.demo;
+
+import android.content.Context;
+import android.net.Uri;
+import android.os.Handler;
+import android.os.Looper;
+import android.util.Log;
+import android.widget.Toast;
+
+import com.google.android.exoplayer2.drm.DrmInitData;
+import com.google.android.exoplayer2.drm.DrmSession;
+import com.google.android.exoplayer2.drm.OfflineLicenseHelper;
+import com.google.android.exoplayer2.source.dash.DashUtil;
+import com.google.android.exoplayer2.source.dash.manifest.DashManifest;
+import com.google.android.exoplayer2.upstream.DataSource;
+import com.google.android.exoplayer2.upstream.DefaultHttpDataSourceFactory;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+class OfflineLicense {
+
+    private final Context context;
+    private final ExecutorService executorService = Executors.newSingleThreadExecutor();
+    private final OfflineLicenseHelper offlineLicenseHelper;
+    private final DefaultHttpDataSourceFactory httpDataSourceFactory;
+    private final Uri mpdAddress;
+
+    OfflineLicense(Context context,
+                   OfflineLicenseHelper offlineLicenseHelper,
+                   DefaultHttpDataSourceFactory httpDataSourceFactory,
+                   Uri mpdAddress) {
+        this.context = context;
+        this.offlineLicenseHelper = offlineLicenseHelper;
+        this.httpDataSourceFactory = httpDataSourceFactory;
+        this.mpdAddress = mpdAddress;
+    }
+
+    void download(final OfflineLicenseCallback offlineLicenseCallback) {
+        executorService.submit(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    DataSource dataSource = httpDataSourceFactory.createDataSource();
+                    DashManifest dashManifest = DashUtil.loadManifest(
+                            dataSource,
+                            mpdAddress
+                    );
+                    DrmInitData drmInitData = DashUtil.loadDrmInitData(dataSource, dashManifest.getPeriod(0));
+                    final byte[] offlineKeySetId = offlineLicenseHelper.downloadLicense(drmInitData);
+
+                    Handler handler = new Handler(Looper.getMainLooper());
+                    handler.post(new Runnable() {
+                        @Override
+                        public void run() {
+                            offlineLicenseCallback.onLicenseDownloaded(offlineKeySetId);
+                        }
+                    });
+                } catch (DrmSession.DrmSessionException e) {
+                    Log.e(getClass().getSimpleName(), "DrmSession.DrmSessionException", e);
+                    Toast.makeText(context, "DrmSession.DrmSessionException: " + e.getMessage(), Toast.LENGTH_SHORT).show();
+                } catch (IOException e) {
+                    Log.e(getClass().getSimpleName(), "IOException", e);
+                    Toast.makeText(context, "IOException:" + e.getMessage(), Toast.LENGTH_SHORT).show();
+                } catch (InterruptedException e) {
+                    Log.e(getClass().getSimpleName(), "InterruptedException", e);
+                    Toast.makeText(context, "InterruptedException:" + e.getMessage(), Toast.LENGTH_SHORT).show();
+                }
+            }
+        });
+    }
+
+    interface OfflineLicenseCallback {
+        void onLicenseDownloaded(byte[] license);
+    }
+
+}

--- a/demo/src/main/java/com/novoda/demo/OfflineLicense.java
+++ b/demo/src/main/java/com/novoda/demo/OfflineLicense.java
@@ -57,15 +57,9 @@ class OfflineLicense {
                             offlineLicenseCallback.onLicenseDownloaded(offlineKeySetId);
                         }
                     });
-                } catch (DrmSession.DrmSessionException e) {
-                    Log.e(getClass().getSimpleName(), "DrmSession.DrmSessionException", e);
-                    Toast.makeText(context, "DrmSession.DrmSessionException: " + e.getMessage(), Toast.LENGTH_SHORT).show();
-                } catch (IOException e) {
-                    Log.e(getClass().getSimpleName(), "IOException", e);
-                    Toast.makeText(context, "IOException:" + e.getMessage(), Toast.LENGTH_SHORT).show();
-                } catch (InterruptedException e) {
-                    Log.e(getClass().getSimpleName(), "InterruptedException", e);
-                    Toast.makeText(context, "InterruptedException:" + e.getMessage(), Toast.LENGTH_SHORT).show();
+                } catch (DrmSession.DrmSessionException | IOException | InterruptedException e) {
+                    Log.e(getClass().getSimpleName(), "Failed to download license", e);
+                    Toast.makeText(context, "Failed to download license" + e.getMessage(), Toast.LENGTH_SHORT).show();
                 }
             }
         });

--- a/demo/src/main/java/com/novoda/demo/PlaybackParameters.java
+++ b/demo/src/main/java/com/novoda/demo/PlaybackParameters.java
@@ -1,0 +1,46 @@
+package com.novoda.demo;
+
+import android.content.Context;
+import android.widget.Toast;
+
+enum PlaybackParameters {
+    INSTANCE;
+
+    private String mpdAddress;
+    private String licenseServerAddress;
+    private boolean downloadLicense;
+
+    public void setMpdAddress(String mpdAddress) {
+        this.mpdAddress = mpdAddress;
+    }
+
+    public void setLicenseServerAddress(String licenseServerAddress) {
+        this.licenseServerAddress = licenseServerAddress;
+    }
+
+    public void setDownloadLicense(boolean downloadLicense) {
+        this.downloadLicense = downloadLicense;
+    }
+
+    public String mpdAddress() {
+        return mpdAddress;
+    }
+
+    public String licenseServerAddress() {
+        return licenseServerAddress;
+    }
+
+    public boolean shouldDownloadLicense() {
+        return downloadLicense;
+    }
+
+    public void toastMissingParameters(Context context) {
+        if (mpdAddress == null || mpdAddress.isEmpty()) {
+            Toast.makeText(context, "MPD address not specified", Toast.LENGTH_SHORT).show();
+        }
+
+        if (licenseServerAddress == null || licenseServerAddress.isEmpty()) {
+            Toast.makeText(context, "License server address not specified", Toast.LENGTH_SHORT).show();
+        }
+    }
+}


### PR DESCRIPTION
## Problem
#257 introduced custom playback parameters via a `LandingActivity`, including the ability to specify whether the DRM KeySetId was downloaded. We should probably go ahead and download the `KeySetId` and use it in this case.

## Solution
Introduce an `OfflineLicense` which uses the `ExoPlayer` `OfflineLicenseHelper` under the hood to provision and request a DRM session, we then extract the relevant `KeySetId` and store for usage by the player. 

## Next Steps
Remove the `LocalDrmSessionManager` replacing it with the `DefaultDrmSessionManager`. The `Default` can perform all of the heavy lifting for us and probably has better error handling in the event something goes wrong.

### Paired with 
Nobody.
