### PR TITLE
Key request executor

### DIFF
--- a/core/src/main/java/com/novoda/noplayer/PlayerBuilder.java
+++ b/core/src/main/java/com/novoda/noplayer/PlayerBuilder.java
@@ -7,7 +7,7 @@ import android.os.Looper;
 import com.novoda.noplayer.drm.DownloadedModularDrm;
 import com.novoda.noplayer.drm.DrmHandler;
 import com.novoda.noplayer.drm.DrmType;
-import com.novoda.noplayer.drm.StreamingModularDrm;
+import com.novoda.noplayer.drm.KeyRequestExecutor;
 import com.novoda.noplayer.internal.drm.provision.ProvisionExecutorCreator;
 import com.novoda.noplayer.internal.exoplayer.NoPlayerExoPlayerCreator;
 import com.novoda.noplayer.internal.exoplayer.drm.DrmSessionCreatorFactory;
@@ -56,12 +56,12 @@ public class PlayerBuilder {
     /**
      * Sets {@link PlayerBuilder} to build a {@link NoPlayer} which supports Widevine modular streaming DRM.
      *
-     * @param streamingModularDrm Implementation of {@link StreamingModularDrm}.
+     * @param keyRequestExecutor Implementation of {@link KeyRequestExecutor}.
      * @return {@link PlayerBuilder}
      * @see NoPlayer
      */
-    public PlayerBuilder withWidevineModularStreamingDrm(StreamingModularDrm streamingModularDrm) {
-        return withDrm(DrmType.WIDEVINE_MODULAR_STREAM, streamingModularDrm);
+    public PlayerBuilder withWidevineModularStreamingDrm(KeyRequestExecutor keyRequestExecutor) {
+        return withDrm(DrmType.WIDEVINE_MODULAR_STREAM, keyRequestExecutor);
     }
 
     /**

--- a/core/src/main/java/com/novoda/noplayer/drm/KeyRequestExecutor.java
+++ b/core/src/main/java/com/novoda/noplayer/drm/KeyRequestExecutor.java
@@ -1,6 +1,6 @@
 package com.novoda.noplayer.drm;
 
-public interface StreamingModularDrm extends DrmHandler {
+public interface KeyRequestExecutor extends DrmHandler {
 
     byte[] executeKeyRequest(ModularDrmKeyRequest request) throws DrmRequestException;
 

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/drm/DownloadDrmSessionCreator.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/drm/DownloadDrmSessionCreator.java
@@ -3,30 +3,60 @@ package com.novoda.noplayer.internal.exoplayer.drm;
 import android.os.Handler;
 
 import com.google.android.exoplayer2.drm.DefaultDrmSessionEventListener;
-import com.google.android.exoplayer2.drm.DrmSessionManager;
+import com.google.android.exoplayer2.drm.DefaultDrmSessionManager;
 import com.google.android.exoplayer2.drm.FrameworkMediaCrypto;
+import com.google.android.exoplayer2.drm.FrameworkMediaDrm;
 import com.novoda.noplayer.drm.DownloadedModularDrm;
+import com.novoda.noplayer.drm.KeyRequestExecutor;
+import com.novoda.noplayer.drm.ModularDrmKeyRequest;
+import com.novoda.noplayer.internal.drm.provision.ProvisionExecutor;
+
+import java.util.HashMap;
 
 class DownloadDrmSessionCreator implements DrmSessionCreator {
 
+    @SuppressWarnings("PMD.LooseCoupling")  // Unfortunately the DefaultDrmSessionManager takes a HashMap, not a Map
+    private static final HashMap<String, String> NO_OPTIONAL_PARAMETERS = null;
+
     private final DownloadedModularDrm downloadedModularDrm;
+    private final ProvisionExecutor provisionExecutor;
     private final FrameworkMediaDrmCreator mediaDrmCreator;
     private final Handler handler;
 
-    DownloadDrmSessionCreator(DownloadedModularDrm downloadedModularDrm, FrameworkMediaDrmCreator mediaDrmCreator, Handler handler) {
+    DownloadDrmSessionCreator(DownloadedModularDrm downloadedModularDrm,
+                              ProvisionExecutor provisionExecutor,
+                              FrameworkMediaDrmCreator mediaDrmCreator,
+                              Handler handler) {
         this.downloadedModularDrm = downloadedModularDrm;
+        this.provisionExecutor = provisionExecutor;
         this.mediaDrmCreator = mediaDrmCreator;
         this.handler = handler;
     }
 
     @Override
-    public DrmSessionManager<FrameworkMediaCrypto> create(DefaultDrmSessionEventListener eventListener) {
-        return new LocalDrmSessionManager(
-                downloadedModularDrm.getKeySetId(),
-                mediaDrmCreator.create(WIDEVINE_MODULAR_UUID),
-                WIDEVINE_MODULAR_UUID,
-                handler,
-                eventListener
+    public DefaultDrmSessionManager<FrameworkMediaCrypto> create(DefaultDrmSessionEventListener eventListener) {
+        ProvisioningModularDrmCallback mediaDrmCallback = new ProvisioningModularDrmCallback(
+                new KeyRequestExecutor() {
+                    @Override
+                    public byte[] executeKeyRequest(ModularDrmKeyRequest request) {
+                        return downloadedModularDrm.getKeySetId().asBytes();
+                    }
+                },
+                provisionExecutor
         );
+
+        FrameworkMediaDrm frameworkMediaDrm = mediaDrmCreator.create(WIDEVINE_MODULAR_UUID);
+
+        DefaultDrmSessionManager<FrameworkMediaCrypto> defaultDrmSessionManager = new DefaultDrmSessionManager<>(
+                WIDEVINE_MODULAR_UUID,
+                frameworkMediaDrm,
+                mediaDrmCallback,
+                NO_OPTIONAL_PARAMETERS
+        );
+        defaultDrmSessionManager.removeListener(eventListener);
+        defaultDrmSessionManager.addListener(handler, eventListener);
+        defaultDrmSessionManager.setMode(DefaultDrmSessionManager.MODE_QUERY, downloadedModularDrm.getKeySetId().asBytes());
+
+        return defaultDrmSessionManager;
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/drm/DrmSessionCreator.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/drm/DrmSessionCreator.java
@@ -1,17 +1,17 @@
 package com.novoda.noplayer.internal.exoplayer.drm;
 
-import androidx.annotation.Nullable;
-
 import com.google.android.exoplayer2.drm.DefaultDrmSessionEventListener;
-import com.google.android.exoplayer2.drm.DrmSessionManager;
+import com.google.android.exoplayer2.drm.DefaultDrmSessionManager;
 import com.google.android.exoplayer2.drm.FrameworkMediaCrypto;
 
 import java.util.UUID;
+
+import androidx.annotation.Nullable;
 
 public interface DrmSessionCreator {
 
     UUID WIDEVINE_MODULAR_UUID = new UUID(0xEDEF8BA979D64ACEL, 0xA3C827DCD51D21EDL);
 
     @Nullable
-    DrmSessionManager<FrameworkMediaCrypto> create(DefaultDrmSessionEventListener eventListener);
+    DefaultDrmSessionManager<FrameworkMediaCrypto> create(DefaultDrmSessionEventListener eventListener);
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/drm/DrmSessionCreatorFactory.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/drm/DrmSessionCreatorFactory.java
@@ -54,16 +54,13 @@ public class DrmSessionCreatorFactory {
 
     private DrmSessionCreator createModularStream(KeyRequestExecutor drmHandler) {
         ProvisionExecutor provisionExecutor = provisionExecutorCreator.create();
-        ProvisioningModularDrmCallback mediaDrmCallback = new ProvisioningModularDrmCallback(
-                drmHandler,
-                provisionExecutor
-        );
         FrameworkMediaDrmCreator mediaDrmCreator = new FrameworkMediaDrmCreator();
-        return new StreamingDrmSessionCreator(mediaDrmCallback, mediaDrmCreator, handler);
+        return new StreamingDrmSessionCreator(drmHandler, provisionExecutor, mediaDrmCreator, handler);
     }
 
     private DownloadDrmSessionCreator createModularDownload(DownloadedModularDrm drmHandler) {
         FrameworkMediaDrmCreator mediaDrmCreator = new FrameworkMediaDrmCreator();
-        return new DownloadDrmSessionCreator(drmHandler, mediaDrmCreator, handler);
+        ProvisionExecutor provisionExecutor = provisionExecutorCreator.create();
+        return new DownloadDrmSessionCreator(drmHandler, provisionExecutor, mediaDrmCreator, handler);
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/drm/DrmSessionCreatorFactory.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/drm/DrmSessionCreatorFactory.java
@@ -7,7 +7,7 @@ import com.novoda.noplayer.UnableToCreatePlayerException;
 import com.novoda.noplayer.drm.DownloadedModularDrm;
 import com.novoda.noplayer.drm.DrmHandler;
 import com.novoda.noplayer.drm.DrmType;
-import com.novoda.noplayer.drm.StreamingModularDrm;
+import com.novoda.noplayer.drm.KeyRequestExecutor;
 import com.novoda.noplayer.internal.drm.provision.ProvisionExecutor;
 import com.novoda.noplayer.internal.drm.provision.ProvisionExecutorCreator;
 import com.novoda.noplayer.internal.utils.AndroidDeviceVersion;
@@ -32,7 +32,7 @@ public class DrmSessionCreatorFactory {
                 return new NoDrmSessionCreator();
             case WIDEVINE_MODULAR_STREAM:
                 assertThatApiLevelIsJellyBeanEighteenOrAbove(drmType);
-                return createModularStream((StreamingModularDrm) drmHandler);
+                return createModularStream((KeyRequestExecutor) drmHandler);
             case WIDEVINE_MODULAR_DOWNLOAD:
                 assertThatApiLevelIsJellyBeanEighteenOrAbove(drmType);
                 return createModularDownload((DownloadedModularDrm) drmHandler);
@@ -52,7 +52,7 @@ public class DrmSessionCreatorFactory {
         );
     }
 
-    private DrmSessionCreator createModularStream(StreamingModularDrm drmHandler) {
+    private DrmSessionCreator createModularStream(KeyRequestExecutor drmHandler) {
         ProvisionExecutor provisionExecutor = provisionExecutorCreator.create();
         ProvisioningModularDrmCallback mediaDrmCallback = new ProvisioningModularDrmCallback(
                 drmHandler,

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/drm/NoDrmSessionCreator.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/drm/NoDrmSessionCreator.java
@@ -1,18 +1,18 @@
 package com.novoda.noplayer.internal.exoplayer.drm;
 
-import androidx.annotation.Nullable;
-
 import com.google.android.exoplayer2.drm.DefaultDrmSessionEventListener;
-import com.google.android.exoplayer2.drm.DrmSessionManager;
+import com.google.android.exoplayer2.drm.DefaultDrmSessionManager;
 import com.google.android.exoplayer2.drm.FrameworkMediaCrypto;
+
+import androidx.annotation.Nullable;
 
 class NoDrmSessionCreator implements DrmSessionCreator {
 
-    private static final DrmSessionManager<FrameworkMediaCrypto> NO_DRM_SESSION = null;
+    private static final DefaultDrmSessionManager<FrameworkMediaCrypto> NO_DRM_SESSION = null;
 
     @Nullable
     @Override
-    public DrmSessionManager<FrameworkMediaCrypto> create(DefaultDrmSessionEventListener eventListener) {
+    public DefaultDrmSessionManager<FrameworkMediaCrypto> create(DefaultDrmSessionEventListener eventListener) {
         return NO_DRM_SESSION;
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/drm/ProvisioningModularDrmCallback.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/drm/ProvisioningModularDrmCallback.java
@@ -4,18 +4,18 @@ import com.google.android.exoplayer2.drm.ExoMediaDrm;
 import com.google.android.exoplayer2.drm.MediaDrmCallback;
 import com.novoda.noplayer.drm.ModularDrmKeyRequest;
 import com.novoda.noplayer.drm.ModularDrmProvisionRequest;
-import com.novoda.noplayer.drm.StreamingModularDrm;
+import com.novoda.noplayer.drm.KeyRequestExecutor;
 import com.novoda.noplayer.internal.drm.provision.ProvisionExecutor;
 
 import java.util.UUID;
 
 class ProvisioningModularDrmCallback implements MediaDrmCallback {
 
-    private final StreamingModularDrm streamingModularDrm;
+    private final KeyRequestExecutor keyRequestExecutor;
     private final ProvisionExecutor provisionExecutor;
 
-    ProvisioningModularDrmCallback(StreamingModularDrm streamingModularDrm, ProvisionExecutor provisionExecutor) {
-        this.streamingModularDrm = streamingModularDrm;
+    ProvisioningModularDrmCallback(KeyRequestExecutor keyRequestExecutor, ProvisionExecutor provisionExecutor) {
+        this.keyRequestExecutor = keyRequestExecutor;
         this.provisionExecutor = provisionExecutor;
     }
 
@@ -26,6 +26,6 @@ class ProvisioningModularDrmCallback implements MediaDrmCallback {
 
     @Override
     public byte[] executeKeyRequest(UUID uuid, ExoMediaDrm.KeyRequest request) throws Exception {
-        return streamingModularDrm.executeKeyRequest(new ModularDrmKeyRequest(request.getLicenseServerUrl(), request.getData()));
+        return keyRequestExecutor.executeKeyRequest(new ModularDrmKeyRequest(request.getLicenseServerUrl(), request.getData()));
     }
 }

--- a/core/src/test/java/com/novoda/noplayer/NoPlayerCreatorTest.java
+++ b/core/src/test/java/com/novoda/noplayer/NoPlayerCreatorTest.java
@@ -5,7 +5,7 @@ import android.content.Context;
 import com.novoda.noplayer.drm.DownloadedModularDrm;
 import com.novoda.noplayer.drm.DrmHandler;
 import com.novoda.noplayer.drm.DrmType;
-import com.novoda.noplayer.drm.StreamingModularDrm;
+import com.novoda.noplayer.drm.KeyRequestExecutor;
 import com.novoda.noplayer.internal.exoplayer.NoPlayerExoPlayerCreator;
 import com.novoda.noplayer.internal.exoplayer.drm.DrmSessionCreator;
 import com.novoda.noplayer.internal.exoplayer.drm.DrmSessionCreatorException;
@@ -36,7 +36,7 @@ public class NoPlayerCreatorTest {
 
         static final boolean USE_SECURE_CODEC = false;
         static final boolean ALLOW_CROSS_PROTOCOL_REDIRECTS = false;
-        static final StreamingModularDrm STREAMING_MODULAR_DRM = mock(StreamingModularDrm.class);
+        static final KeyRequestExecutor STREAMING_MODULAR_DRM = mock(KeyRequestExecutor.class);
         static final DownloadedModularDrm DOWNLOADED_MODULAR_DRM = mock(DownloadedModularDrm.class);
         static final NoPlayer EXO_PLAYER = mock(NoPlayer.class);
         static final NoPlayer MEDIA_PLAYER = mock(NoPlayer.class);

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/drm/DrmSessionCreatorFactoryTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/drm/DrmSessionCreatorFactoryTest.java
@@ -6,7 +6,7 @@ import com.novoda.noplayer.UnableToCreatePlayerException;
 import com.novoda.noplayer.drm.DownloadedModularDrm;
 import com.novoda.noplayer.drm.DrmHandler;
 import com.novoda.noplayer.drm.DrmType;
-import com.novoda.noplayer.drm.StreamingModularDrm;
+import com.novoda.noplayer.drm.KeyRequestExecutor;
 import com.novoda.noplayer.internal.drm.provision.ProvisionExecutorCreator;
 import com.novoda.noplayer.internal.utils.AndroidDeviceVersion;
 
@@ -38,7 +38,7 @@ public class DrmSessionCreatorFactoryTest {
     @Mock
     private DownloadedModularDrm downloadedModularDrm;
     @Mock
-    private StreamingModularDrm streamingModularDrm;
+    private KeyRequestExecutor keyRequestExecutor;
     @Mock
     private ProvisionExecutorCreator provisionExecutorCreator;
 
@@ -65,7 +65,7 @@ public class DrmSessionCreatorFactoryTest {
 
     @Test
     public void givenDrmTypeWidevineModularStream_whenCreatingDrmSessionCreator_thenReturnsStreaming() throws DrmSessionCreatorException {
-        DrmSessionCreator drmSessionCreator = drmSessionCreatorFactory.createFor(DrmType.WIDEVINE_MODULAR_STREAM, streamingModularDrm);
+        DrmSessionCreator drmSessionCreator = drmSessionCreatorFactory.createFor(DrmType.WIDEVINE_MODULAR_STREAM, keyRequestExecutor);
 
         assertThat(drmSessionCreator).isInstanceOf(StreamingDrmSessionCreator.class);
     }

--- a/demo/src/main/java/com/novoda/demo/DataPostingModularDrm.java
+++ b/demo/src/main/java/com/novoda/demo/DataPostingModularDrm.java
@@ -1,9 +1,9 @@
 package com.novoda.demo;
 
 import com.novoda.noplayer.drm.ModularDrmKeyRequest;
-import com.novoda.noplayer.drm.StreamingModularDrm;
+import com.novoda.noplayer.drm.KeyRequestExecutor;
 
-class DataPostingModularDrm implements StreamingModularDrm {
+class DataPostingModularDrm implements KeyRequestExecutor {
 
     private final String url;
 


### PR DESCRIPTION
## Problem
We have a `LocalDrmSessionManager` which is super old and is used for starting a local Drm session. We can use the `DefaultDrmSessionManager` for this and move towards a `Drm` system where if the `KeySetId` is missing we can request another. 

## Solution
Rename `StreamingModularDrm` to `KeyRequestExecutor`, the idea being that in future the client can supply `KeySetId` AND this `KeyRequestExecutor` so that in the event that the `KeySetId` is invalid it will fetch another, which it cannot do at the moment. Force all `DrmSessionCreators` to talk in terms of the `DefaultDrmSession` because it can handle both `Streaming` and `Download` `DRM` just fine. 

This is all going on a feature branch at the moment because I want to test this solution in it's entirety before pushing to `develop`.

## Next steps
To create a `DrmSessionManager` based on whether the `KeySetId` has expired or not. In the case it is expired it will switch to the `Streaming` version. 

### Test(s) added 
No, just moving code around. 

### Paired with 
Nobody.
