### PR TITLE
Revert DRM expiry check

### DIFF
--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/drm/ExoPlayerDrmSessionCreator.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/drm/ExoPlayerDrmSessionCreator.java
@@ -16,6 +16,7 @@ import com.novoda.noplayer.internal.drm.provision.ProvisionExecutor;
 import com.novoda.noplayer.model.KeySetId;
 
 import java.util.HashMap;
+import java.util.concurrent.TimeUnit;
 
 import androidx.annotation.Nullable;
 
@@ -80,9 +81,8 @@ class ExoPlayerDrmSessionCreator implements DrmSessionCreator {
 
             byte[] rawKeySetId = keySetId.asBytes();
             Pair<Long, Long> licenseDurationRemainingSec = offlineLicenseHelper.getLicenseDurationRemainingSec(rawKeySetId);
-            Long remainingLicenseTimeInSeconds = licenseDurationRemainingSec.first;
-            Long playbackTimeInSeconds = licenseDurationRemainingSec.second;
-            if (remainingLicenseTimeInSeconds > playbackTimeInSeconds) {
+            Long first = licenseDurationRemainingSec.first;
+            if (first > TimeUnit.HOURS.toSeconds(1)) {
                 drmSessionManager.setMode(DefaultDrmSessionManager.MODE_QUERY, rawKeySetId);
             }
 

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/drm/ExoPlayerDrmSessionCreator.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/drm/ExoPlayerDrmSessionCreator.java
@@ -81,8 +81,8 @@ class ExoPlayerDrmSessionCreator implements DrmSessionCreator {
 
             byte[] rawKeySetId = keySetId.asBytes();
             Pair<Long, Long> licenseDurationRemainingSec = offlineLicenseHelper.getLicenseDurationRemainingSec(rawKeySetId);
-            Long first = licenseDurationRemainingSec.first;
-            if (first > TimeUnit.HOURS.toSeconds(1)) {
+            Long licenseDurationRemainingInSeconds = licenseDurationRemainingSec.first;
+            if (licenseDurationRemainingInSeconds > TimeUnit.HOURS.toSeconds(1)) {
                 drmSessionManager.setMode(DefaultDrmSessionManager.MODE_QUERY, rawKeySetId);
             }
 


### PR DESCRIPTION
## Problem
#262 reworked the expiry check to be based off of the license duration remaining and the playback duration. I think playback duration might be specified by the clients DRM configuration, so this might not work in some scenarios. Better to rely on just the `license remaining` time for now and improve this in the future.

## Solution
Revert back to using 1 hours. We should update to allow clients to specify in the future. 

### Paired with 
Nobody.
