### PR TITLE
Secure and unsupported codecs

### DIFF
--- a/core/src/main/java/com/novoda/noplayer/Options.java
+++ b/core/src/main/java/com/novoda/noplayer/Options.java
@@ -16,6 +16,7 @@ public class Options {
     private final Optional<Long> initialPositionInMillis;
     private final Optional<Long> initialAdvertBreakPositionInMillis;
     private final List<String> unsupportedVideoDecoders;
+    private final Optional<Integer> hdQualityThreshold;
 
     /**
      * Creates a {@link OptionsBuilder} from this Options.
@@ -44,7 +45,8 @@ public class Options {
             int maxVideoBitrate,
             Optional<Long> initialPositionInMillis,
             Optional<Long> initialAdvertBreakPositionInMillis,
-            List<String> unsupportedVideoDecoders) {
+            List<String> unsupportedVideoDecoders,
+            Optional<Integer> hdQualityThreshold) {
         this.contentType = contentType;
         this.minDurationBeforeQualityIncreaseInMillis = minDurationBeforeQualityIncreaseInMillis;
         this.maxInitialBitrate = maxInitialBitrate;
@@ -52,6 +54,7 @@ public class Options {
         this.initialPositionInMillis = initialPositionInMillis;
         this.initialAdvertBreakPositionInMillis = initialAdvertBreakPositionInMillis;
         this.unsupportedVideoDecoders = unsupportedVideoDecoders;
+        this.hdQualityThreshold = hdQualityThreshold;
     }
 
     public ContentType contentType() {
@@ -80,6 +83,10 @@ public class Options {
 
     public List<String> getUnsupportedVideoDecoders() {
         return unsupportedVideoDecoders;
+    }
+
+    public Optional<Integer> getHdQualityThreshold() {
+        return hdQualityThreshold;
     }
 
     @Override
@@ -111,7 +118,10 @@ public class Options {
         if (initialAdvertBreakPositionInMillis != null ? !initialAdvertBreakPositionInMillis.equals(options.initialAdvertBreakPositionInMillis) : options.initialAdvertBreakPositionInMillis != null) {
             return false;
         }
-        return unsupportedVideoDecoders != null ? unsupportedVideoDecoders.equals(options.unsupportedVideoDecoders) : options.unsupportedVideoDecoders == null;
+        if (unsupportedVideoDecoders != null ? !unsupportedVideoDecoders.equals(options.unsupportedVideoDecoders) : options.unsupportedVideoDecoders != null) {
+            return false;
+        }
+        return hdQualityThreshold != null ? hdQualityThreshold.equals(options.hdQualityThreshold) : options.hdQualityThreshold == null;
     }
 
     @Override
@@ -123,6 +133,7 @@ public class Options {
         result = 31 * result + (initialPositionInMillis != null ? initialPositionInMillis.hashCode() : 0);
         result = 31 * result + (initialAdvertBreakPositionInMillis != null ? initialAdvertBreakPositionInMillis.hashCode() : 0);
         result = 31 * result + (unsupportedVideoDecoders != null ? unsupportedVideoDecoders.hashCode() : 0);
+        result = 31 * result + (hdQualityThreshold != null ? hdQualityThreshold.hashCode() : 0);
         return result;
     }
 
@@ -136,6 +147,7 @@ public class Options {
                 + ", initialPositionInMillis=" + initialPositionInMillis
                 + ", initialAdvertBreakPositionInMillis=" + initialAdvertBreakPositionInMillis
                 + ", unsupportedVideoDecoders=" + unsupportedVideoDecoders
+                + ", hdQualityThreshold=" + hdQualityThreshold
                 + '}';
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/Options.java
+++ b/core/src/main/java/com/novoda/noplayer/Options.java
@@ -41,7 +41,7 @@ public class Options {
     }
 
     // There's a lot of customisation here.
-    @SuppressWarnings("PMD.ExcessiveParameterList")
+    @SuppressWarnings({"checkstyle:ParameterNumber", "PMD.ExcessiveParameterList"})
     Options(ContentType contentType,
             int minDurationBeforeQualityIncreaseInMillis,
             int maxInitialBitrate,

--- a/core/src/main/java/com/novoda/noplayer/Options.java
+++ b/core/src/main/java/com/novoda/noplayer/Options.java
@@ -2,6 +2,8 @@ package com.novoda.noplayer;
 
 import com.novoda.noplayer.internal.utils.Optional;
 
+import java.util.List;
+
 /**
  * Options to customise the underlying player.
  */
@@ -13,6 +15,7 @@ public class Options {
     private final int maxVideoBitrate;
     private final Optional<Long> initialPositionInMillis;
     private final Optional<Long> initialAdvertBreakPositionInMillis;
+    private final List<String> unsupportedVideoDecoders;
 
     /**
      * Creates a {@link OptionsBuilder} from this Options.
@@ -40,13 +43,15 @@ public class Options {
             int maxInitialBitrate,
             int maxVideoBitrate,
             Optional<Long> initialPositionInMillis,
-            Optional<Long> initialAdvertBreakPositionInMillis) {
+            Optional<Long> initialAdvertBreakPositionInMillis,
+            List<String> unsupportedVideoDecoders) {
         this.contentType = contentType;
         this.minDurationBeforeQualityIncreaseInMillis = minDurationBeforeQualityIncreaseInMillis;
         this.maxInitialBitrate = maxInitialBitrate;
         this.maxVideoBitrate = maxVideoBitrate;
         this.initialPositionInMillis = initialPositionInMillis;
         this.initialAdvertBreakPositionInMillis = initialAdvertBreakPositionInMillis;
+        this.unsupportedVideoDecoders = unsupportedVideoDecoders;
     }
 
     public ContentType contentType() {
@@ -73,6 +78,10 @@ public class Options {
         return initialAdvertBreakPositionInMillis;
     }
 
+    public List<String> getUnsupportedVideoDecoders() {
+        return unsupportedVideoDecoders;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -96,14 +105,13 @@ public class Options {
         if (contentType != options.contentType) {
             return false;
         }
-        if (initialPositionInMillis != null
-                ? !initialPositionInMillis.equals(options.initialPositionInMillis)
-                : options.initialPositionInMillis != null) {
+        if (initialPositionInMillis != null ? !initialPositionInMillis.equals(options.initialPositionInMillis) : options.initialPositionInMillis != null) {
             return false;
         }
-        return initialAdvertBreakPositionInMillis != null
-                ? initialAdvertBreakPositionInMillis.equals(options.initialAdvertBreakPositionInMillis)
-                : options.initialAdvertBreakPositionInMillis == null;
+        if (initialAdvertBreakPositionInMillis != null ? !initialAdvertBreakPositionInMillis.equals(options.initialAdvertBreakPositionInMillis) : options.initialAdvertBreakPositionInMillis != null) {
+            return false;
+        }
+        return unsupportedVideoDecoders != null ? unsupportedVideoDecoders.equals(options.unsupportedVideoDecoders) : options.unsupportedVideoDecoders == null;
     }
 
     @Override
@@ -114,6 +122,7 @@ public class Options {
         result = 31 * result + maxVideoBitrate;
         result = 31 * result + (initialPositionInMillis != null ? initialPositionInMillis.hashCode() : 0);
         result = 31 * result + (initialAdvertBreakPositionInMillis != null ? initialAdvertBreakPositionInMillis.hashCode() : 0);
+        result = 31 * result + (unsupportedVideoDecoders != null ? unsupportedVideoDecoders.hashCode() : 0);
         return result;
     }
 
@@ -125,6 +134,8 @@ public class Options {
                 + ", maxInitialBitrate=" + maxInitialBitrate
                 + ", maxVideoBitrate=" + maxVideoBitrate
                 + ", initialPositionInMillis=" + initialPositionInMillis
+                + ", initialAdvertBreakPositionInMillis=" + initialAdvertBreakPositionInMillis
+                + ", unsupportedVideoDecoders=" + unsupportedVideoDecoders
                 + '}';
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/Options.java
+++ b/core/src/main/java/com/novoda/noplayer/Options.java
@@ -16,7 +16,7 @@ public class Options {
     private final Optional<Long> initialPositionInMillis;
     private final Optional<Long> initialAdvertBreakPositionInMillis;
     private final List<String> unsupportedVideoDecoders;
-    private final Optional<Integer> hdQualityThreshold;
+    private final Optional<Integer> hdQualityBitrateThreshold;
 
     /**
      * Creates a {@link OptionsBuilder} from this Options.
@@ -46,7 +46,7 @@ public class Options {
             Optional<Long> initialPositionInMillis,
             Optional<Long> initialAdvertBreakPositionInMillis,
             List<String> unsupportedVideoDecoders,
-            Optional<Integer> hdQualityThreshold) {
+            Optional<Integer> hdQualityBitrateThreshold) {
         this.contentType = contentType;
         this.minDurationBeforeQualityIncreaseInMillis = minDurationBeforeQualityIncreaseInMillis;
         this.maxInitialBitrate = maxInitialBitrate;
@@ -54,7 +54,7 @@ public class Options {
         this.initialPositionInMillis = initialPositionInMillis;
         this.initialAdvertBreakPositionInMillis = initialAdvertBreakPositionInMillis;
         this.unsupportedVideoDecoders = unsupportedVideoDecoders;
-        this.hdQualityThreshold = hdQualityThreshold;
+        this.hdQualityBitrateThreshold = hdQualityBitrateThreshold;
     }
 
     public ContentType contentType() {
@@ -85,8 +85,8 @@ public class Options {
         return unsupportedVideoDecoders;
     }
 
-    public Optional<Integer> getHdQualityThreshold() {
-        return hdQualityThreshold;
+    public Optional<Integer> getHdQualityBitrateThreshold() {
+        return hdQualityBitrateThreshold;
     }
 
     @Override
@@ -121,7 +121,7 @@ public class Options {
         if (unsupportedVideoDecoders != null ? !unsupportedVideoDecoders.equals(options.unsupportedVideoDecoders) : options.unsupportedVideoDecoders != null) {
             return false;
         }
-        return hdQualityThreshold != null ? hdQualityThreshold.equals(options.hdQualityThreshold) : options.hdQualityThreshold == null;
+        return hdQualityBitrateThreshold != null ? hdQualityBitrateThreshold.equals(options.hdQualityBitrateThreshold) : options.hdQualityBitrateThreshold == null;
     }
 
     @Override
@@ -133,7 +133,7 @@ public class Options {
         result = 31 * result + (initialPositionInMillis != null ? initialPositionInMillis.hashCode() : 0);
         result = 31 * result + (initialAdvertBreakPositionInMillis != null ? initialAdvertBreakPositionInMillis.hashCode() : 0);
         result = 31 * result + (unsupportedVideoDecoders != null ? unsupportedVideoDecoders.hashCode() : 0);
-        result = 31 * result + (hdQualityThreshold != null ? hdQualityThreshold.hashCode() : 0);
+        result = 31 * result + (hdQualityBitrateThreshold != null ? hdQualityBitrateThreshold.hashCode() : 0);
         return result;
     }
 
@@ -147,7 +147,7 @@ public class Options {
                 + ", initialPositionInMillis=" + initialPositionInMillis
                 + ", initialAdvertBreakPositionInMillis=" + initialAdvertBreakPositionInMillis
                 + ", unsupportedVideoDecoders=" + unsupportedVideoDecoders
-                + ", hdQualityThreshold=" + hdQualityThreshold
+                + ", hdQualityBitrateThreshold=" + hdQualityBitrateThreshold
                 + '}';
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/Options.java
+++ b/core/src/main/java/com/novoda/noplayer/Options.java
@@ -7,6 +7,7 @@ import java.util.List;
 /**
  * Options to customise the underlying player.
  */
+@SuppressWarnings("PMD.ExcessiveImports")
 public class Options {
 
     private final ContentType contentType;
@@ -39,6 +40,8 @@ public class Options {
         return optionsBuilder;
     }
 
+    // There's a lot of customisation here.
+    @SuppressWarnings("PMD.ExcessiveParameterList")
     Options(ContentType contentType,
             int minDurationBeforeQualityIncreaseInMillis,
             int maxInitialBitrate,
@@ -112,16 +115,20 @@ public class Options {
         if (contentType != options.contentType) {
             return false;
         }
-        if (initialPositionInMillis != null ? !initialPositionInMillis.equals(options.initialPositionInMillis) : options.initialPositionInMillis != null) {
+        if (initialPositionInMillis != null ? !initialPositionInMillis.equals(options.initialPositionInMillis)
+                : options.initialPositionInMillis != null) {
             return false;
         }
-        if (initialAdvertBreakPositionInMillis != null ? !initialAdvertBreakPositionInMillis.equals(options.initialAdvertBreakPositionInMillis) : options.initialAdvertBreakPositionInMillis != null) {
+        if (initialAdvertBreakPositionInMillis != null ? !initialAdvertBreakPositionInMillis.equals(options.initialAdvertBreakPositionInMillis)
+                : options.initialAdvertBreakPositionInMillis != null) {
             return false;
         }
-        if (unsupportedVideoDecoders != null ? !unsupportedVideoDecoders.equals(options.unsupportedVideoDecoders) : options.unsupportedVideoDecoders != null) {
+        if (unsupportedVideoDecoders != null ? !unsupportedVideoDecoders.equals(options.unsupportedVideoDecoders)
+                : options.unsupportedVideoDecoders != null) {
             return false;
         }
-        return hdQualityBitrateThreshold != null ? hdQualityBitrateThreshold.equals(options.hdQualityBitrateThreshold) : options.hdQualityBitrateThreshold == null;
+        return hdQualityBitrateThreshold != null ? hdQualityBitrateThreshold.equals(options.hdQualityBitrateThreshold)
+                : options.hdQualityBitrateThreshold == null;
     }
 
     @Override

--- a/core/src/main/java/com/novoda/noplayer/OptionsBuilder.java
+++ b/core/src/main/java/com/novoda/noplayer/OptionsBuilder.java
@@ -4,6 +4,9 @@ import android.net.Uri;
 
 import com.novoda.noplayer.internal.utils.Optional;
 
+import java.util.Collections;
+import java.util.List;
+
 /**
  * Builds instances of {@link Options} for {@link NoPlayer#loadVideo(Uri, Options)}.
  */
@@ -19,6 +22,7 @@ public class OptionsBuilder {
     private int maxVideoBitrate = DEFAULT_MAX_VIDEO_BITRATE;
     private Optional<Long> initialPositionInMillis = Optional.absent();
     private Optional<Long> initialAdvertBreakPositionInMillis = Optional.absent();
+    private List<String> unsupportedVideoDecoders = Collections.emptyList();
 
     /**
      * Sets {@link OptionsBuilder} to build {@link Options} with a given {@link ContentType}.
@@ -96,6 +100,18 @@ public class OptionsBuilder {
     }
 
     /**
+     * Sets {@link OptionsBuilder} to build {@link Options} with the given unsupported video decoders,
+     * which will be removed from the codec selection.
+     *
+     * @param unsupportedVideoDecoders that should be removed when selecting codecs.
+     * @return {@link OptionsBuilder}.
+     */
+    public OptionsBuilder withUnsupportedVideoDecoders(List<String> unsupportedVideoDecoders) {
+        this.unsupportedVideoDecoders = unsupportedVideoDecoders;
+        return this;
+    }
+
+    /**
      * Builds a new {@link Options} instance.
      *
      * @return a {@link Options} instance.
@@ -107,6 +123,8 @@ public class OptionsBuilder {
                 maxInitialBitrate,
                 maxVideoBitrate,
                 initialPositionInMillis,
-                initialAdvertBreakPositionInMillis);
+                initialAdvertBreakPositionInMillis,
+                unsupportedVideoDecoders
+        );
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/OptionsBuilder.java
+++ b/core/src/main/java/com/novoda/noplayer/OptionsBuilder.java
@@ -106,7 +106,7 @@ public class OptionsBuilder {
      * <p>
      * NOTE: This will do nothing unless {@link PlayerBuilder#allowFallbackDecoders()} is enabled.
      *
-     * @param unsupportedVideoDecoders that should be removed when selecting codecs.
+     * @param unsupportedVideoDecoders The names of the codecs that should be removed when selecting codecs.
      * @return {@link OptionsBuilder}.
      */
     public OptionsBuilder withUnsupportedVideoDecoders(List<String> unsupportedVideoDecoders) {

--- a/core/src/main/java/com/novoda/noplayer/OptionsBuilder.java
+++ b/core/src/main/java/com/novoda/noplayer/OptionsBuilder.java
@@ -103,6 +103,8 @@ public class OptionsBuilder {
     /**
      * Sets {@link OptionsBuilder} to build {@link Options} with the given unsupported video decoders,
      * which will be removed from the codec selection.
+     * <p>
+     * NOTE: This will do nothing unless {@link PlayerBuilder#allowFallbackDecoders()} is enabled.
      *
      * @param unsupportedVideoDecoders that should be removed when selecting codecs.
      * @return {@link OptionsBuilder}.
@@ -112,8 +114,17 @@ public class OptionsBuilder {
         return this;
     }
 
-    public OptionsBuilder withSecureDecoderRequiredForHD(int hdQualityThreshold) {
-        this.hdQualityThreshold = Optional.fromNullable(hdQualityThreshold);
+    /**
+     * Sets {@link OptionsBuilder} to build {@link Options} with the given HD quality bitrate threshold,
+     * which will remove all non-secure codecs from HD tracks.
+     * <p>
+     * NOTE: This will do nothing unless {@link PlayerBuilder#allowFallbackDecoders()} is enabled.
+     *
+     * @param hdQualityBitrateThreshold at which tracks will be considered HD.
+     * @return {@link OptionsBuilder}.
+     */
+    public OptionsBuilder withSecureDecoderRequiredForHD(int hdQualityBitrateThreshold) {
+        this.hdQualityThreshold = Optional.fromNullable(hdQualityBitrateThreshold);
         return this;
     }
 

--- a/core/src/main/java/com/novoda/noplayer/OptionsBuilder.java
+++ b/core/src/main/java/com/novoda/noplayer/OptionsBuilder.java
@@ -23,6 +23,7 @@ public class OptionsBuilder {
     private Optional<Long> initialPositionInMillis = Optional.absent();
     private Optional<Long> initialAdvertBreakPositionInMillis = Optional.absent();
     private List<String> unsupportedVideoDecoders = Collections.emptyList();
+    private Optional<Integer> hdQualityThreshold = Optional.absent();
 
     /**
      * Sets {@link OptionsBuilder} to build {@link Options} with a given {@link ContentType}.
@@ -111,6 +112,11 @@ public class OptionsBuilder {
         return this;
     }
 
+    public OptionsBuilder withSecureDecoderRequiredForHD(int hdQualityThreshold) {
+        this.hdQualityThreshold = Optional.fromNullable(hdQualityThreshold);
+        return this;
+    }
+
     /**
      * Builds a new {@link Options} instance.
      *
@@ -124,7 +130,8 @@ public class OptionsBuilder {
                 maxVideoBitrate,
                 initialPositionInMillis,
                 initialAdvertBreakPositionInMillis,
-                unsupportedVideoDecoders
+                unsupportedVideoDecoders,
+                hdQualityThreshold
         );
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/PlayerBuilder.java
+++ b/core/src/main/java/com/novoda/noplayer/PlayerBuilder.java
@@ -4,8 +4,6 @@ import android.content.Context;
 import android.os.Handler;
 import android.os.Looper;
 
-import androidx.annotation.Nullable;
-
 import com.novoda.noplayer.drm.DrmType;
 import com.novoda.noplayer.drm.KeyRequestExecutor;
 import com.novoda.noplayer.drm.ModularDrmKeyRequest;
@@ -19,6 +17,8 @@ import com.novoda.noplayer.model.KeySetId;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+
+import androidx.annotation.Nullable;
 
 /**
  * Builds instances of {@link NoPlayer} for given configurations.
@@ -131,6 +131,8 @@ public class PlayerBuilder {
 
     /**
      * Will indicate the engine that it requires secure decoders.
+     * <p>
+     * NOTE: This will do nothing unless {@link PlayerBuilder#allowFallbackDecoders()} is enabled.
      *
      * @return {@link PlayerBuilder}
      */

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerCreator.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerCreator.java
@@ -45,7 +45,7 @@ class ExoPlayerCreator {
                 allowFallbackDecoder,
                 requiresSecureDecoder,
                 options.getUnsupportedVideoDecoders(),
-                options.getHdQualityThreshold(),
+                options.getHdQualityBitrateThreshold(),
                 subtitleDecoderFactory
         );
 

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerCreator.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerCreator.java
@@ -2,8 +2,6 @@ package com.novoda.noplayer.internal.exoplayer;
 
 import android.content.Context;
 
-import androidx.annotation.NonNull;
-
 import com.google.android.exoplayer2.DefaultLoadControl;
 import com.google.android.exoplayer2.ExoPlayerFactory;
 import com.google.android.exoplayer2.RenderersFactory;
@@ -15,6 +13,10 @@ import com.google.android.exoplayer2.text.SubtitleDecoderFactory;
 import com.google.android.exoplayer2.trackselection.TrackSelector;
 import com.novoda.noplayer.internal.exoplayer.drm.DrmSessionCreator;
 import com.novoda.noplayer.text.NoPlayerSubtitleDecoderFactory;
+
+import java.util.List;
+
+import androidx.annotation.NonNull;
 
 import static com.novoda.noplayer.internal.exoplayer.SimpleRenderersFactory.EXTENSION_RENDERER_MODE_OFF;
 
@@ -33,6 +35,7 @@ class ExoPlayerCreator {
                                   DefaultDrmSessionEventListener drmSessionEventListener,
                                   boolean allowFallbackDecoder,
                                   boolean requiresSecureDecoder,
+                                  List<String> unsupportedVideoDecoders,
                                   TrackSelector trackSelector) {
         DrmSessionManager<FrameworkMediaCrypto> drmSessionManager = drmSessionCreator.create(drmSessionEventListener);
         SubtitleDecoderFactory subtitleDecoderFactory = new NoPlayerSubtitleDecoderFactory();
@@ -42,6 +45,7 @@ class ExoPlayerCreator {
                 DEFAULT_ALLOWED_VIDEO_JOINING_TIME_MS,
                 allowFallbackDecoder,
                 requiresSecureDecoder,
+                unsupportedVideoDecoders,
                 subtitleDecoderFactory
         );
 

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerCreator.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerCreator.java
@@ -11,10 +11,9 @@ import com.google.android.exoplayer2.drm.DrmSessionManager;
 import com.google.android.exoplayer2.drm.FrameworkMediaCrypto;
 import com.google.android.exoplayer2.text.SubtitleDecoderFactory;
 import com.google.android.exoplayer2.trackselection.TrackSelector;
+import com.novoda.noplayer.Options;
 import com.novoda.noplayer.internal.exoplayer.drm.DrmSessionCreator;
 import com.novoda.noplayer.text.NoPlayerSubtitleDecoderFactory;
-
-import java.util.List;
 
 import androidx.annotation.NonNull;
 
@@ -35,7 +34,7 @@ class ExoPlayerCreator {
                                   DefaultDrmSessionEventListener drmSessionEventListener,
                                   boolean allowFallbackDecoder,
                                   boolean requiresSecureDecoder,
-                                  List<String> unsupportedVideoDecoders,
+                                  Options options,
                                   TrackSelector trackSelector) {
         DrmSessionManager<FrameworkMediaCrypto> drmSessionManager = drmSessionCreator.create(drmSessionEventListener);
         SubtitleDecoderFactory subtitleDecoderFactory = new NoPlayerSubtitleDecoderFactory();
@@ -45,7 +44,8 @@ class ExoPlayerCreator {
                 DEFAULT_ALLOWED_VIDEO_JOINING_TIME_MS,
                 allowFallbackDecoder,
                 requiresSecureDecoder,
-                unsupportedVideoDecoders,
+                options.getUnsupportedVideoDecoders(),
+                options.getHdQualityThreshold(),
                 subtitleDecoderFactory
         );
 

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
@@ -2,8 +2,6 @@ package com.novoda.noplayer.internal.exoplayer;
 
 import android.net.Uri;
 
-import androidx.annotation.Nullable;
-
 import com.google.android.exoplayer2.C;
 import com.google.android.exoplayer2.Player;
 import com.google.android.exoplayer2.SimpleExoPlayer;
@@ -27,6 +25,8 @@ import com.novoda.noplayer.model.PlayerSubtitleTrack;
 import com.novoda.noplayer.model.PlayerVideoTrack;
 
 import java.util.List;
+
+import androidx.annotation.Nullable;
 
 // Not much we can do, wrapping ExoPlayer is a lot of work
 @SuppressWarnings("PMD.GodClass")
@@ -208,6 +208,7 @@ class ExoPlayerFacade {
                 forwarder.drmSessionEventListener(),
                 allowFallbackDecoder,
                 requiresSecureDecoder,
+                options.getUnsupportedVideoDecoders(),
                 compositeTrackSelector.trackSelector()
         );
         rendererTypeRequester = rendererTypeRequesterCreator.createfrom(exoPlayer);

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
@@ -208,7 +208,7 @@ class ExoPlayerFacade {
                 forwarder.drmSessionEventListener(),
                 allowFallbackDecoder,
                 requiresSecureDecoder,
-                options.getUnsupportedVideoDecoders(),
+                options,
                 compositeTrackSelector.trackSelector()
         );
         rendererTypeRequester = rendererTypeRequesterCreator.createfrom(exoPlayer);

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/InternalMediaCodecUtil.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/InternalMediaCodecUtil.java
@@ -1,7 +1,5 @@
 package com.novoda.noplayer.internal.exoplayer;
 
-import androidx.annotation.CheckResult;
-
 import com.google.android.exoplayer2.Format;
 import com.google.android.exoplayer2.mediacodec.MediaCodecInfo;
 import com.google.android.exoplayer2.mediacodec.MediaCodecUtil;
@@ -10,6 +8,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+
+import androidx.annotation.CheckResult;
 
 class InternalMediaCodecUtil {
 
@@ -50,7 +50,6 @@ class InternalMediaCodecUtil {
     }
 
     /**
-     *
      * Returns a list of decoders that supports the provided format
      */
     static List<MediaCodecInfo> getOnlySupportedDecoderInfos(List<MediaCodecInfo> decoderInfos, Format format) {
@@ -65,6 +64,19 @@ class InternalMediaCodecUtil {
             }
         }
 
+        return onlySupported;
+    }
+
+    static List<MediaCodecInfo> removeUnsupportedVideoDecoders(List<MediaCodecInfo> decoderInfos, List<String> unsupportedDecoders) {
+        List<MediaCodecInfo> onlySupported = new ArrayList<>(decoderInfos);
+        for (MediaCodecInfo decoderInfo : decoderInfos) {
+            for (String unsupportedDecoder : unsupportedDecoders) {
+                if (decoderInfo.name.equalsIgnoreCase(unsupportedDecoder)) {
+                    onlySupported.remove(decoderInfo);
+                    break;
+                }
+            }
+        }
         return onlySupported;
     }
 

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/InternalMediaCodecUtil.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/InternalMediaCodecUtil.java
@@ -80,6 +80,20 @@ class InternalMediaCodecUtil {
         return onlySupported;
     }
 
+    static List<MediaCodecInfo> removeAllUnsecureDecodersFromHdTrack(Format format, List<MediaCodecInfo> decoderInfos, int hdQualityThreshold) {
+        if (format.bitrate < hdQualityThreshold) {
+            return decoderInfos;
+        }
+
+        List<MediaCodecInfo> onlySupported = new ArrayList<>(decoderInfos);
+        for (MediaCodecInfo decoderInfo : decoderInfos) {
+            if (!decoderInfo.secure) {
+                onlySupported.remove(decoderInfo);
+            }
+        }
+        return onlySupported;
+    }
+
     /**
      * Stably sorts the provided {@code list} in-place, in order of decreasing score.
      */

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/MediaCodecVideoRendererWithSimplifiedDrmRequirement.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/MediaCodecVideoRendererWithSimplifiedDrmRequirement.java
@@ -70,7 +70,7 @@ class MediaCodecVideoRendererWithSimplifiedDrmRequirement extends MediaCodecVide
     protected List<MediaCodecInfo> getDecoderInfos(MediaCodecSelector mediaCodecSelector,
                                                    Format format,
                                                    boolean requiresSecureDecoder) throws MediaCodecUtil.DecoderQueryException {
-        return getDecoderInfos(mediaCodecSelector, format, requiresSecureDecoder(format), getCodecNeedsEosPropagation());
+        return getDecoderInfos(mediaCodecSelector, format, requiresSecureDecoder(format), getCodecNeedsEosPropagation(), unsupportedVideoDecoders);
     }
 
     private boolean requiresSecureDecoder(Format format) {
@@ -82,7 +82,8 @@ class MediaCodecVideoRendererWithSimplifiedDrmRequirement extends MediaCodecVide
             MediaCodecSelector mediaCodecSelector,
             Format format,
             boolean requiresSecureDecoder,
-            boolean requiresTunnelingDecoder)
+            boolean requiresTunnelingDecoder,
+            List<String> unsupportedVideoDecoders)
             throws MediaCodecUtil.DecoderQueryException {
         List<MediaCodecInfo> decoderInfos = mediaCodecSelector.getDecoderInfos(
                 format.sampleMimeType,
@@ -116,6 +117,7 @@ class MediaCodecVideoRendererWithSimplifiedDrmRequirement extends MediaCodecVide
             }
         }
 
+        decoderInfos = InternalMediaCodecUtil.removeUnsupportedVideoDecoders(decoderInfos, unsupportedVideoDecoders);
         saveTrackCodecMapping(format.codecs, decoderInfos);
 
         printDecoderInfos(format.codecs, decoderInfos);

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/MediaCodecVideoRendererWithSimplifiedDrmRequirement.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/MediaCodecVideoRendererWithSimplifiedDrmRequirement.java
@@ -5,8 +5,6 @@ import android.os.Handler;
 import android.util.Log;
 import android.util.Pair;
 
-import androidx.annotation.Nullable;
-
 import com.google.android.exoplayer2.Format;
 import com.google.android.exoplayer2.drm.DrmSessionManager;
 import com.google.android.exoplayer2.drm.FrameworkMediaCrypto;
@@ -20,6 +18,8 @@ import com.novoda.noplayer.model.PlayerVideoTrackCodecMapping;
 
 import java.util.Collections;
 import java.util.List;
+
+import androidx.annotation.Nullable;
 
 /**
  * Relaxes the Drm requirement so that a secure decoder is selected in the event that `DrmInitData` is present.
@@ -36,6 +36,7 @@ class MediaCodecVideoRendererWithSimplifiedDrmRequirement extends MediaCodecVide
     private static final String TAG = MediaCodecVideoRendererWithSimplifiedDrmRequirement.class.getSimpleName();
 
     private final boolean requiresSecureDecoder;
+    private final List<String> unsupportedVideoDecoders;
 
     // Extension from MediaCodecVideoRenderer, we can't do anything about this.
     @SuppressWarnings({"checkstyle:ParameterNumber", "PMD.ExcessiveParameterList"})
@@ -46,6 +47,7 @@ class MediaCodecVideoRendererWithSimplifiedDrmRequirement extends MediaCodecVide
                                                         boolean playClearSamplesWithoutKeys,
                                                         boolean enableDecoderFallback,
                                                         boolean requiresSecureDecoder,
+                                                        List<String> unsupportedVideoDecoders,
                                                         @Nullable Handler eventHandler,
                                                         @Nullable VideoRendererEventListener eventListener,
                                                         int maxDroppedFramesToNotify) {
@@ -61,6 +63,7 @@ class MediaCodecVideoRendererWithSimplifiedDrmRequirement extends MediaCodecVide
                 maxDroppedFramesToNotify
         );
         this.requiresSecureDecoder = requiresSecureDecoder;
+        this.unsupportedVideoDecoders = unsupportedVideoDecoders;
     }
 
     @Override

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/MediaCodecVideoRendererWithSimplifiedDrmRequirement.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/MediaCodecVideoRendererWithSimplifiedDrmRequirement.java
@@ -38,7 +38,7 @@ class MediaCodecVideoRendererWithSimplifiedDrmRequirement extends MediaCodecVide
 
     private final boolean requiresSecureDecoder;
     private final List<String> unsupportedVideoDecoders;
-    private final Optional<Integer> hdQualityThreshold;
+    private final Optional<Integer> hdQualityBitrateThreshold;
 
     // Extension from MediaCodecVideoRenderer, we can't do anything about this.
     @SuppressWarnings({"checkstyle:ParameterNumber", "PMD.ExcessiveParameterList"})
@@ -50,7 +50,7 @@ class MediaCodecVideoRendererWithSimplifiedDrmRequirement extends MediaCodecVide
                                                         boolean enableDecoderFallback,
                                                         boolean requiresSecureDecoder,
                                                         List<String> unsupportedVideoDecoders,
-                                                        Optional<Integer> hdQualityThreshold,
+                                                        Optional<Integer> hdQualityBitrateThreshold,
                                                         @Nullable Handler eventHandler,
                                                         @Nullable VideoRendererEventListener eventListener,
                                                         int maxDroppedFramesToNotify) {
@@ -67,7 +67,7 @@ class MediaCodecVideoRendererWithSimplifiedDrmRequirement extends MediaCodecVide
         );
         this.requiresSecureDecoder = requiresSecureDecoder;
         this.unsupportedVideoDecoders = unsupportedVideoDecoders;
-        this.hdQualityThreshold = hdQualityThreshold;
+        this.hdQualityBitrateThreshold = hdQualityBitrateThreshold;
     }
 
     @Override
@@ -80,7 +80,7 @@ class MediaCodecVideoRendererWithSimplifiedDrmRequirement extends MediaCodecVide
                 requiresSecureDecoder(format),
                 getCodecNeedsEosPropagation(),
                 unsupportedVideoDecoders,
-                hdQualityThreshold
+                hdQualityBitrateThreshold
         );
     }
 
@@ -95,7 +95,7 @@ class MediaCodecVideoRendererWithSimplifiedDrmRequirement extends MediaCodecVide
             boolean requiresSecureDecoder,
             boolean requiresTunnelingDecoder,
             List<String> unsupportedVideoDecoders,
-            Optional<Integer> hdQualityThreshold)
+            Optional<Integer> hdQualityBitrateThreshold)
             throws MediaCodecUtil.DecoderQueryException {
         List<MediaCodecInfo> decoderInfos = mediaCodecSelector.getDecoderInfos(
                 format.sampleMimeType,
@@ -130,8 +130,8 @@ class MediaCodecVideoRendererWithSimplifiedDrmRequirement extends MediaCodecVide
         }
 
         decoderInfos = InternalMediaCodecUtil.removeUnsupportedVideoDecoders(decoderInfos, unsupportedVideoDecoders);
-        if (hdQualityThreshold.isPresent()) {
-            decoderInfos = InternalMediaCodecUtil.removeAllUnsecureDecodersFromHdTrack(format, decoderInfos, hdQualityThreshold.get());
+        if (hdQualityBitrateThreshold.isPresent()) {
+            decoderInfos = InternalMediaCodecUtil.removeAllUnsecureDecodersFromHdTrack(format, decoderInfos, hdQualityBitrateThreshold.get());
         }
 
         saveTrackCodecMapping(format.codecs, decoderInfos);

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/SimpleRenderersFactory.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/SimpleRenderersFactory.java
@@ -117,6 +117,8 @@ class SimpleRenderersFactory implements RenderersFactory {
      * @param hdQualityBitrateThreshold The threshold over which secure decoders must be present.
      * @param subtitleDecoderFactory    A factory from which to obtain {@link SubtitleDecoder} instances.
      */
+    // Lots of customisation here.
+    @SuppressWarnings("PMD.ExcessiveParameterList")
     SimpleRenderersFactory(Context context,
                            @ExtensionRendererMode int extensionRendererMode,
                            long allowedVideoJoiningTimeMs,

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/SimpleRenderersFactory.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/SimpleRenderersFactory.java
@@ -52,7 +52,13 @@ import androidx.annotation.Nullable;
 /**
  * Default {@link RenderersFactory} implementation.
  */
-@SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.StdCyclomaticComplexity", "PMD.ModifiedCyclomaticComplexity", "PMD.NPathComplexity"})
+@SuppressWarnings({
+        "PMD.CyclomaticComplexity",
+        "PMD.StdCyclomaticComplexity",
+        "PMD.ModifiedCyclomaticComplexity",
+        "PMD.NPathComplexity",
+        "PMD.ExcessiveImports"
+})
 class SimpleRenderersFactory implements RenderersFactory {
 
     private static final boolean DO_NOT_PLAY_CLEAR_SAMPLES_WITHOUT_KEYS = false;
@@ -117,8 +123,7 @@ class SimpleRenderersFactory implements RenderersFactory {
      * @param hdQualityBitrateThreshold The threshold over which secure decoders must be present.
      * @param subtitleDecoderFactory    A factory from which to obtain {@link SubtitleDecoder} instances.
      */
-    // Lots of customisation here.
-    @SuppressWarnings("PMD.ExcessiveParameterList")
+    @SuppressWarnings({"checkstyle:ParameterNumber", "PMD.ExcessiveParameterList"})
     SimpleRenderersFactory(Context context,
                            @ExtensionRendererMode int extensionRendererMode,
                            long allowedVideoJoiningTimeMs,

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/SimpleRenderersFactory.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/SimpleRenderersFactory.java
@@ -20,9 +20,6 @@ import android.os.Handler;
 import android.os.Looper;
 import android.util.Log;
 
-import androidx.annotation.IntDef;
-import androidx.annotation.Nullable;
-
 import com.google.android.exoplayer2.Renderer;
 import com.google.android.exoplayer2.RenderersFactory;
 import com.google.android.exoplayer2.audio.AudioCapabilities;
@@ -47,6 +44,9 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.reflect.Constructor;
 import java.util.ArrayList;
 import java.util.List;
+
+import androidx.annotation.IntDef;
+import androidx.annotation.Nullable;
 
 /**
  * Default {@link RenderersFactory} implementation.
@@ -100,6 +100,7 @@ class SimpleRenderersFactory implements RenderersFactory {
     private final long allowedVideoJoiningTimeMs;
     private final boolean allowFallbackDecoder;
     private final boolean requiresSecureDecoder;
+    private final List<String> unsupportedVideoDecoders;
     private final SubtitleDecoderFactory subtitleDecoderFactory;
 
     /**
@@ -110,6 +111,7 @@ class SimpleRenderersFactory implements RenderersFactory {
      * @param allowedVideoJoiningTimeMs The maximum duration for which video renderers can attempt
      *                                  to seamlessly join an ongoing playback.
      * @param allowFallbackDecoder      Used for selecting the codec for the video renderer.
+     * @param unsupportedVideoDecoders
      * @param subtitleDecoderFactory    A factory from which to obtain {@link SubtitleDecoder} instances.
      */
     SimpleRenderersFactory(Context context,
@@ -117,12 +119,14 @@ class SimpleRenderersFactory implements RenderersFactory {
                            long allowedVideoJoiningTimeMs,
                            boolean allowFallbackDecoder,
                            boolean requiresSecureDecoder,
+                           List<String> unsupportedVideoDecoders,
                            SubtitleDecoderFactory subtitleDecoderFactory) {
         this.context = context;
         this.extensionRendererMode = extensionRendererMode;
         this.allowedVideoJoiningTimeMs = allowedVideoJoiningTimeMs;
         this.allowFallbackDecoder = allowFallbackDecoder;
         this.requiresSecureDecoder = requiresSecureDecoder;
+        this.unsupportedVideoDecoders = unsupportedVideoDecoders;
         this.subtitleDecoderFactory = subtitleDecoderFactory;
     }
 
@@ -178,6 +182,7 @@ class SimpleRenderersFactory implements RenderersFactory {
                     DO_NOT_PLAY_CLEAR_SAMPLES_WITHOUT_KEYS,
                     ENABLE_DECODER_FALLBACK,
                     requiresSecureDecoder,
+                    unsupportedVideoDecoders,
                     eventHandler,
                     eventListener,
                     MAX_DROPPED_VIDEO_FRAME_COUNT_TO_NOTIFY

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/SimpleRenderersFactory.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/SimpleRenderersFactory.java
@@ -38,6 +38,7 @@ import com.google.android.exoplayer2.text.TextRenderer;
 import com.google.android.exoplayer2.trackselection.TrackSelector;
 import com.google.android.exoplayer2.video.MediaCodecVideoRenderer;
 import com.google.android.exoplayer2.video.VideoRendererEventListener;
+import com.novoda.noplayer.internal.utils.Optional;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -101,6 +102,7 @@ class SimpleRenderersFactory implements RenderersFactory {
     private final boolean allowFallbackDecoder;
     private final boolean requiresSecureDecoder;
     private final List<String> unsupportedVideoDecoders;
+    private final Optional<Integer> hdQualityThreshold;
     private final SubtitleDecoderFactory subtitleDecoderFactory;
 
     /**
@@ -112,6 +114,7 @@ class SimpleRenderersFactory implements RenderersFactory {
      *                                  to seamlessly join an ongoing playback.
      * @param allowFallbackDecoder      Used for selecting the codec for the video renderer.
      * @param unsupportedVideoDecoders
+     * @param hdQualityThreshold
      * @param subtitleDecoderFactory    A factory from which to obtain {@link SubtitleDecoder} instances.
      */
     SimpleRenderersFactory(Context context,
@@ -120,6 +123,7 @@ class SimpleRenderersFactory implements RenderersFactory {
                            boolean allowFallbackDecoder,
                            boolean requiresSecureDecoder,
                            List<String> unsupportedVideoDecoders,
+                           Optional<Integer> hdQualityThreshold,
                            SubtitleDecoderFactory subtitleDecoderFactory) {
         this.context = context;
         this.extensionRendererMode = extensionRendererMode;
@@ -127,6 +131,7 @@ class SimpleRenderersFactory implements RenderersFactory {
         this.allowFallbackDecoder = allowFallbackDecoder;
         this.requiresSecureDecoder = requiresSecureDecoder;
         this.unsupportedVideoDecoders = unsupportedVideoDecoders;
+        this.hdQualityThreshold = hdQualityThreshold;
         this.subtitleDecoderFactory = subtitleDecoderFactory;
     }
 
@@ -183,6 +188,7 @@ class SimpleRenderersFactory implements RenderersFactory {
                     ENABLE_DECODER_FALLBACK,
                     requiresSecureDecoder,
                     unsupportedVideoDecoders,
+                    hdQualityThreshold,
                     eventHandler,
                     eventListener,
                     MAX_DROPPED_VIDEO_FRAME_COUNT_TO_NOTIFY

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/SimpleRenderersFactory.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/SimpleRenderersFactory.java
@@ -102,7 +102,7 @@ class SimpleRenderersFactory implements RenderersFactory {
     private final boolean allowFallbackDecoder;
     private final boolean requiresSecureDecoder;
     private final List<String> unsupportedVideoDecoders;
-    private final Optional<Integer> hdQualityThreshold;
+    private final Optional<Integer> hdQualityBitrateThreshold;
     private final SubtitleDecoderFactory subtitleDecoderFactory;
 
     /**
@@ -113,8 +113,8 @@ class SimpleRenderersFactory implements RenderersFactory {
      * @param allowedVideoJoiningTimeMs The maximum duration for which video renderers can attempt
      *                                  to seamlessly join an ongoing playback.
      * @param allowFallbackDecoder      Used for selecting the codec for the video renderer.
-     * @param unsupportedVideoDecoders
-     * @param hdQualityThreshold
+     * @param unsupportedVideoDecoders  The decoders to remove from the list of supported codecs.
+     * @param hdQualityBitrateThreshold The threshold over which secure decoders must be present.
      * @param subtitleDecoderFactory    A factory from which to obtain {@link SubtitleDecoder} instances.
      */
     SimpleRenderersFactory(Context context,
@@ -123,7 +123,7 @@ class SimpleRenderersFactory implements RenderersFactory {
                            boolean allowFallbackDecoder,
                            boolean requiresSecureDecoder,
                            List<String> unsupportedVideoDecoders,
-                           Optional<Integer> hdQualityThreshold,
+                           Optional<Integer> hdQualityBitrateThreshold,
                            SubtitleDecoderFactory subtitleDecoderFactory) {
         this.context = context;
         this.extensionRendererMode = extensionRendererMode;
@@ -131,7 +131,7 @@ class SimpleRenderersFactory implements RenderersFactory {
         this.allowFallbackDecoder = allowFallbackDecoder;
         this.requiresSecureDecoder = requiresSecureDecoder;
         this.unsupportedVideoDecoders = unsupportedVideoDecoders;
-        this.hdQualityThreshold = hdQualityThreshold;
+        this.hdQualityBitrateThreshold = hdQualityBitrateThreshold;
         this.subtitleDecoderFactory = subtitleDecoderFactory;
     }
 
@@ -188,7 +188,7 @@ class SimpleRenderersFactory implements RenderersFactory {
                     ENABLE_DECODER_FALLBACK,
                     requiresSecureDecoder,
                     unsupportedVideoDecoders,
-                    hdQualityThreshold,
+                    hdQualityBitrateThreshold,
                     eventHandler,
                     eventListener,
                     MAX_DROPPED_VIDEO_FRAME_COUNT_TO_NOTIFY

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacadeTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacadeTest.java
@@ -35,6 +35,9 @@ import com.novoda.noplayer.model.PlayerSubtitleTrack;
 import com.novoda.noplayer.model.PlayerVideoTrack;
 import com.novoda.noplayer.model.PlayerVideoTrackFixture;
 
+import java.util.Collections;
+import java.util.List;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -45,9 +48,6 @@ import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
-
-import java.util.Collections;
-import java.util.List;
 
 import utils.ExceptionMatcher;
 
@@ -793,6 +793,7 @@ public class ExoPlayerFacadeTest {
         static final float ANY_VOLUME = 0.5f;
         static final boolean allowFallbackDecoder = true;
         static final boolean requiresSecureDecoder = true;
+        static final List<String> unsupportedVideoDecoders = Collections.emptyList();
 
         @Rule
         public MockitoRule mockitoRule = MockitoJUnit.rule();
@@ -850,7 +851,7 @@ public class ExoPlayerFacadeTest {
             given(exoPlayerForwarder.advertListener()).willReturn(optionalAdvertListener);
             given(bandwidthMeterCreator.create(anyLong())).willReturn(defaultBandwidthMeter);
             given(trackSelectorCreator.create(any(Options.class), eq(defaultBandwidthMeter))).willReturn(trackSelector);
-            given(exoPlayerCreator.create(drmSessionCreator, drmSessionEventListener, allowFallbackDecoder, requiresSecureDecoder, trackSelector.trackSelector())).willReturn(exoPlayer);
+            given(exoPlayerCreator.create(drmSessionCreator, drmSessionEventListener, allowFallbackDecoder, requiresSecureDecoder, unsupportedVideoDecoders, trackSelector.trackSelector())).willReturn(exoPlayer);
             willDoNothing().given(exoPlayer).seekTo(anyInt());
             given(rendererTypeRequesterCreator.createfrom(exoPlayer)).willReturn(rendererTypeRequester);
             facade = new ExoPlayerFacade(

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacadeTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacadeTest.java
@@ -793,7 +793,6 @@ public class ExoPlayerFacadeTest {
         static final float ANY_VOLUME = 0.5f;
         static final boolean allowFallbackDecoder = true;
         static final boolean requiresSecureDecoder = true;
-        static final List<String> unsupportedVideoDecoders = Collections.emptyList();
 
         @Rule
         public MockitoRule mockitoRule = MockitoJUnit.rule();
@@ -851,7 +850,7 @@ public class ExoPlayerFacadeTest {
             given(exoPlayerForwarder.advertListener()).willReturn(optionalAdvertListener);
             given(bandwidthMeterCreator.create(anyLong())).willReturn(defaultBandwidthMeter);
             given(trackSelectorCreator.create(any(Options.class), eq(defaultBandwidthMeter))).willReturn(trackSelector);
-            given(exoPlayerCreator.create(drmSessionCreator, drmSessionEventListener, allowFallbackDecoder, requiresSecureDecoder, unsupportedVideoDecoders, trackSelector.trackSelector())).willReturn(exoPlayer);
+            given(exoPlayerCreator.create(drmSessionCreator, drmSessionEventListener, allowFallbackDecoder, requiresSecureDecoder, OPTIONS, trackSelector.trackSelector())).willReturn(exoPlayer);
             willDoNothing().given(exoPlayer).seekTo(anyInt());
             given(rendererTypeRequesterCreator.createfrom(exoPlayer)).willReturn(rendererTypeRequester);
             facade = new ExoPlayerFacade(

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacadeTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacadeTest.java
@@ -187,6 +187,7 @@ public class ExoPlayerFacadeTest {
             Options options = OPTIONS.toOptionsBuilder()
                     .withInitialAdvertBreakPositionInMillis(TWENTY_FIVE_SECONDS_IN_MILLIS)
                     .build();
+            given(exoPlayerCreator.create(drmSessionCreator, drmSessionEventListener, allowFallbackDecoder, requiresSecureDecoder, options, trackSelector.trackSelector())).willReturn(exoPlayer);
             given(optionalAdsLoader.isPresent()).willReturn(true);
             given(optionalAdsLoader.get()).willReturn(adsLoader);
 
@@ -200,6 +201,7 @@ public class ExoPlayerFacadeTest {
             Options options = OPTIONS.toOptionsBuilder()
                     .withInitialPositionInMillis(TWENTY_FIVE_SECONDS_IN_MILLIS)
                     .build();
+            given(exoPlayerCreator.create(drmSessionCreator, drmSessionEventListener, allowFallbackDecoder, requiresSecureDecoder, options, trackSelector.trackSelector())).willReturn(exoPlayer);
             given(optionalAdsLoader.isPresent()).willReturn(true);
             given(optionalAdsLoader.get()).willReturn(adsLoader);
 
@@ -275,6 +277,7 @@ public class ExoPlayerFacadeTest {
             Options options = OPTIONS.toOptionsBuilder()
                     .withInitialPositionInMillis(TWENTY_FIVE_SECONDS_IN_MILLIS)
                     .build();
+            given(exoPlayerCreator.create(drmSessionCreator, drmSessionEventListener, allowFallbackDecoder, requiresSecureDecoder, options, trackSelector.trackSelector())).willReturn(exoPlayer);
             MediaSource mediaSource = givenMediaSource(options);
 
             facade.loadVideo(surfaceViewHolder, drmSessionCreator, uri, options, exoPlayerForwarder, allowFallbackDecoder, requiresSecureDecoder);
@@ -424,6 +427,7 @@ public class ExoPlayerFacadeTest {
 
         private void givenPlayerIsLoaded() {
             givenMediaSource(OPTIONS);
+            given(exoPlayerCreator.create(drmSessionCreator, drmSessionEventListener, allowFallbackDecoder, requiresSecureDecoder, OPTIONS, trackSelector.trackSelector())).willReturn(exoPlayer);
             facade.loadVideo(surfaceViewHolder, drmSessionCreator, uri, OPTIONS, exoPlayerForwarder, allowFallbackDecoder, requiresSecureDecoder);
         }
 
@@ -837,6 +841,8 @@ public class ExoPlayerFacadeTest {
         SurfaceView surfaceView;
         @Mock
         TextureView textureView;
+        @Mock
+        ExoPlayerCreator exoPlayerCreator;
         PlayerSurfaceHolder surfaceViewHolder;
         PlayerSurfaceHolder textureViewHolder;
 
@@ -844,7 +850,6 @@ public class ExoPlayerFacadeTest {
 
         @Before
         public void setUp() {
-            ExoPlayerCreator exoPlayerCreator = mock(ExoPlayerCreator.class);
             given(exoPlayerForwarder.drmSessionEventListener()).willReturn(drmSessionEventListener);
             given(exoPlayerForwarder.mediaSourceEventListener()).willReturn(mediaSourceEventListener);
             given(exoPlayerForwarder.advertListener()).willReturn(optionalAdvertListener);

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/InternalMediaCodecUtilTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/InternalMediaCodecUtilTest.java
@@ -1,0 +1,27 @@
+package com.novoda.noplayer.internal.exoplayer;
+
+import com.google.android.exoplayer2.mediacodec.MediaCodecInfo;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+
+public class InternalMediaCodecUtilTest {
+
+    private final MediaCodecInfo firstMediaCodec = MediaCodecInfo.newInstance("first.codec.name", "video/mp4", null);
+    private final MediaCodecInfo secondMediaCodec = MediaCodecInfo.newInstance("second.codec.name", "video/mp4", null);
+    private final MediaCodecInfo thirdMediaCodec = MediaCodecInfo.newInstance("third.codec.name", "video/mp4", null);
+
+    @Test
+    public void removesUnsupportedCodecs() {
+        List<MediaCodecInfo> deviceMediaCodecs = Arrays.asList(firstMediaCodec, secondMediaCodec, thirdMediaCodec);
+        List<String> unsupportedMediaCodec = Arrays.asList("first.codec.name", "third.codec.name");
+
+        List<MediaCodecInfo> mediaCodecInfos = InternalMediaCodecUtil.removeUnsupportedVideoDecoders(deviceMediaCodecs, unsupportedMediaCodec);
+
+        assertThat(mediaCodecInfos).containsExactly(secondMediaCodec);
+    }
+}

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/InternalMediaCodecUtilTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/InternalMediaCodecUtilTest.java
@@ -1,5 +1,6 @@
 package com.novoda.noplayer.internal.exoplayer;
 
+import com.google.android.exoplayer2.Format;
 import com.google.android.exoplayer2.mediacodec.MediaCodecInfo;
 
 import java.util.Arrays;
@@ -11,17 +12,39 @@ import static org.fest.assertions.api.Assertions.assertThat;
 
 public class InternalMediaCodecUtilTest {
 
-    private final MediaCodecInfo firstMediaCodec = MediaCodecInfo.newInstance("first.codec.name", "video/mp4", null);
+    private static final int HD_QUALITY_THRESHOLD = 1000;
+
+    private static final Format HD_FORMAT = Format.createVideoSampleFormat(null, null, null, 1000, 0, 0, 0, 0, null, null);
+    private static final Format STANDARD_FORMAT = Format.createVideoSampleFormat(null, null, null, 999, 0, 0, 0, 0, null, null);
+    private final MediaCodecInfo firstMediaCodec = MediaCodecInfo.newInstance("first.codec.name.secure", "video/mp4", null, false, true);
     private final MediaCodecInfo secondMediaCodec = MediaCodecInfo.newInstance("second.codec.name", "video/mp4", null);
     private final MediaCodecInfo thirdMediaCodec = MediaCodecInfo.newInstance("third.codec.name", "video/mp4", null);
 
     @Test
     public void removesUnsupportedCodecs() {
         List<MediaCodecInfo> deviceMediaCodecs = Arrays.asList(firstMediaCodec, secondMediaCodec, thirdMediaCodec);
-        List<String> unsupportedMediaCodec = Arrays.asList("first.codec.name", "third.codec.name");
+        List<String> unsupportedMediaCodec = Arrays.asList("first.codec.name.secure", "third.codec.name");
 
         List<MediaCodecInfo> mediaCodecInfos = InternalMediaCodecUtil.removeUnsupportedVideoDecoders(deviceMediaCodecs, unsupportedMediaCodec);
 
         assertThat(mediaCodecInfos).containsExactly(secondMediaCodec);
+    }
+
+    @Test
+    public void returnsOriginalDecoderInfos_whenFormatIsNotHighDefinition() {
+        List<MediaCodecInfo> deviceMediaCodecs = Arrays.asList(firstMediaCodec, secondMediaCodec, thirdMediaCodec);
+
+        List<MediaCodecInfo> mediaCodecInfos = InternalMediaCodecUtil.removeAllUnsecureDecodersFromHdTrack(STANDARD_FORMAT, deviceMediaCodecs, HD_QUALITY_THRESHOLD);
+
+        assertThat(mediaCodecInfos).containsExactly(firstMediaCodec, secondMediaCodec, thirdMediaCodec);
+    }
+
+    @Test
+    public void removesAllUnsecureDecoders_whenFormatIsHighDefinition() {
+        List<MediaCodecInfo> deviceMediaCodecs = Arrays.asList(firstMediaCodec, secondMediaCodec, thirdMediaCodec);
+
+        List<MediaCodecInfo> mediaCodecInfos = InternalMediaCodecUtil.removeAllUnsecureDecodersFromHdTrack(HD_FORMAT, deviceMediaCodecs, HD_QUALITY_THRESHOLD);
+
+        assertThat(mediaCodecInfos).containsExactly(firstMediaCodec);
     }
 }

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -26,7 +26,7 @@ dependencies {
     implementation project(':core')
     implementation 'com.google.android.exoplayer:exoplayer:2.10.1'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
-    implementation 'com.google.android.material:material:1.1.0-alpha07'
+    implementation 'com.google.android.material:material:1.1.0-alpha08'
     implementation 'androidx.appcompat:appcompat:1.0.2'
     testImplementation 'junit:junit:4.12'
     testImplementation 'com.google.truth:truth:0.44'

--- a/demo/src/main/java/com/novoda/demo/DialogCreator.java
+++ b/demo/src/main/java/com/novoda/demo/DialogCreator.java
@@ -17,7 +17,7 @@ import java.util.Locale;
 
 class DialogCreator {
 
-    private static final String VIDEO_TRACK_MESSAGE_FORMAT = "ID: %s Quality: %s, Codec: %s, Decoder: %s";
+    private static final String VIDEO_TRACK_MESSAGE_FORMAT = "ID: %s Quality: %s, Codec: %s, Decoder: %s, Bitrate: %s";
     private static final String AUDIO_TRACK_MESSAGE_FORMAT = "ID: %s Type: %s";
     private static final int AUTO_TRACK_POSITION = 0;
 
@@ -58,7 +58,8 @@ class DialogCreator {
                     videoTrack.id(),
                     videoTrack.height(),
                     videoTrack.codecName(),
-                    videoTrack.associatedDecoderName()
+                    videoTrack.associatedDecoderName(),
+                    videoTrack.bitrate()
             );
             labels.add(message);
         }


### PR DESCRIPTION
## Problem
We want to be able to remove unsupported codecs from the list of available codecs when preparing a track for playback. Additionally we want to force all tracks that are considered to be HD to use `secure` codecs. 

## Solution
Introduce two new parameters to the `Options` interface:

`withSecureDecoderRequiredForHD(int hdQualityBitrateThreshold)` - above which the track will remove all codecs that are not secure. 

`withUnsupportedVideoDecoders(List<String> unsupportedVideoDecoders)` - the names of the codecs that should be removed from all tracks.

### Test(s) added 
Yes. All of the changes related to stripping out codecs is done on the `InternalMediaCodecUtil` so these new methods have been tested.

### Screenshots
Shows removing the codec from the HD track.

![device-2019-07-19-152254](https://user-images.githubusercontent.com/3380092/61544843-22cc0100-aa3e-11e9-9272-cbb564e46743.png)


### Paired with 
Nobody.
