### PR TITLE
Return undefined video type when timeline is empty

### DIFF
--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
@@ -1,7 +1,7 @@
 package com.novoda.noplayer.internal.exoplayer;
 
 import android.net.Uri;
-
+import androidx.annotation.Nullable;
 import com.google.android.exoplayer2.C;
 import com.google.android.exoplayer2.Player;
 import com.google.android.exoplayer2.SimpleExoPlayer;
@@ -25,8 +25,6 @@ import com.novoda.noplayer.model.PlayerSubtitleTrack;
 import com.novoda.noplayer.model.PlayerVideoTrack;
 
 import java.util.List;
-
-import androidx.annotation.Nullable;
 
 // Not much we can do, wrapping ExoPlayer is a lot of work
 @SuppressWarnings("PMD.GodClass")
@@ -73,7 +71,7 @@ class ExoPlayerFacade {
     }
 
     PlayerState.VideoType videoType() {
-        if (exoPlayer == null) {
+        if (exoPlayer == null || exoPlayer.getCurrentTimeline().isEmpty()) {
             return PlayerState.VideoType.UNDEFINED;
         }
         if (exoPlayer.isPlayingAd()) {

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacadeTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacadeTest.java
@@ -4,7 +4,6 @@ import android.net.Uri;
 import android.view.SurfaceHolder;
 import android.view.SurfaceView;
 import android.view.TextureView;
-
 import com.google.android.exoplayer2.C;
 import com.google.android.exoplayer2.Player;
 import com.google.android.exoplayer2.SimpleExoPlayer;
@@ -34,10 +33,6 @@ import com.novoda.noplayer.model.PlayerAudioTrackFixture;
 import com.novoda.noplayer.model.PlayerSubtitleTrack;
 import com.novoda.noplayer.model.PlayerVideoTrack;
 import com.novoda.noplayer.model.PlayerVideoTrackFixture;
-
-import java.util.Collections;
-import java.util.List;
-
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -48,8 +43,10 @@ import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
-
 import utils.ExceptionMatcher;
+
+import java.util.Collections;
+import java.util.List;
 
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -487,6 +484,16 @@ public class ExoPlayerFacadeTest {
         }
 
         @Test
+        public void givenExoPlayerTimelineIsEmpty_whenQueryingVideoType_thenReturnsUndefined() {
+            given(exoPlayer.isPlayingAd()).willReturn(IS_PLAYING);
+            given(timeline.isEmpty()).willReturn(true);
+
+            PlayerState.VideoType videoType = facade.videoType();
+
+            assertThat(videoType).isEqualTo(PlayerState.VideoType.UNDEFINED);
+        }
+
+        @Test
         public void givenExoPlayerIsPlayingAd_whenQueryingVideoType_thenReturnsAdvert() {
             given(exoPlayer.isPlayingAd()).willReturn(IS_PLAYING);
 
@@ -843,6 +850,8 @@ public class ExoPlayerFacadeTest {
         TextureView textureView;
         @Mock
         ExoPlayerCreator exoPlayerCreator;
+        @Mock
+        Timeline timeline;
         PlayerSurfaceHolder surfaceViewHolder;
         PlayerSurfaceHolder textureViewHolder;
 
@@ -858,6 +867,7 @@ public class ExoPlayerFacadeTest {
             given(exoPlayerCreator.create(drmSessionCreator, drmSessionEventListener, allowFallbackDecoder, requiresSecureDecoder, OPTIONS, trackSelector.trackSelector())).willReturn(exoPlayer);
             willDoNothing().given(exoPlayer).seekTo(anyInt());
             given(rendererTypeRequesterCreator.createfrom(exoPlayer)).willReturn(rendererTypeRequester);
+            given(exoPlayer.getCurrentTimeline()).willReturn(timeline);
             facade = new ExoPlayerFacade(
                     bandwidthMeterCreator,
                     androidDeviceVersion,


### PR DESCRIPTION
## Problem

`getVideoType` would fallback to `CONTENT` also in case when the player doesn't have any information about the content type yet.

## Solution

The solution is to just check if `Timeline` is empty or not before asking ExoPlayer if it's playing an advert. This is the same check that is used inside `ExoPlayerImpl#isPlayingAd` where ExoPlayer doesn't have enough information to say if it's playing an advert or not so it just returns `false`.

### Test(s) added 

yes a new test for this case

### Screenshots
no changes

### Paired with 

nobody
