### PR TITLE
Content position and duration

### DIFF
--- a/core/src/main/java/com/novoda/noplayer/PlayerState.java
+++ b/core/src/main/java/com/novoda/noplayer/PlayerState.java
@@ -86,6 +86,14 @@ public interface PlayerState {
     long mediaDurationInMillis();
 
     /**
+     * Duration of the content that is being played.
+     * Use {@link PlayerState#mediaDurationInMillis} for duration of an advert when one is playing.
+     *
+     * @return duration of the content that is being played.
+     */
+    long contentDurationInMillis();
+
+    /**
      * Buffered percentage of the video that is being played.
      * <p>
      * If the player is playing an advert break then this value will represent a buffer of each individual advert

--- a/core/src/main/java/com/novoda/noplayer/PlayerState.java
+++ b/core/src/main/java/com/novoda/noplayer/PlayerState.java
@@ -66,6 +66,16 @@ public interface PlayerState {
     long playheadPositionInMillis();
 
     /**
+     * Position in the content that is being played in milliseconds.
+     * <p>
+     * If the player is playing an advert then this value will be the position that will be played
+     * when the advert ends.
+     *
+     * @return position in the content that is being played.
+     */
+    long contentPositionInMillis();
+
+    /**
      * Duration of the video that is being played in milliseconds.
      * <p>
      * If the player is playing an advert then this value will be a duration of a single advert.

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
@@ -87,6 +87,11 @@ class ExoPlayerFacade {
         return exoPlayer.getDuration();
     }
 
+    long contentDurationInMillis() throws IllegalStateException {
+        assertVideoLoaded();
+        return exoPlayer.getContentDuration();
+    }
+
     long playheadPositionInMillis() throws IllegalStateException {
         assertVideoLoaded();
         return exoPlayer.getCurrentPosition();

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
@@ -92,6 +92,11 @@ class ExoPlayerFacade {
         return exoPlayer.getCurrentPosition();
     }
 
+    long contentPositionInMillis() throws IllegalStateException {
+        assertVideoLoaded();
+        return exoPlayer.getContentPosition();
+    }
+
     long advertBreakDurationInMillis() throws IllegalStateException {
         assertVideoLoaded();
         Timeline currentTimeline = exoPlayer.getCurrentTimeline();

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImpl.java
@@ -124,6 +124,11 @@ class ExoPlayerTwoImpl implements NoPlayer {
     }
 
     @Override
+    public long contentPositionInMillis() throws IllegalStateException {
+        return exoPlayer.contentPositionInMillis();
+    }
+
+    @Override
     public long advertBreakDurationInMillis() {
         return exoPlayer.advertBreakDurationInMillis();
     }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImpl.java
@@ -144,6 +144,11 @@ class ExoPlayerTwoImpl implements NoPlayer {
     }
 
     @Override
+    public long contentDurationInMillis() {
+        return exoPlayer.contentDurationInMillis();
+    }
+
+    @Override
     public int bufferPercentage() throws IllegalStateException {
         return exoPlayer.bufferPercentage();
     }

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerFacade.java
@@ -25,7 +25,6 @@ import java.util.Map;
 
 import androidx.annotation.Nullable;
 
-
 // Not much we can do, wrapping MediaPlayer is a lot of work
 @SuppressWarnings("PMD.GodClass")
 class AndroidMediaPlayerFacade {
@@ -209,6 +208,11 @@ class AndroidMediaPlayerFacade {
     }
 
     int mediaDurationInMillis() throws IllegalStateException {
+        assertIsInPlaybackState();
+        return mediaPlayer.getDuration();
+    }
+
+    int contentDurationInMillis() throws IllegalStateException {
         assertIsInPlaybackState();
         return mediaPlayer.getDuration();
     }

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImpl.java
@@ -295,6 +295,11 @@ class AndroidMediaPlayerImpl implements NoPlayer {
     }
 
     @Override
+    public long contentDurationInMillis() {
+        return mediaPlayer.mediaDurationInMillis();
+    }
+
+    @Override
     public int bufferPercentage() throws IllegalStateException {
         return mediaPlayer.getBufferPercentage();
     }

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImpl.java
@@ -280,6 +280,11 @@ class AndroidMediaPlayerImpl implements NoPlayer {
         return isSeeking() ? seekToPositionInMillis : mediaPlayer.currentPositionInMillis();
     }
 
+    @Override
+    public long contentPositionInMillis() {
+        return isSeeking() ? seekToPositionInMillis : mediaPlayer.currentPositionInMillis();
+    }
+
     private boolean isSeeking() {
         return seekToPositionInMillis != NO_SEEK_TO_POSITION;
     }

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImpl.java
@@ -296,7 +296,7 @@ class AndroidMediaPlayerImpl implements NoPlayer {
 
     @Override
     public long contentDurationInMillis() {
-        return mediaPlayer.mediaDurationInMillis();
+        return mediaPlayer.contentDurationInMillis();
     }
 
     @Override

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacadeTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacadeTest.java
@@ -326,6 +326,13 @@ public class ExoPlayerFacadeTest {
         }
 
         @Test
+        public void whenQueryingContentDuration_thenThrowsIllegalStateException() {
+            thrown.expect(ExceptionMatcher.matches("Video must be loaded before trying to interact with the player", IllegalStateException.class));
+
+            facade.contentDurationInMillis();
+        }
+
+        @Test
         public void whenQueryingAdvertBreakDuration_thenThrowsIllegalStateException() {
             thrown.expect(ExceptionMatcher.matches("Video must be loaded before trying to interact with the player", IllegalStateException.class));
 
@@ -509,6 +516,15 @@ public class ExoPlayerFacadeTest {
             long videoDurationInMillis = facade.mediaDurationInMillis();
 
             assertThat(videoDurationInMillis).isEqualTo(TEN_MINUTES_IN_MILLIS);
+        }
+
+        @Test
+        public void whenGettingContentDuration_thenReturnsDuration() {
+            given(exoPlayer.getContentDuration()).willReturn(TEN_MINUTES_IN_MILLIS);
+
+            long contentDurationInMillis = facade.contentDurationInMillis();
+
+            assertThat(contentDurationInMillis).isEqualTo(TEN_MINUTES_IN_MILLIS);
         }
 
         @Test

--- a/core/src/test/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImplTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImplTest.java
@@ -5,6 +5,7 @@ import android.net.Uri;
 import android.view.Surface;
 import android.view.SurfaceHolder;
 import android.view.View;
+
 import com.novoda.noplayer.ContentType;
 import com.novoda.noplayer.NoPlayer;
 import com.novoda.noplayer.Options;
@@ -24,6 +25,9 @@ import com.novoda.noplayer.model.LoadTimeout;
 import com.novoda.noplayer.model.PlayerAudioTrack;
 import com.novoda.noplayer.model.PlayerAudioTrackFixture;
 import com.novoda.noplayer.model.Timeout;
+
+import java.util.Collections;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -37,8 +41,6 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import org.mockito.stubbing.Answer;
-
-import java.util.Collections;
 
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -267,6 +269,24 @@ public class AndroidMediaPlayerImplTest {
             player.seekTo(seekPositionInMillis);
 
             long videoPositionInMillis = player.playheadPositionInMillis();
+
+            assertThat(videoPositionInMillis).isEqualTo(seekPositionInMillis);
+        }
+
+        @Test
+        public void givenPlayerIsNotSeeking_whenGettingContentPosition_thenReturnsCurrentMediaPlayerPosition() {
+            given(mediaPlayer.currentPositionInMillis()).willReturn(ONE_SECOND_IN_MILLIS);
+            long playheadPositionInMillis = player.contentPositionInMillis();
+
+            assertThat(playheadPositionInMillis).isEqualTo(ONE_SECOND_IN_MILLIS);
+        }
+
+        @Test
+        public void givenPlayerIsSeeking_whenGettingContentPosition_thenReturnsSeekPosition() {
+            long seekPositionInMillis = TEN_SECONDS;
+            player.seekTo(seekPositionInMillis);
+
+            long videoPositionInMillis = player.contentPositionInMillis();
 
             assertThat(videoPositionInMillis).isEqualTo(seekPositionInMillis);
         }

--- a/core/src/test/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImplTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImplTest.java
@@ -300,6 +300,14 @@ public class AndroidMediaPlayerImplTest {
         }
 
         @Test
+        public void whenGettingContentDuration_thenReturnsMediaPlayerDuration() {
+            given(mediaPlayer.contentDurationInMillis()).willReturn(ONE_SECOND_IN_MILLIS);
+            long videoDurationInMillis = player.contentDurationInMillis();
+
+            assertThat(videoDurationInMillis).isEqualTo(ONE_SECOND_IN_MILLIS);
+        }
+
+        @Test
         public void whenGettingBufferPercentage_thenReturnsMediaPlayerBufferPercentage() {
             int mediaPlayerBufferPercentage = 10;
             given(mediaPlayer.getBufferPercentage()).willReturn(mediaPlayerBufferPercentage);


### PR DESCRIPTION
## Problem
We have `mediaDurationInMillis` and `playheadPositionInMillis` which can return very different values based on the underlying state of the player 😬 Ideally we should guarantee that methods will have predictable behaviour that does not require extensive documentation.  

## Solution
Introduce a `contentDurationInMillis` and `contentPositionInMillis` that **only** deal with the content. Adverts should be considered separately. This should help to avoid lots of checks for `adverts` and `content` when we already know it is safe to call these methods. 

### Test(s) added 
Yes where necessary.

### Paired with 
Nobody.
