### PR TITLE
Codec capabilities

### DIFF
--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/CodecSelectorWithFallback.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/CodecSelectorWithFallback.java
@@ -65,18 +65,4 @@ class CodecSelectorWithFallback implements MediaCodecSelector {
         return internalMediaCodecUtil.getPassthroughDecoderInfo();
     }
 
-    static class InternalMediaCodecUtil {
-
-        List<MediaCodecInfo> getDecoderInfos(
-                String mimeType,
-                boolean requiresSecureDecoder,
-                boolean requiresTunnelingDecoder
-        ) throws MediaCodecUtil.DecoderQueryException {
-            return MediaCodecUtil.getDecoderInfos(mimeType, requiresSecureDecoder, requiresTunnelingDecoder);
-        }
-
-        MediaCodecInfo getPassthroughDecoderInfo() throws MediaCodecUtil.DecoderQueryException {
-            return MediaCodecUtil.getPassthroughDecoderInfo();
-        }
-    }
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/InternalMediaCodecUtil.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/InternalMediaCodecUtil.java
@@ -1,0 +1,21 @@
+package com.novoda.noplayer.internal.exoplayer;
+
+import com.google.android.exoplayer2.mediacodec.MediaCodecInfo;
+import com.google.android.exoplayer2.mediacodec.MediaCodecUtil;
+
+import java.util.List;
+
+class InternalMediaCodecUtil {
+
+    List<MediaCodecInfo> getDecoderInfos(
+            String mimeType,
+            boolean requiresSecureDecoder,
+            boolean requiresTunnelingDecoder
+    ) throws MediaCodecUtil.DecoderQueryException {
+        return MediaCodecUtil.getDecoderInfos(mimeType, requiresSecureDecoder, requiresTunnelingDecoder);
+    }
+
+    MediaCodecInfo getPassthroughDecoderInfo() throws MediaCodecUtil.DecoderQueryException {
+        return MediaCodecUtil.getPassthroughDecoderInfo();
+    }
+}

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/InternalMediaCodecUtil.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/InternalMediaCodecUtil.java
@@ -29,6 +29,7 @@ class InternalMediaCodecUtil {
      * Returns a copy of the provided decoder list sorted such that decoders with format support are
      * listed first. The returned list is modifiable for convenience.
      */
+    @SuppressWarnings({"PMD.AvoidReassigningParameters"})
     @CheckResult
     public static List<MediaCodecInfo> getDecoderInfosSortedByFormatSupport(
             List<MediaCodecInfo> decoderInfos, final Format format) {

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/InternalMediaCodecUtil.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/InternalMediaCodecUtil.java
@@ -1,9 +1,15 @@
 package com.novoda.noplayer.internal.exoplayer;
 
+import com.google.android.exoplayer2.Format;
 import com.google.android.exoplayer2.mediacodec.MediaCodecInfo;
 import com.google.android.exoplayer2.mediacodec.MediaCodecUtil;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
+
+import androidx.annotation.CheckResult;
 
 class InternalMediaCodecUtil {
 
@@ -17,5 +23,51 @@ class InternalMediaCodecUtil {
 
     MediaCodecInfo getPassthroughDecoderInfo() throws MediaCodecUtil.DecoderQueryException {
         return MediaCodecUtil.getPassthroughDecoderInfo();
+    }
+
+    /**
+     * Returns a copy of the provided decoder list sorted such that decoders with format support are
+     * listed first. The returned list is modifiable for convenience.
+     */
+    @CheckResult
+    public static List<MediaCodecInfo> getDecoderInfosSortedByFormatSupport(
+            List<MediaCodecInfo> decoderInfos, final Format format) {
+        decoderInfos = new ArrayList<>(decoderInfos);
+        sortByScore(
+                decoderInfos,
+                new ScoreProvider<MediaCodecInfo>() {
+                    @Override
+                    public int getScore(MediaCodecInfo decoderInfo) {
+                        try {
+                            return decoderInfo.isFormatSupported(format) ? 1 : 0;
+                        } catch (MediaCodecUtil.DecoderQueryException e) {
+                            return -1;
+                        }
+                    }
+                }
+        );
+        return decoderInfos;
+    }
+
+    /**
+     * Stably sorts the provided {@code list} in-place, in order of decreasing score.
+     */
+    private static <T> void sortByScore(List<T> list, final ScoreProvider<T> scoreProvider) {
+        Collections.sort(list, new Comparator<T>() {
+            @Override
+            public int compare(T a, T b) {
+                return scoreProvider.getScore(b) - scoreProvider.getScore(a);
+            }
+        });
+    }
+
+    /**
+     * Interface for providers of item scores.
+     */
+    private interface ScoreProvider<T> {
+        /**
+         * Returns the score of the provided item.
+         */
+        int getScore(T t);
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/MediaCodecAudioRendererWithSimplifiedDrmRequirement.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/MediaCodecAudioRendererWithSimplifiedDrmRequirement.java
@@ -24,7 +24,7 @@ import androidx.annotation.Nullable;
  * Relaxes the Drm requirement so that a secure decoder is selected in the event that `DrmInitData` is present.
  * <p>
  * Also contains a workaround for sorting codecs which can be reverted once
- * https://github.com/google/ExoPlayer/blob/dev-v2/library/core/src/main/java/com/google/android/exoplayer2/video/MediaCodecVideoRenderer.java#L385
+ * https://github.com/google/ExoPlayer/blob/dev-v2/library/core/src/main/java/com/google/android/exoplayer2/audio/MediaCodecAudioRenderer.java#L342-L364
  * hits the release branch.
  */
 class MediaCodecAudioRendererWithSimplifiedDrmRequirement extends MediaCodecAudioRenderer {

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/MediaCodecAudioRendererWithSimplifiedDrmRequirement.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/MediaCodecAudioRendererWithSimplifiedDrmRequirement.java
@@ -24,7 +24,7 @@ import androidx.annotation.Nullable;
  * Relaxes the Drm requirement so that a secure decoder is selected in the event that `DrmInitData` is present.
  * <p>
  * Also contains a workaround for sorting codecs which can be reverted once
- * https://github.com/google/ExoPlayer/blob/dev-v2/library/core/src/main/java/com/google/android/exoplayer2/audio/MediaCodecAudioRenderer.java#L342-L364
+ * https://github.com/google/ExoPlayer/blob/dev-v2/library/core/src/main/java/com/google/android/exoplayer2/audio/MediaCodecAudioRenderer.java#L342
  * hits the release branch. See https://github.com/novoda/no-player/pull/265.
  */
 class MediaCodecAudioRendererWithSimplifiedDrmRequirement extends MediaCodecAudioRenderer {

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/MediaCodecAudioRendererWithSimplifiedDrmRequirement.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/MediaCodecAudioRendererWithSimplifiedDrmRequirement.java
@@ -25,7 +25,7 @@ import androidx.annotation.Nullable;
  * <p>
  * Also contains a workaround for sorting codecs which can be reverted once
  * https://github.com/google/ExoPlayer/blob/dev-v2/library/core/src/main/java/com/google/android/exoplayer2/audio/MediaCodecAudioRenderer.java#L342-L364
- * hits the release branch.
+ * hits the release branch. See https://github.com/novoda/no-player/pull/265.
  */
 class MediaCodecAudioRendererWithSimplifiedDrmRequirement extends MediaCodecAudioRenderer {
 

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/MediaCodecAudioRendererWithSimplifiedDrmRequirement.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/MediaCodecAudioRendererWithSimplifiedDrmRequirement.java
@@ -13,11 +13,20 @@ import com.google.android.exoplayer2.drm.FrameworkMediaCrypto;
 import com.google.android.exoplayer2.mediacodec.MediaCodecInfo;
 import com.google.android.exoplayer2.mediacodec.MediaCodecSelector;
 import com.google.android.exoplayer2.mediacodec.MediaCodecUtil;
+import com.google.android.exoplayer2.util.MimeTypes;
 
+import java.util.Collections;
 import java.util.List;
 
 import androidx.annotation.Nullable;
 
+/**
+ * Relaxes the Drm requirement so that a secure decoder is selected in the event that `DrmInitData` is present.
+ * <p>
+ * Also contains a workaround for sorting codecs which can be reverted once
+ * https://github.com/google/ExoPlayer/blob/dev-v2/library/core/src/main/java/com/google/android/exoplayer2/video/MediaCodecVideoRenderer.java#L385
+ * hits the release branch.
+ */
 class MediaCodecAudioRendererWithSimplifiedDrmRequirement extends MediaCodecAudioRenderer {
 
     // Extension from MediaCodecAudioRenderer, we can't do anything about this.
@@ -46,6 +55,23 @@ class MediaCodecAudioRendererWithSimplifiedDrmRequirement extends MediaCodecAudi
     protected List<MediaCodecInfo> getDecoderInfos(MediaCodecSelector mediaCodecSelector,
                                                    Format format,
                                                    boolean requiresSecureDecoder) throws MediaCodecUtil.DecoderQueryException {
-        return super.getDecoderInfos(mediaCodecSelector, format, format.drmInitData != null);
+        if (allowPassthrough(format.channelCount, format.sampleMimeType)) {
+            MediaCodecInfo passthroughDecoderInfo = mediaCodecSelector.getPassthroughDecoderInfo();
+            if (passthroughDecoderInfo != null) {
+                return Collections.singletonList(passthroughDecoderInfo);
+            }
+        }
+        List<MediaCodecInfo> decoderInfos =
+                mediaCodecSelector.getDecoderInfos(
+                        format.sampleMimeType, format.drmInitData != null, /* requiresTunnelingDecoder= */ false);
+        decoderInfos = InternalMediaCodecUtil.getDecoderInfosSortedByFormatSupport(decoderInfos, format);
+        if (MimeTypes.AUDIO_E_AC3_JOC.equals(format.sampleMimeType)) {
+            // E-AC3 decoders can decode JOC streams, but in 2-D rather than 3-D.
+            List<MediaCodecInfo> eac3DecoderInfos =
+                    mediaCodecSelector.getDecoderInfos(
+                            MimeTypes.AUDIO_E_AC3, format.drmInitData != null, /* requiresTunnelingDecoder= */ false);
+            decoderInfos.addAll(eac3DecoderInfos);
+        }
+        return Collections.unmodifiableList(decoderInfos);
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/MediaCodecVideoRendererWithSimplifiedDrmRequirement.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/MediaCodecVideoRendererWithSimplifiedDrmRequirement.java
@@ -24,7 +24,7 @@ import androidx.annotation.Nullable;
  * <p>
  * Also contains a workaround for sorting codecs which can be reverted once
  * https://github.com/google/ExoPlayer/blob/dev-v2/library/core/src/main/java/com/google/android/exoplayer2/video/MediaCodecVideoRenderer.java#L385
- * hits the release branch.
+ * hits the release branch. See https://github.com/novoda/no-player/pull/265.
  */
 class MediaCodecVideoRendererWithSimplifiedDrmRequirement extends MediaCodecVideoRenderer {
 

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/MediaCodecVideoRendererWithSimplifiedDrmRequirement.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/MediaCodecVideoRendererWithSimplifiedDrmRequirement.java
@@ -28,6 +28,10 @@ import androidx.annotation.Nullable;
  */
 class MediaCodecVideoRendererWithSimplifiedDrmRequirement extends MediaCodecVideoRenderer {
 
+    private static final int LEVEL_FOUR = 4;
+    private static final int LEVEL_EIGHT = 8;
+    private static final int LEVEL_NINE = 9;
+
     // Extension from MediaCodecVideoRenderer, we can't do anything about this.
     @SuppressWarnings({"checkstyle:ParameterNumber", "PMD.ExcessiveParameterList"})
     MediaCodecVideoRendererWithSimplifiedDrmRequirement(Context context,
@@ -59,6 +63,7 @@ class MediaCodecVideoRendererWithSimplifiedDrmRequirement extends MediaCodecVide
         return getDecoderInfos(mediaCodecSelector, format, format.drmInitData != null, getCodecNeedsEosPropagation());
     }
 
+    @SuppressWarnings({"PMD.AvoidDeeplyNestedIfStmts"})
     private static List<MediaCodecInfo> getDecoderInfos(
             MediaCodecSelector mediaCodecSelector,
             Format format,
@@ -75,11 +80,11 @@ class MediaCodecVideoRendererWithSimplifiedDrmRequirement extends MediaCodecVide
                     MediaCodecUtil.getCodecProfileAndLevel(format.codecs);
             if (codecProfileAndLevel != null) {
                 int profile = codecProfileAndLevel.first;
-                if (profile == 4 || profile == 8) {
+                if (profile == LEVEL_FOUR || profile == LEVEL_EIGHT) {
                     decoderInfos.addAll(
                             mediaCodecSelector.getDecoderInfos(
                                     MimeTypes.VIDEO_H265, requiresSecureDecoder, requiresTunnelingDecoder));
-                } else if (profile == 9) {
+                } else if (profile == LEVEL_NINE) {
                     decoderInfos.addAll(
                             mediaCodecSelector.getDecoderInfos(
                                     MimeTypes.VIDEO_H264, requiresSecureDecoder, requiresTunnelingDecoder));

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/CodecSelectorWithFallbackTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/CodecSelectorWithFallbackTest.java
@@ -2,7 +2,6 @@ package com.novoda.noplayer.internal.exoplayer;
 
 import com.google.android.exoplayer2.mediacodec.MediaCodecInfo;
 import com.google.android.exoplayer2.mediacodec.MediaCodecUtil;
-import com.novoda.noplayer.internal.exoplayer.CodecSelectorWithFallback.InternalMediaCodecUtil;
 
 import java.util.Arrays;
 import java.util.Collection;


### PR DESCRIPTION
## Problem
We've been testing the #263 DRM Rework and we discovered that on some devices we were seeing codec failures. Which is super strange when we include `secure` and `non-secure` codecs AND also fallback when there are any errors. 🤔 

I had a little look into how the renderers select codecs and it seems that `ExoPlayer` is a little too optimistic 😄 It picks the first decoder and roles with it even if it states that it cannot support a given format. I posted a message in the `ExoPlayer` Slack and it seems this was intentional because `hardware` decoders normally understate what they can playback, which sometimes leads to falling back to a software decoder unnecessarily. They did acknowledge the problem and it seems they have a fix for this in the `dev` branch but it hasn't been released yet. https://github.com/google/ExoPlayer/blob/dev-v2/library/core/src/main/java/com/google/android/exoplayer2/video/MediaCodecVideoRenderer.java#L376-L404

## Solution
Copy the code from: 
https://github.com/google/ExoPlayer/blob/dev-v2/library/core/src/main/java/com/google/android/exoplayer2/video/MediaCodecVideoRenderer.java#L385 and https://github.com/google/ExoPlayer/blob/dev-v2/library/core/src/main/java/com/google/android/exoplayer2/audio/MediaCodecAudioRenderer.java#L342-L364 to sort the codecs until the version supporting the changes is released. 

## Testing
I've tested this on a client application using a problematic device in question and all seems good again.

### Paired with 
Nobody.
