### PR TITLE
Handle advert start on seek adjustment

### DIFF
--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
@@ -181,7 +181,10 @@ public class NoPlayerAdsLoader implements AdsLoader, Player.EventListener, Adver
             return;
         }
 
-        handleAdvertStart();
+        // handle only pre-roll start on timeline change
+        if (reason == Player.TIMELINE_CHANGE_REASON_PREPARED) {
+            handleAdvertStart();
+        }
     }
 
     private void handleAdvertStart() {

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
@@ -2,7 +2,7 @@ package com.novoda.noplayer.internal.exoplayer;
 
 import android.os.Handler;
 import android.os.Looper;
-
+import androidx.annotation.Nullable;
 import com.google.android.exoplayer2.C;
 import com.google.android.exoplayer2.Player;
 import com.google.android.exoplayer2.Timeline;
@@ -20,8 +20,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-
-import androidx.annotation.Nullable;
 
 // Not much we can do, orchestrating adverts is a lot of work.
 @SuppressWarnings("PMD.GodClass")

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
@@ -234,6 +234,9 @@ public class NoPlayerAdsLoader implements AdsLoader, Player.EventListener, Adver
 
             handleAdvertStart();
         }
+        if (reason == Player.DISCONTINUITY_REASON_SEEK_ADJUSTMENT) {
+            handleAdvertStart();
+        }
     }
 
     private boolean isPlayingAdvert() {


### PR DESCRIPTION
## Problem

Advert break events did not get called correctly when seeking. The issue would happen in some cases when `onPositionDiscontinuity` would be called with `DISCONTINUITY_REASON_SEEK_ADJUSTMENT` reason and not `DISCONTINUITY_REASON_AD_INSERTION` (which happens during normal playback).

## Solution

Now we handle advert start on seek adjustment too. For a bit of a background, seek adjustment happens when we seek past an advert break. In that case the player _adjusts_ the seek position to the start of the advert break in order to play the advert. `handleAdvertStart()` checks inside if the player is set to play advert and only calls the listener if that's the case so there's no extra check necessary here.

I also added an extra check and comment to `onTimelineChanged` to make it more obvious that it only handles one specific pre-roll case where we don't get any discontinuity events since the playback starts with an advert in that case. Previously this method would handle `TIMELINE_CHANGE_REASON_DYNAMIC` which only works in some cases of seeking but can also happen before the advert break.

### Test(s) added 

none, unfortunately we cannot really tests the loader as it is now

### Paired with 

@Mecharyry on understanding the issue
