### PR TITLE
Add track decoder association

### DIFF
--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/InternalMediaCodecUtil.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/InternalMediaCodecUtil.java
@@ -51,7 +51,7 @@ class InternalMediaCodecUtil {
 
     /**
      *
-     * Returns a list of decoders that supports the procided format
+     * Returns a list of decoders that supports the provided format
      */
     static List<MediaCodecInfo> getOnlySupportedDecoderInfos(List<MediaCodecInfo> decoderInfos, Format format) {
         List<MediaCodecInfo> onlySupported = new ArrayList<>();

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/InternalMediaCodecUtil.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/InternalMediaCodecUtil.java
@@ -50,6 +50,25 @@ class InternalMediaCodecUtil {
     }
 
     /**
+     *
+     * Returns a list of decoders that supports the procided format
+     */
+    static List<MediaCodecInfo> getOnlySupportedDecoderInfos(List<MediaCodecInfo> decoderInfos, Format format) {
+        List<MediaCodecInfo> onlySupported = new ArrayList<>();
+        for (MediaCodecInfo decoderInfo : decoderInfos) {
+            try {
+                if (decoderInfo.isFormatSupported(format)) {
+                    onlySupported.add(decoderInfo);
+                }
+            } catch (MediaCodecUtil.DecoderQueryException e) {
+                // ignore, decoder will not be added in this case
+            }
+        }
+
+        return onlySupported;
+    }
+
+    /**
      * Stably sorts the provided {@code list} in-place, in order of decreasing score.
      */
     private static <T> void sortByScore(List<T> list, final ScoreProvider<T> scoreProvider) {

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/MediaCodecVideoRendererWithSimplifiedDrmRequirement.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/MediaCodecVideoRendererWithSimplifiedDrmRequirement.java
@@ -121,7 +121,7 @@ class MediaCodecVideoRendererWithSimplifiedDrmRequirement extends MediaCodecVide
     }
 
     private static void saveTrackCodecMapping(String trackCodecName, List<MediaCodecInfo> decoderInfos) {
-        PlayerVideoTrackCodecMapping.getInstance().addTrackCodec(trackCodecName, codecName(decoderInfos));
+        new PlayerVideoTrackCodecMapping().addTrackCodec(trackCodecName, codecName(decoderInfos));
     }
 
     private static String codecName(List<MediaCodecInfo> decoderInfos) {

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/MediaCodecVideoRendererWithSimplifiedDrmRequirement.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/MediaCodecVideoRendererWithSimplifiedDrmRequirement.java
@@ -2,6 +2,7 @@ package com.novoda.noplayer.internal.exoplayer;
 
 import android.content.Context;
 import android.os.Handler;
+import android.util.Log;
 import android.util.Pair;
 
 import androidx.annotation.Nullable;
@@ -15,6 +16,7 @@ import com.google.android.exoplayer2.mediacodec.MediaCodecUtil;
 import com.google.android.exoplayer2.util.MimeTypes;
 import com.google.android.exoplayer2.video.MediaCodecVideoRenderer;
 import com.google.android.exoplayer2.video.VideoRendererEventListener;
+import com.novoda.noplayer.model.PlayerVideoTrackCodecMapping;
 
 import java.util.Collections;
 import java.util.List;
@@ -31,6 +33,7 @@ class MediaCodecVideoRendererWithSimplifiedDrmRequirement extends MediaCodecVide
     private static final int LEVEL_FOUR = 4;
     private static final int LEVEL_EIGHT = 8;
     private static final int LEVEL_NINE = 9;
+    private static final String TAG = MediaCodecVideoRendererWithSimplifiedDrmRequirement.class.getSimpleName();
 
     private final boolean requiresSecureDecoder;
 
@@ -84,7 +87,7 @@ class MediaCodecVideoRendererWithSimplifiedDrmRequirement extends MediaCodecVide
                 requiresTunnelingDecoder
         );
 
-        decoderInfos = InternalMediaCodecUtil.getDecoderInfosSortedByFormatSupport(decoderInfos, format);
+        decoderInfos = InternalMediaCodecUtil.getOnlySupportedDecoderInfos(decoderInfos, format);
 
         if (MimeTypes.VIDEO_DOLBY_VISION.equals(format.sampleMimeType)) {
             // Fallback to primary decoders for H.265/HEVC or H.264/AVC for the relevant DV profiles.
@@ -110,6 +113,26 @@ class MediaCodecVideoRendererWithSimplifiedDrmRequirement extends MediaCodecVide
             }
         }
 
+        saveTrackCodecMapping(format.codecs, decoderInfos);
+
+        printDecoderInfos(format.codecs, decoderInfos);
+
         return Collections.unmodifiableList(decoderInfos);
+    }
+
+    private static void saveTrackCodecMapping(String trackCodecName, List<MediaCodecInfo> decoderInfos) {
+        PlayerVideoTrackCodecMapping.getInstance().addTrackCodec(trackCodecName, codecName(decoderInfos));
+    }
+
+    private static String codecName(List<MediaCodecInfo> decoderInfos) {
+        return decoderInfos.isEmpty() ? "no codec available" : decoderInfos.get(0).name;
+
+    }
+
+    private static void printDecoderInfos(String codecs, List<MediaCodecInfo> decoderInfos) {
+        Log.v(TAG, "track with codec: " + codecs + ", has " + decoderInfos.size() + " available decoders");
+        for (MediaCodecInfo decoderInfo : decoderInfos) {
+            Log.v(TAG, "- decoder name: " + decoderInfo.name);
+        }
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/mediasource/ExoPlayerVideoTrackSelector.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/mediasource/ExoPlayerVideoTrackSelector.java
@@ -9,6 +9,7 @@ import com.novoda.noplayer.ContentType;
 import com.novoda.noplayer.internal.exoplayer.RendererTypeRequester;
 import com.novoda.noplayer.internal.utils.Optional;
 import com.novoda.noplayer.model.PlayerVideoTrack;
+import com.novoda.noplayer.model.PlayerVideoTrackCodecMapping;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -38,6 +39,8 @@ public class ExoPlayerVideoTrackSelector {
 
         List<PlayerVideoTrack> videoTracks = new ArrayList<>();
 
+        PlayerVideoTrackCodecMapping trackCodecMapping = PlayerVideoTrackCodecMapping.getInstance();
+
         for (int groupIndex = 0; groupIndex < trackGroups.length; groupIndex++) {
             TrackGroup trackGroup = trackGroups.get(groupIndex);
 
@@ -54,6 +57,7 @@ public class ExoPlayerVideoTrackSelector {
                         (int) format.frameRate,
                         format.bitrate,
                         format.codecs,
+                        trackCodecMapping.getCodecFor(format.codecs),
                         trackSelector.trackSupport(VIDEO, groupIndex, trackIndex, rendererTypeRequester)
                 );
 

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/mediasource/ExoPlayerVideoTrackSelector.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/mediasource/ExoPlayerVideoTrackSelector.java
@@ -39,7 +39,7 @@ public class ExoPlayerVideoTrackSelector {
 
         List<PlayerVideoTrack> videoTracks = new ArrayList<>();
 
-        PlayerVideoTrackCodecMapping trackCodecMapping = PlayerVideoTrackCodecMapping.getInstance();
+        PlayerVideoTrackCodecMapping trackCodecMapping = new PlayerVideoTrackCodecMapping();
 
         for (int groupIndex = 0; groupIndex < trackGroups.length; groupIndex++) {
             TrackGroup trackGroup = trackGroups.get(groupIndex);

--- a/core/src/main/java/com/novoda/noplayer/model/PlayerVideoTrack.java
+++ b/core/src/main/java/com/novoda/noplayer/model/PlayerVideoTrack.java
@@ -13,6 +13,7 @@ public class PlayerVideoTrack {
     private final int fps;
     private final int bitrate;
     private final String codecName;
+    private final String associatedDecoderName;
     private final Support support;
 
     @SuppressWarnings({"checkstyle:parameternumber", "PMD.ExcessiveParameterList"}) // We need all this parameters as a bundle
@@ -25,6 +26,7 @@ public class PlayerVideoTrack {
                             int fps,
                             int bitrate,
                             String codecName,
+                            String associatedDecoderName,
                             Support support) {
         this.groupIndex = groupIndex;
         this.formatIndex = formatIndex;
@@ -35,6 +37,7 @@ public class PlayerVideoTrack {
         this.fps = fps;
         this.bitrate = bitrate;
         this.codecName = codecName;
+        this.associatedDecoderName = associatedDecoderName;
         this.support = support;
     }
 
@@ -76,6 +79,10 @@ public class PlayerVideoTrack {
 
     public String codecName() {
         return codecName;
+    }
+
+    public String associatedDecoderName() {
+        return associatedDecoderName;
     }
 
     @Override

--- a/core/src/main/java/com/novoda/noplayer/model/PlayerVideoTrackCodecMapping.java
+++ b/core/src/main/java/com/novoda/noplayer/model/PlayerVideoTrackCodecMapping.java
@@ -10,36 +10,21 @@ import java.util.Map;
  * and the decoder that the engine assigns to this codec.
  *
  * Bear in mind that this association is provisional and there is no guarantee that
- * the engine will fallback to another decoder. This is due to that usually several
+ * the engine will not fallback to another decoder. This is due to that usually several
  * decoders are provided for a particual track. If the first decoder fails to initialise
  * then the engine will choose another decoder. This information is not easely accessible
  * and so we only provide the first association that the engine does.
  */
 public final class PlayerVideoTrackCodecMapping {
 
-    private static final PlayerVideoTrackCodecMapping INSTANCE = LazySingleton.INSTANCE;
-
-    private static class LazySingleton {
-
-        private static final PlayerVideoTrackCodecMapping INSTANCE = new PlayerVideoTrackCodecMapping();
-    }
-
-    public static PlayerVideoTrackCodecMapping getInstance() {
-        return INSTANCE;
-    }
-
-    private final Map<String, String> trackCodecMap = new HashMap<>();
-
-    private PlayerVideoTrackCodecMapping() {
-        // private class
-    }
+    private static final Map<String, String> TRACK_CODEC_MAP = new HashMap<>();
 
     public void addTrackCodec(String track, String codec) {
-        trackCodecMap.put(track, codec);
+        TRACK_CODEC_MAP.put(track, codec);
     }
 
     @Nullable
     public String getCodecFor(String track) {
-        return trackCodecMap.get(track);
+        return TRACK_CODEC_MAP.get(track);
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/model/PlayerVideoTrackCodecMapping.java
+++ b/core/src/main/java/com/novoda/noplayer/model/PlayerVideoTrackCodecMapping.java
@@ -1,0 +1,41 @@
+package com.novoda.noplayer.model;
+
+import androidx.annotation.Nullable;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * This class holds an association betwen the codec being used by a particular track
+ * and the decoder that the engine assigns to this codec.
+ *
+ *
+ */
+public class PlayerVideoTrackCodecMapping {
+
+    private static final PlayerVideoTrackCodecMapping INSTANCE = LazySingleton.INSTANCE;
+
+    private static class LazySingleton {
+
+        private static final PlayerVideoTrackCodecMapping INSTANCE = new PlayerVideoTrackCodecMapping();
+    }
+
+    public static PlayerVideoTrackCodecMapping getInstance() {
+        return INSTANCE;
+    }
+
+    private final Map<String, String> trackCodecMap = new HashMap<>();
+
+    private PlayerVideoTrackCodecMapping() {
+        // private class
+    }
+
+    public void addTrackCodec(String track, String codec) {
+        trackCodecMap.put(track, codec);
+    }
+
+    @Nullable
+    public String getCodecFor(String track) {
+        return trackCodecMap.get(track);
+    }
+}

--- a/core/src/main/java/com/novoda/noplayer/model/PlayerVideoTrackCodecMapping.java
+++ b/core/src/main/java/com/novoda/noplayer/model/PlayerVideoTrackCodecMapping.java
@@ -9,9 +9,13 @@ import java.util.Map;
  * This class holds an association betwen the codec being used by a particular track
  * and the decoder that the engine assigns to this codec.
  *
- *
+ * Bear in mind that this association is provisional and there is no guarantee that
+ * the engine will fallback to another decoder. This is due to that usually several
+ * decoders are provided for a particual track. If the first decoder fails to initialise
+ * then the engine will choose another decoder. This information is not easely accessible
+ * and so we only provide the first association that the engine does.
  */
-public class PlayerVideoTrackCodecMapping {
+public final class PlayerVideoTrackCodecMapping {
 
     private static final PlayerVideoTrackCodecMapping INSTANCE = LazySingleton.INSTANCE;
 

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/mediasource/ExoPlayerVideoTrackSelectorTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/mediasource/ExoPlayerVideoTrackSelectorTest.java
@@ -34,6 +34,7 @@ public class ExoPlayerVideoTrackSelectorTest {
 
     private static final Format VIDEO_FORMAT = aVideoFormat().withId("id1").build();
     private static final String CODEC_NAME = "codecs";
+    private static final String ASSOCIATED_DECODER_NAME = "intel-decoder";
     private static final Support SUPPORT = null;
     private static final PlayerVideoTrack PLAYER_VIDEO_TRACK = new PlayerVideoTrack(
             0,
@@ -45,6 +46,7 @@ public class ExoPlayerVideoTrackSelectorTest {
             (int) VIDEO_FORMAT.frameRate,
             VIDEO_FORMAT.bitrate,
             CODEC_NAME,
+            ASSOCIATED_DECODER_NAME,
             SUPPORT
     );
 
@@ -61,6 +63,7 @@ public class ExoPlayerVideoTrackSelectorTest {
             (int) ADDITIONAL_VIDEO_FORMAT.frameRate,
             ADDITIONAL_VIDEO_FORMAT.bitrate,
             CODEC_NAME,
+            ASSOCIATED_DECODER_NAME,
             SUPPORT
     );
 

--- a/core/src/test/java/com/novoda/noplayer/model/PlayerVideoTrackFixture.java
+++ b/core/src/test/java/com/novoda/noplayer/model/PlayerVideoTrackFixture.java
@@ -13,6 +13,7 @@ public class PlayerVideoTrackFixture {
     private int fps = 30;
     private int bitrate = 180000;
     private String codecName = "codec-name";
+    private String associatedDecoderName = "intel-decoder-name";
     private Support support = Support.FORMAT_UNKNOWN;
 
     public static PlayerVideoTrackFixture aPlayerVideoTrack() {
@@ -64,6 +65,18 @@ public class PlayerVideoTrackFixture {
     }
 
     public PlayerVideoTrack build() {
-        return new PlayerVideoTrack(groupIndex, formatIndex, id, contentType, width, height, fps, bitrate, codecName, support);
+        return new PlayerVideoTrack(
+                groupIndex,
+                formatIndex,
+                id,
+                contentType,
+                width,
+                height,
+                fps,
+                bitrate,
+                codecName,
+                associatedDecoderName,
+                support
+        );
     }
 }

--- a/demo/src/main/java/com/novoda/demo/DialogCreator.java
+++ b/demo/src/main/java/com/novoda/demo/DialogCreator.java
@@ -17,7 +17,7 @@ import java.util.Locale;
 
 class DialogCreator {
 
-    private static final String VIDEO_TRACK_MESSAGE_FORMAT = "ID: %s Quality: %s Renderer Capability: %s";
+    private static final String VIDEO_TRACK_MESSAGE_FORMAT = "ID: %s Quality: %s, Codec: %s, Decoder: %s";
     private static final String AUDIO_TRACK_MESSAGE_FORMAT = "ID: %s Type: %s";
     private static final int AUTO_TRACK_POSITION = 0;
 
@@ -53,7 +53,13 @@ class DialogCreator {
         List<String> labels = new ArrayList<>();
         labels.add("Auto");
         for (PlayerVideoTrack videoTrack : videoTracks) {
-            String message = String.format(VIDEO_TRACK_MESSAGE_FORMAT, videoTrack.id(), videoTrack.height(), videoTrack.support());
+            String message = String.format(
+                    VIDEO_TRACK_MESSAGE_FORMAT,
+                    videoTrack.id(),
+                    videoTrack.height(),
+                    videoTrack.codecName(),
+                    videoTrack.associatedDecoderName()
+            );
             labels.add(message);
         }
         return labels;

--- a/demo/src/main/res/values/dimens.xml
+++ b/demo/src/main/res/values/dimens.xml
@@ -13,6 +13,6 @@
 
   <dimen name="use_weight">0dp</dimen>
   <dimen name="list_item_text">12sp</dimen>
-  <dimen name="list_item_padding">6dp</dimen>
+  <dimen name="list_item_padding">4dp</dimen>
 
 </resources>


### PR DESCRIPTION
## Problem

We do not know which decoder is going to be used by the engine per track.

## Solution

Surface that information using a singleton. I have tried to do it without a singleton but I didn't find a nice and performance way to do it.

I have also provided a list of decoders that *actually* supports the required format, instead of providing decoders that the engine already says that it is not supported.

### Test(s) added 

All tested

### Screenshots

![Screenshot_1562256914](https://user-images.githubusercontent.com/2845931/60679434-7a377200-9e7f-11e9-99a7-cce6e47d8214.png)

### Paired with 

Nobody
