### PR TITLE
NO-272/Advert Tests

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -65,7 +65,7 @@ dependencies {
     implementation 'androidx.annotation:annotation:1.1.0'
 
     testImplementation 'junit:junit:4.12'
-    testImplementation 'org.mockito:mockito-core:2.28.2'
+    testImplementation 'org.mockito:mockito-core:3.0.0'
     testImplementation 'org.easytesting:fest-assert-core:2.0M10'
 }
 

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/AdvertState.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/AdvertState.java
@@ -17,6 +17,8 @@ class AdvertState {
         void onAdvertsEnabled();
 
         void onAdvertBreakSkipped(int advertBreakIndex);
+
+        void onAdvertSkipped(int advertBreakIndex, int advertIndex);
     }
 
     private static final int INVALID_INDEX = -1;
@@ -91,10 +93,10 @@ class AdvertState {
             return;
         }
 
-        resetState();
         advertsDisabled = true;
         callback.onAdvertsDisabled();
         advertListener.onAdvertsDisabled();
+        resetState();
     }
 
     void enableAdverts() {
@@ -102,10 +104,10 @@ class AdvertState {
             return;
         }
 
-        resetState();
         advertsDisabled = false;
         callback.onAdvertsEnabled();
         advertListener.onAdvertsEnabled(advertBreaks);
+        resetState();
     }
 
     void skipAdvertBreak() {
@@ -115,6 +117,21 @@ class AdvertState {
 
         callback.onAdvertBreakSkipped(advertBreakIndex);
         advertListener.onAdvertBreakSkipped(advertBreaks.get(advertBreakIndex));
+        resetState();
+    }
+
+    void skipAdvert() {
+        if (advertsDisabled || advertBreakIndex < 0 || advertIndex < 0) {
+            return;
+        }
+
+        callback.onAdvertSkipped(advertBreakIndex, advertIndex);
+        AdvertBreak advertBreak = advertBreaks.get(advertBreakIndex);
+        List<Advert> adverts = advertBreak.adverts();
+        advertListener.onAdvertSkipped(adverts.get(advertIndex));
+        if (advertIndex == adverts.size() - 1) {
+            advertListener.onAdvertBreakEnd(advertBreak);
+        }
         resetState();
     }
 

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/AdvertState.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/AdvertState.java
@@ -13,6 +13,8 @@ class AdvertState {
         void onAdvertPlayed(int advertBreakIndex, int advertIndex);
 
         void onAdvertsDisabled();
+
+        void onAdvertsEnabled();
     }
 
     private static final int INVALID_INDEX = -1;
@@ -94,7 +96,14 @@ class AdvertState {
     }
 
     void enableAdverts() {
+        if (!advertsDisabled) {
+            return;
+        }
 
+        resetState();
+        advertsDisabled = false;
+        callback.onAdvertsEnabled();
+        advertListener.onAdvertsEnabled(advertBreaks);
     }
 
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/AdvertState.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/AdvertState.java
@@ -20,7 +20,7 @@ class AdvertState {
 
         void onAdvertPlayed(int advertBreakIndex, int advertIndex);
 
-        void onAdvertsDisabled();
+        void onAdvertsDisabled(List<AdvertBreak> advertBreaks);
 
         void onAdvertsEnabled(List<AdvertBreak> advertBreaks);
 
@@ -102,7 +102,7 @@ class AdvertState {
         }
 
         advertsDisabled = true;
-        callback.onAdvertsDisabled();
+        callback.onAdvertsDisabled(advertBreaks);
         resetState();
     }
 

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/AdvertState.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/AdvertState.java
@@ -15,6 +15,8 @@ class AdvertState {
         void onAdvertsDisabled();
 
         void onAdvertsEnabled();
+
+        void onAdvertBreakSkipped(int advertBreakIndex);
     }
 
     private static final int INVALID_INDEX = -1;
@@ -104,6 +106,16 @@ class AdvertState {
         advertsDisabled = false;
         callback.onAdvertsEnabled();
         advertListener.onAdvertsEnabled(advertBreaks);
+    }
+
+    void skipAdvertBreak() {
+        if (advertsDisabled || advertBreakIndex < 0) {
+            return;
+        }
+
+        callback.onAdvertBreakSkipped(advertBreakIndex);
+        advertListener.onAdvertBreakSkipped(advertBreaks.get(advertBreakIndex));
+        resetState();
     }
 
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/AdvertState.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/AdvertState.java
@@ -174,10 +174,10 @@ class AdvertState {
     }
 
     void stop(long stopPositionInMillis) {
-        resetState();
-
         if (playingAdvert) {
             callback.markAdvertResumePosition(stopPositionInMillis);
         }
+
+        resetState();
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/AdvertState.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/AdvertState.java
@@ -1,5 +1,6 @@
 package com.novoda.noplayer.internal.exoplayer;
 
+import com.google.android.exoplayer2.C;
 import com.novoda.noplayer.Advert;
 import com.novoda.noplayer.AdvertBreak;
 import com.novoda.noplayer.NoPlayer;
@@ -144,4 +145,16 @@ class AdvertState {
         advertListener.onAdvertClicked(advert);
     }
 
+    long advertDurationBy(int advertBreakIndex, int advertIndex) {
+        if (advertBreakIndex >= advertBreaks.size()) {
+            throw new IllegalStateException("Advert is being played but no data about advert breaks is cached.");
+        }
+
+        AdvertBreak advertBreak = advertBreaks.get(advertBreakIndex);
+        if (advertIndex >= advertBreak.adverts().size()) {
+            throw new IllegalStateException("Cached advert break data contains less adverts than current index.");
+        }
+
+        return C.msToUs(advertBreak.adverts().get(advertIndex).durationInMillis());
+    }
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/AdvertState.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/AdvertState.java
@@ -135,4 +135,13 @@ class AdvertState {
         resetState();
     }
 
+    void clickAdvert() {
+        if (advertBreakIndex < 0 || advertIndex < 0) {
+            return;
+        }
+
+        Advert advert = advertBreaks.get(advertBreakIndex).adverts().get(advertIndex);
+        advertListener.onAdvertClicked(advert);
+    }
+
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/AdvertState.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/AdvertState.java
@@ -1,0 +1,100 @@
+package com.novoda.noplayer.internal.exoplayer;
+
+import com.novoda.noplayer.Advert;
+import com.novoda.noplayer.AdvertBreak;
+import com.novoda.noplayer.NoPlayer;
+
+import java.util.List;
+
+class AdvertState {
+
+    interface Callback {
+
+        void onAdvertPlayed(int advertBreakIndex, int advertIndex);
+
+        void onAdvertsDisabled();
+    }
+
+    private static final int INVALID_INDEX = -1;
+
+    private final List<AdvertBreak> advertBreaks;
+    private final NoPlayer.AdvertListener advertListener;
+    private final Callback callback;
+
+    private int advertIndex = -1;
+    private int advertBreakIndex = -1;
+    private boolean playingAdvert;
+    private boolean advertsDisabled;
+
+    AdvertState(List<AdvertBreak> advertBreaks, NoPlayer.AdvertListener advertListener, Callback callback) {
+        this.advertBreaks = advertBreaks;
+        this.advertListener = advertListener;
+        this.callback = callback;
+    }
+
+    void update(boolean isPlayingAdvert, int currentAdvertBreakIndex, int currentAdvertIndex) {
+        boolean wasPlayingAd = playingAdvert;
+        playingAdvert = isPlayingAdvert;
+
+        int previousAdvertBreakIndex = advertBreakIndex;
+        int previousAdvertIndex = advertIndex;
+
+        advertBreakIndex = playingAdvert ? currentAdvertBreakIndex : INVALID_INDEX;
+        advertIndex = playingAdvert ? currentAdvertIndex : INVALID_INDEX;
+        boolean advertFinished = wasPlayingAd && advertIndex != previousAdvertIndex;
+
+        if (advertFinished) {
+            callback.onAdvertPlayed(previousAdvertBreakIndex, previousAdvertIndex);
+            notifyAdvertEnd(previousAdvertBreakIndex, previousAdvertIndex);
+        }
+
+        boolean advertStarted = isPlayingAdvert && advertIndex != previousAdvertIndex;
+        if (advertStarted) {
+            notifyAdvertStart(advertBreakIndex, advertIndex);
+        }
+    }
+
+    private void notifyAdvertEnd(int playedAdvertBreakIndex, int playedAdvertIndex) {
+        AdvertBreak advertBreak = advertBreaks.get(playedAdvertBreakIndex);
+        List<Advert> adverts = advertBreak.adverts();
+        advertListener.onAdvertEnd(adverts.get(playedAdvertIndex));
+
+        if (advertBreakIndex != playedAdvertBreakIndex) {
+            advertListener.onAdvertBreakEnd(advertBreak);
+            resetState();
+        }
+    }
+
+    private void resetState() {
+        advertBreakIndex = -1;
+        advertIndex = -1;
+        playingAdvert = false;
+    }
+
+    private void notifyAdvertStart(int advertBreakIndex, int advertIndex) {
+        AdvertBreak advertBreak = advertBreaks.get(advertBreakIndex);
+
+        if (advertIndex == 0) {
+            advertListener.onAdvertBreakStart(advertBreak);
+        }
+
+        Advert advert = advertBreak.adverts().get(advertIndex);
+        advertListener.onAdvertStart(advert);
+    }
+
+    void disableAdverts() {
+        if (advertsDisabled) {
+            return;
+        }
+
+        resetState();
+        advertsDisabled = true;
+        callback.onAdvertsDisabled();
+        advertListener.onAdvertsDisabled();
+    }
+
+    void enableAdverts() {
+
+    }
+
+}

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
@@ -35,6 +35,8 @@ public class NoPlayerAdsLoader implements AdsLoader, Player.EventListener, Adver
     @Nullable
     private AdPlaybackState adPlaybackState;
     @Nullable
+    private AdvertState advertState;
+    @Nullable
     private EventListener eventListener;
     @Nullable
     private AdvertsLoader.Cancellable loadingAds;

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
@@ -143,7 +143,7 @@ public class NoPlayerAdsLoader implements AdsLoader, Player.EventListener, Adver
             loadingAds.cancel();
             loadingAds = null;
         }
-        if (adPlaybackState != null && player != null) {
+        if (adPlaybackState != null && player != null && advertState != null) {
             advertState.stop(player.getCurrentPosition());
         }
         eventListener = null;

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/AdvertStateTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/AdvertStateTest.java
@@ -60,7 +60,7 @@ public class AdvertStateTest {
     );
 
     @Test
-    public void emitsNoEvents_whenNotPlayingAdvert() {
+    public void emitsNoEvents_whenNotTransitioningToAdverts() {
         advertState.update(IS_NOT_PLAYING_ADVERT, UNSET_ADVERT_BREAK_INDEX, UNSET_ADVERT_INDEX);
 
         then(advertListener).shouldHaveZeroInteractions();
@@ -68,7 +68,7 @@ public class AdvertStateTest {
     }
 
     @Test
-    public void notifiesStartOfAdvertBreak_andAdvert_whenPlayingAdvert() {
+    public void notifiesStartOfAdvertBreak_andAdvert_whenTransitioningToAdverts() {
         advertState.update(IS_PLAYING_ADVERT, 0, 0);
 
         InOrder inOrder = Mockito.inOrder(advertListener);
@@ -79,7 +79,7 @@ public class AdvertStateTest {
     }
 
     @Test
-    public void emitsNoAdditionalEvents_whenCallingWithSameAdvertIndex() {
+    public void emitsNoAdditionalEvents_whenCallingWithTheSameIndices() {
         advertState.update(IS_PLAYING_ADVERT, 0, 0);
         Mockito.reset(advertListener, callback);
         advertState.update(IS_PLAYING_ADVERT, 0, 0);
@@ -89,7 +89,7 @@ public class AdvertStateTest {
     }
 
     @Test
-    public void notifiesEndAdvertBreak_andAdvert_whenPlayingContent() {
+    public void notifiesEndOfAdvertBreak_andAdvert_whenTransitioningToContent() {
         advertState.update(IS_PLAYING_ADVERT, 0, 0);
         Mockito.reset(advertListener, callback);
         advertState.update(IS_NOT_PLAYING_ADVERT, UNSET_ADVERT_BREAK_INDEX, UNSET_ADVERT_INDEX);
@@ -117,7 +117,7 @@ public class AdvertStateTest {
     }
 
     @Test
-    public void notifiesAdvertsDisabled() {
+    public void disablesAdverts() {
         advertState.disableAdverts();
 
         InOrder inOrder = Mockito.inOrder(advertListener, callback);
@@ -128,7 +128,7 @@ public class AdvertStateTest {
     }
 
     @Test
-    public void emitsNoEvents_whenAlreadyDisabled() {
+    public void doesNotDisableAdverts_whenAlreadyDisabled() {
         advertState.disableAdverts();
         Mockito.reset(advertListener, callback);
         advertState.disableAdverts();
@@ -138,7 +138,7 @@ public class AdvertStateTest {
     }
 
     @Test
-    public void notifiesAdvertsEnabled() {
+    public void enablesAdverts() {
         advertState.disableAdverts();
         Mockito.reset(advertListener, callback);
         advertState.enableAdverts();
@@ -151,10 +151,51 @@ public class AdvertStateTest {
     }
 
     @Test
-    public void emitsNoEvents_whenAlreadyEnabled() {
+    public void doesNotEnableAdverts_whenAlreadyEnabled() {
         advertState.enableAdverts();
 
         then(advertListener).shouldHaveZeroInteractions();
         then(callback).shouldHaveZeroInteractions();
+    }
+
+    @Test
+    public void doesNotSkipAdvertBreak_whenDisabled() {
+        advertState.disableAdverts();
+        Mockito.reset(advertListener, callback);
+        advertState.skipAdvertBreak();
+
+        then(advertListener).shouldHaveZeroInteractions();
+        then(callback).shouldHaveZeroInteractions();
+    }
+
+    @Test
+    public void doesNotSkipAdvertBreak_whenNotPlaying() {
+        advertState.skipAdvertBreak();
+
+        then(advertListener).shouldHaveZeroInteractions();
+        then(callback).shouldHaveZeroInteractions();
+    }
+
+    @Test
+    public void doesNotSkipAdvertBreak_whenPlayingContent() {
+        advertState.update(false, UNSET_ADVERT_BREAK_INDEX, UNSET_ADVERT_INDEX);
+        Mockito.reset(advertListener, callback);
+        advertState.skipAdvertBreak();
+
+        then(advertListener).shouldHaveZeroInteractions();
+        then(callback).shouldHaveZeroInteractions();
+    }
+
+    @Test
+    public void skipsAdvertBreak_whenPlayingAdverts() {
+        advertState.update(true, 0, 0);
+        Mockito.reset(advertListener, callback);
+        advertState.skipAdvertBreak();
+
+        InOrder inOrder = Mockito.inOrder(advertListener, callback);
+        then(callback).should(inOrder).onAdvertBreakSkipped(0);
+        then(advertListener).should(inOrder).onAdvertBreakSkipped(FIRST_ADVERT_BREAK);
+        then(callback).shouldHaveNoMoreInteractions();
+        then(advertListener).shouldHaveNoMoreInteractions();
     }
 }

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/AdvertStateTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/AdvertStateTest.java
@@ -10,7 +10,6 @@ import java.util.List;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.mockito.InOrder;
 import org.mockito.Mockito;
 
 import utils.ExceptionMatcher;
@@ -96,7 +95,6 @@ public class AdvertStateTest {
         Mockito.reset(callback);
         advertState.update(IS_NOT_PLAYING_ADVERT, UNSET_ADVERT_BREAK_INDEX, UNSET_ADVERT_INDEX);
 
-        InOrder inOrder = Mockito.inOrder(callback);
         then(callback).should().onAdvertPlayed(0, 0);
         then(callback).should().onAdvertEnd(FIRST_ADVERT);
         then(callback).should().onAdvertBreakEnd(FIRST_ADVERT_BREAK);
@@ -118,8 +116,7 @@ public class AdvertStateTest {
     public void disablesAdverts() {
         advertState.disableAdverts();
 
-        then(callback).should().onAdvertsDisabled(advertBreaks);
-        then(callback).should().onAdvertsDisabled(advertBreaks);
+        then(callback).should().onAdvertsDisabled(ADVERT_BREAKS);
         then(callback).shouldHaveNoMoreInteractions();
     }
 

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/AdvertStateTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/AdvertStateTest.java
@@ -1,0 +1,139 @@
+package com.novoda.noplayer.internal.exoplayer;
+
+import com.novoda.noplayer.Advert;
+import com.novoda.noplayer.AdvertBreak;
+import com.novoda.noplayer.NoPlayer;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+
+import static com.novoda.noplayer.AdvertBreakFixtures.anAdvertBreak;
+import static com.novoda.noplayer.AdvertFixtures.anAdvert;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+
+public class AdvertStateTest {
+
+    private static final boolean IS_NOT_PLAYING_ADVERT = false;
+    private static final boolean IS_PLAYING_ADVERT = true;
+    private static final int UNSET_ADVERT_BREAK_INDEX = -1;
+    private static final int UNSET_ADVERT_INDEX = -1;
+    private static final int ONE_SECOND_IN_MILLIS = 1000;
+    private static final int TWO_SECONDS_IN_MILLIS = 2000;
+    private static final int THREE_SECONDS_IN_MILLIS = 3000;
+
+    private static final Advert FIRST_ADVERT = anAdvert()
+            .withDurationInMillis(ONE_SECOND_IN_MILLIS)
+            .build();
+    private static final Advert SECOND_ADVERT = anAdvert()
+            .withDurationInMillis(TWO_SECONDS_IN_MILLIS)
+            .build();
+    private static final Advert THIRD_ADVERT = anAdvert()
+            .withDurationInMillis(THREE_SECONDS_IN_MILLIS)
+            .build();
+
+    private static final AdvertBreak FIRST_ADVERT_BREAK = anAdvertBreak()
+            .withStartTimeInMillis(ONE_SECOND_IN_MILLIS)
+            .withAdvert(FIRST_ADVERT)
+            .build();
+    private static final AdvertBreak SECOND_ADVERT_BREAK = anAdvertBreak()
+            .withStartTimeInMillis(TWO_SECONDS_IN_MILLIS)
+            .withAdverts(FIRST_ADVERT, SECOND_ADVERT)
+            .build();
+    private static final AdvertBreak THIRD_ADVERT_BREAK = anAdvertBreak()
+            .withStartTimeInMillis(THREE_SECONDS_IN_MILLIS)
+            .withAdverts(FIRST_ADVERT, SECOND_ADVERT, THIRD_ADVERT)
+            .build();
+
+    private final List<AdvertBreak> ADVERT_BREAKS = Arrays.asList(FIRST_ADVERT_BREAK, SECOND_ADVERT_BREAK, THIRD_ADVERT_BREAK);
+    private final NoPlayer.AdvertListener advertListener = mock(NoPlayer.AdvertListener.class);
+    private final AdvertState.Callback callback = mock(AdvertState.Callback.class);
+
+    private final AdvertState advertState = new AdvertState(
+            ADVERT_BREAKS,
+            advertListener,
+            callback
+    );
+
+    @Test
+    public void emitsNoEvents_whenNotPlayingAdvert() {
+        advertState.update(IS_NOT_PLAYING_ADVERT, UNSET_ADVERT_BREAK_INDEX, UNSET_ADVERT_INDEX);
+
+        then(advertListener).shouldHaveZeroInteractions();
+        then(callback).shouldHaveZeroInteractions();
+    }
+
+    @Test
+    public void notifiesStartOfAdvertBreak_andAdvert_whenPlayingAdvert() {
+        advertState.update(IS_PLAYING_ADVERT, 0, 0);
+
+        InOrder inOrder = Mockito.inOrder(advertListener);
+        then(advertListener).should(inOrder).onAdvertBreakStart(FIRST_ADVERT_BREAK);
+        then(advertListener).should(inOrder).onAdvertStart(FIRST_ADVERT);
+        then(advertListener).shouldHaveNoMoreInteractions();
+        then(callback).shouldHaveZeroInteractions();
+    }
+
+    @Test
+    public void emitsNoAdditionalEvents_whenCallingWithSameAdvertIndex() {
+        advertState.update(IS_PLAYING_ADVERT, 0, 0);
+        Mockito.reset(advertListener, callback);
+        advertState.update(IS_PLAYING_ADVERT, 0, 0);
+
+        then(advertListener).shouldHaveZeroInteractions();
+        then(callback).shouldHaveZeroInteractions();
+    }
+
+    @Test
+    public void notifiesEndAdvertBreak_andAdvert_whenPlayingContent() {
+        advertState.update(IS_PLAYING_ADVERT, 0, 0);
+        Mockito.reset(advertListener, callback);
+        advertState.update(IS_NOT_PLAYING_ADVERT, UNSET_ADVERT_BREAK_INDEX, UNSET_ADVERT_INDEX);
+
+        InOrder inOrder = Mockito.inOrder(advertListener, callback);
+        then(callback).should(inOrder).onAdvertPlayed(0, 0);
+        then(advertListener).should(inOrder).onAdvertEnd(FIRST_ADVERT);
+        then(advertListener).should(inOrder).onAdvertBreakEnd(FIRST_ADVERT_BREAK);
+        then(callback).shouldHaveNoMoreInteractions();
+        then(advertListener).shouldHaveNoMoreInteractions();
+    }
+
+    @Test
+    public void transitionsBetweenAdverts() {
+        advertState.update(IS_PLAYING_ADVERT, 1, 0);
+        Mockito.reset(advertListener, callback);
+        advertState.update(IS_PLAYING_ADVERT, 1, 1);
+
+        InOrder inOrder = Mockito.inOrder(advertListener, callback);
+        then(callback).should(inOrder).onAdvertPlayed(1, 0);
+        then(advertListener).should(inOrder).onAdvertEnd(FIRST_ADVERT);
+        then(advertListener).should(inOrder).onAdvertStart(SECOND_ADVERT);
+        then(callback).shouldHaveNoMoreInteractions();
+        then(advertListener).shouldHaveNoMoreInteractions();
+    }
+
+    @Test
+    public void notifiesAdvertsDisabled() {
+        advertState.disableAdverts();
+
+        InOrder inOrder = Mockito.inOrder(advertListener, callback);
+        then(callback).should(inOrder).onAdvertsDisabled();
+        then(advertListener).should(inOrder).onAdvertsDisabled();
+        then(callback).shouldHaveNoMoreInteractions();
+        then(advertListener).shouldHaveNoMoreInteractions();
+    }
+
+    @Test
+    public void emitsNoEvents_whenAlreadyDisabled() {
+        advertState.disableAdverts();
+        Mockito.reset(advertListener, callback);
+        advertState.disableAdverts();
+
+        then(advertListener).shouldHaveZeroInteractions();
+        then(callback).shouldHaveZeroInteractions();
+    }
+}

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/AdvertStateTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/AdvertStateTest.java
@@ -136,4 +136,25 @@ public class AdvertStateTest {
         then(advertListener).shouldHaveZeroInteractions();
         then(callback).shouldHaveZeroInteractions();
     }
+
+    @Test
+    public void notifiesAdvertsEnabled() {
+        advertState.disableAdverts();
+        Mockito.reset(advertListener, callback);
+        advertState.enableAdverts();
+
+        InOrder inOrder = Mockito.inOrder(advertListener, callback);
+        then(callback).should(inOrder).onAdvertsEnabled();
+        then(advertListener).should(inOrder).onAdvertsEnabled(ADVERT_BREAKS);
+        then(callback).shouldHaveNoMoreInteractions();
+        then(advertListener).shouldHaveNoMoreInteractions();
+    }
+
+    @Test
+    public void emitsNoEvents_whenAlreadyEnabled() {
+        advertState.enableAdverts();
+
+        then(advertListener).shouldHaveZeroInteractions();
+        then(callback).shouldHaveZeroInteractions();
+    }
 }

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/AdvertStateTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/AdvertStateTest.java
@@ -253,4 +253,34 @@ public class AdvertStateTest {
         then(callback).shouldHaveNoMoreInteractions();
         then(advertListener).shouldHaveNoMoreInteractions();
     }
+
+    @Test
+    public void doesNotClickAdvert_whenPlayingContent() {
+        advertState.update(false, UNSET_ADVERT_BREAK_INDEX, UNSET_ADVERT_INDEX);
+        Mockito.reset(advertListener, callback);
+        advertState.clickAdvert();
+
+        then(advertListener).shouldHaveZeroInteractions();
+        then(callback).shouldHaveZeroInteractions();
+    }
+
+    @Test
+    public void doesNotClickAdvert_whenNotPlaying() {
+        advertState.clickAdvert();
+
+        then(advertListener).shouldHaveZeroInteractions();
+        then(callback).shouldHaveZeroInteractions();
+    }
+
+    @Test
+    public void clicksAdvert_whenPlayingAdverts() {
+        advertState.update(true, 0, 0);
+        Mockito.reset(advertListener, callback);
+        advertState.clickAdvert();
+
+        InOrder inOrder = Mockito.inOrder(advertListener, callback);
+        then(advertListener).should(inOrder).onAdvertClicked(FIRST_ADVERT);
+        then(callback).shouldHaveNoMoreInteractions();
+        then(advertListener).shouldHaveNoMoreInteractions();
+    }
 }

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/AdvertStateTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/AdvertStateTest.java
@@ -4,6 +4,7 @@ import com.google.android.exoplayer2.C;
 import com.novoda.noplayer.Advert;
 import com.novoda.noplayer.AdvertBreak;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
@@ -63,6 +64,15 @@ public class AdvertStateTest {
             ADVERT_BREAKS,
             callback
     );
+
+    @Test
+    public void handlesPrepareError() {
+        IOException ioException = new IOException("prepare error");
+
+        advertState.handlePrepareError(0, 0, ioException);
+
+        then(callback).should().onHandledPrepareError(0, 0, FIRST_ADVERT, ioException);
+    }
 
     @Test
     public void emitsNoEvents_whenNotTransitioningToAdverts() {

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/AdvertStateTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/AdvertStateTest.java
@@ -3,7 +3,6 @@ package com.novoda.noplayer.internal.exoplayer;
 import com.google.android.exoplayer2.C;
 import com.novoda.noplayer.Advert;
 import com.novoda.noplayer.AdvertBreak;
-import com.novoda.noplayer.NoPlayer;
 
 import java.util.Arrays;
 import java.util.List;
@@ -59,12 +58,10 @@ public class AdvertStateTest {
     public ExpectedException thrown = ExpectedException.none();
 
     private final List<AdvertBreak> ADVERT_BREAKS = Arrays.asList(FIRST_ADVERT_BREAK, SECOND_ADVERT_BREAK, THIRD_ADVERT_BREAK);
-    private final NoPlayer.AdvertListener advertListener = mock(NoPlayer.AdvertListener.class);
     private final AdvertState.Callback callback = mock(AdvertState.Callback.class);
 
     private final AdvertState advertState = new AdvertState(
             ADVERT_BREAKS,
-            advertListener,
             callback
     );
 
@@ -72,7 +69,6 @@ public class AdvertStateTest {
     public void emitsNoEvents_whenNotTransitioningToAdverts() {
         advertState.update(IS_NOT_PLAYING_ADVERT, UNSET_ADVERT_BREAK_INDEX, UNSET_ADVERT_INDEX);
 
-        then(advertListener).shouldHaveZeroInteractions();
         then(callback).shouldHaveZeroInteractions();
     }
 
@@ -80,100 +76,85 @@ public class AdvertStateTest {
     public void notifiesStartOfAdvertBreak_andAdvert_whenTransitioningToAdverts() {
         advertState.update(IS_PLAYING_ADVERT, 0, 0);
 
-        InOrder inOrder = Mockito.inOrder(advertListener);
-        then(advertListener).should(inOrder).onAdvertBreakStart(FIRST_ADVERT_BREAK);
-        then(advertListener).should(inOrder).onAdvertStart(FIRST_ADVERT);
-        then(advertListener).shouldHaveNoMoreInteractions();
-        then(callback).shouldHaveZeroInteractions();
+        then(callback).should().onAdvertBreakStart(FIRST_ADVERT_BREAK);
+        then(callback).should().onAdvertStart(FIRST_ADVERT);
+        then(callback).shouldHaveNoMoreInteractions();
     }
 
     @Test
     public void emitsNoAdditionalEvents_whenCallingWithTheSameIndices() {
         advertState.update(IS_PLAYING_ADVERT, 0, 0);
-        Mockito.reset(advertListener, callback);
+        Mockito.reset(callback);
         advertState.update(IS_PLAYING_ADVERT, 0, 0);
 
-        then(advertListener).shouldHaveZeroInteractions();
         then(callback).shouldHaveZeroInteractions();
     }
 
     @Test
     public void notifiesEndOfAdvertBreak_andAdvert_whenTransitioningToContent() {
         advertState.update(IS_PLAYING_ADVERT, 0, 0);
-        Mockito.reset(advertListener, callback);
+        Mockito.reset(callback);
         advertState.update(IS_NOT_PLAYING_ADVERT, UNSET_ADVERT_BREAK_INDEX, UNSET_ADVERT_INDEX);
 
-        InOrder inOrder = Mockito.inOrder(advertListener, callback);
-        then(callback).should(inOrder).onAdvertPlayed(0, 0);
-        then(advertListener).should(inOrder).onAdvertEnd(FIRST_ADVERT);
-        then(advertListener).should(inOrder).onAdvertBreakEnd(FIRST_ADVERT_BREAK);
+        InOrder inOrder = Mockito.inOrder(callback);
+        then(callback).should().onAdvertPlayed(0, 0);
+        then(callback).should().onAdvertEnd(FIRST_ADVERT);
+        then(callback).should().onAdvertBreakEnd(FIRST_ADVERT_BREAK);
         then(callback).shouldHaveNoMoreInteractions();
-        then(advertListener).shouldHaveNoMoreInteractions();
     }
 
     @Test
     public void transitionsBetweenAdverts() {
         advertState.update(IS_PLAYING_ADVERT, 1, 0);
-        Mockito.reset(advertListener, callback);
+        Mockito.reset(callback);
         advertState.update(IS_PLAYING_ADVERT, 1, 1);
 
-        InOrder inOrder = Mockito.inOrder(advertListener, callback);
-        then(callback).should(inOrder).onAdvertPlayed(1, 0);
-        then(advertListener).should(inOrder).onAdvertEnd(FIRST_ADVERT);
-        then(advertListener).should(inOrder).onAdvertStart(SECOND_ADVERT);
-        then(callback).shouldHaveNoMoreInteractions();
-        then(advertListener).shouldHaveNoMoreInteractions();
+        then(callback).should().onAdvertPlayed(1, 0);
+        then(callback).should().onAdvertEnd(FIRST_ADVERT);
+        then(callback).should().onAdvertStart(SECOND_ADVERT);
     }
 
     @Test
     public void disablesAdverts() {
         advertState.disableAdverts();
 
-        InOrder inOrder = Mockito.inOrder(advertListener, callback);
-        then(callback).should(inOrder).onAdvertsDisabled();
-        then(advertListener).should(inOrder).onAdvertsDisabled();
+        then(callback).should().onAdvertsDisabled();
+        then(callback).should().onAdvertsDisabled();
         then(callback).shouldHaveNoMoreInteractions();
-        then(advertListener).shouldHaveNoMoreInteractions();
     }
 
     @Test
     public void doesNotDisableAdverts_whenAlreadyDisabled() {
         advertState.disableAdverts();
-        Mockito.reset(advertListener, callback);
+        Mockito.reset(callback);
         advertState.disableAdverts();
 
-        then(advertListener).shouldHaveZeroInteractions();
         then(callback).shouldHaveZeroInteractions();
     }
 
     @Test
     public void enablesAdverts() {
         advertState.disableAdverts();
-        Mockito.reset(advertListener, callback);
+        Mockito.reset(callback);
         advertState.enableAdverts();
 
-        InOrder inOrder = Mockito.inOrder(advertListener, callback);
-        then(callback).should(inOrder).onAdvertsEnabled();
-        then(advertListener).should(inOrder).onAdvertsEnabled(ADVERT_BREAKS);
+        then(callback).should().onAdvertsEnabled(ADVERT_BREAKS);
         then(callback).shouldHaveNoMoreInteractions();
-        then(advertListener).shouldHaveNoMoreInteractions();
     }
 
     @Test
     public void doesNotEnableAdverts_whenAlreadyEnabled() {
         advertState.enableAdverts();
 
-        then(advertListener).shouldHaveZeroInteractions();
         then(callback).shouldHaveZeroInteractions();
     }
 
     @Test
     public void doesNotSkipAdvertBreak_whenDisabled() {
         advertState.disableAdverts();
-        Mockito.reset(advertListener, callback);
+        Mockito.reset(callback);
         advertState.skipAdvertBreak();
 
-        then(advertListener).shouldHaveZeroInteractions();
         then(callback).shouldHaveZeroInteractions();
     }
 
@@ -181,40 +162,34 @@ public class AdvertStateTest {
     public void doesNotSkipAdvertBreak_whenNotPlaying() {
         advertState.skipAdvertBreak();
 
-        then(advertListener).shouldHaveZeroInteractions();
         then(callback).shouldHaveZeroInteractions();
     }
 
     @Test
     public void doesNotSkipAdvertBreak_whenPlayingContent() {
         advertState.update(false, UNSET_ADVERT_BREAK_INDEX, UNSET_ADVERT_INDEX);
-        Mockito.reset(advertListener, callback);
+        Mockito.reset(callback);
         advertState.skipAdvertBreak();
 
-        then(advertListener).shouldHaveZeroInteractions();
         then(callback).shouldHaveZeroInteractions();
     }
 
     @Test
     public void skipsAdvertBreak_whenPlayingAdverts() {
         advertState.update(true, 0, 0);
-        Mockito.reset(advertListener, callback);
+        Mockito.reset(callback);
         advertState.skipAdvertBreak();
 
-        InOrder inOrder = Mockito.inOrder(advertListener, callback);
-        then(callback).should(inOrder).onAdvertBreakSkipped(0);
-        then(advertListener).should(inOrder).onAdvertBreakSkipped(FIRST_ADVERT_BREAK);
+        then(callback).should().onAdvertBreakSkipped(0, FIRST_ADVERT_BREAK);
         then(callback).shouldHaveNoMoreInteractions();
-        then(advertListener).shouldHaveNoMoreInteractions();
     }
 
     @Test
     public void doesNotSkipAdvert_whenDisabled() {
         advertState.disableAdverts();
-        Mockito.reset(advertListener, callback);
+        Mockito.reset(callback);
         advertState.skipAdvert();
 
-        then(advertListener).shouldHaveZeroInteractions();
         then(callback).shouldHaveZeroInteractions();
     }
 
@@ -222,54 +197,45 @@ public class AdvertStateTest {
     public void doesNotSkipAdvert_whenNotPlaying() {
         advertState.skipAdvert();
 
-        then(advertListener).shouldHaveZeroInteractions();
         then(callback).shouldHaveZeroInteractions();
     }
 
     @Test
     public void doesNotSkipAdvert_whenPlayingContent() {
         advertState.update(false, UNSET_ADVERT_BREAK_INDEX, UNSET_ADVERT_INDEX);
-        Mockito.reset(advertListener, callback);
+        Mockito.reset(callback);
         advertState.skipAdvert();
 
-        then(advertListener).shouldHaveZeroInteractions();
         then(callback).shouldHaveZeroInteractions();
     }
 
     @Test
     public void skipsAdvert_whenPlayingAdverts() {
         advertState.update(true, 1, 0);
-        Mockito.reset(advertListener, callback);
+        Mockito.reset(callback);
         advertState.skipAdvert();
 
-        InOrder inOrder = Mockito.inOrder(advertListener, callback);
-        then(callback).should(inOrder).onAdvertSkipped(1, 0);
-        then(advertListener).should(inOrder).onAdvertSkipped(FIRST_ADVERT);
+        then(callback).should().onAdvertSkipped(1, 0, FIRST_ADVERT);
         then(callback).shouldHaveNoMoreInteractions();
-        then(advertListener).shouldHaveNoMoreInteractions();
     }
 
     @Test
     public void notifiesBreakEnd_whenSkippingLastAdvertInBreak() {
         advertState.update(true, 1, 1);
-        Mockito.reset(advertListener, callback);
+        Mockito.reset(callback);
         advertState.skipAdvert();
 
-        InOrder inOrder = Mockito.inOrder(advertListener, callback);
-        then(callback).should(inOrder).onAdvertSkipped(1, 1);
-        then(advertListener).should(inOrder).onAdvertSkipped(SECOND_ADVERT);
-        then(advertListener).should(inOrder).onAdvertBreakEnd(SECOND_ADVERT_BREAK);
+        then(callback).should().onAdvertSkipped(1, 1, SECOND_ADVERT);
+        then(callback).should().onAdvertBreakEnd(SECOND_ADVERT_BREAK);
         then(callback).shouldHaveNoMoreInteractions();
-        then(advertListener).shouldHaveNoMoreInteractions();
     }
 
     @Test
     public void doesNotClickAdvert_whenPlayingContent() {
         advertState.update(false, UNSET_ADVERT_BREAK_INDEX, UNSET_ADVERT_INDEX);
-        Mockito.reset(advertListener, callback);
+        Mockito.reset(callback);
         advertState.clickAdvert();
 
-        then(advertListener).shouldHaveZeroInteractions();
         then(callback).shouldHaveZeroInteractions();
     }
 
@@ -277,20 +243,17 @@ public class AdvertStateTest {
     public void doesNotClickAdvert_whenNotPlaying() {
         advertState.clickAdvert();
 
-        then(advertListener).shouldHaveZeroInteractions();
         then(callback).shouldHaveZeroInteractions();
     }
 
     @Test
     public void clicksAdvert_whenPlayingAdverts() {
         advertState.update(true, 0, 0);
-        Mockito.reset(advertListener, callback);
+        Mockito.reset(callback);
         advertState.clickAdvert();
 
-        InOrder inOrder = Mockito.inOrder(advertListener, callback);
-        then(advertListener).should(inOrder).onAdvertClicked(FIRST_ADVERT);
+        then(callback).should().onAdvertClicked(FIRST_ADVERT);
         then(callback).shouldHaveNoMoreInteractions();
-        then(advertListener).shouldHaveNoMoreInteractions();
     }
 
     @Test

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/AdvertStateTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/AdvertStateTest.java
@@ -198,4 +198,59 @@ public class AdvertStateTest {
         then(callback).shouldHaveNoMoreInteractions();
         then(advertListener).shouldHaveNoMoreInteractions();
     }
+
+    @Test
+    public void doesNotSkipAdvert_whenDisabled() {
+        advertState.disableAdverts();
+        Mockito.reset(advertListener, callback);
+        advertState.skipAdvert();
+
+        then(advertListener).shouldHaveZeroInteractions();
+        then(callback).shouldHaveZeroInteractions();
+    }
+
+    @Test
+    public void doesNotSkipAdvert_whenNotPlaying() {
+        advertState.skipAdvert();
+
+        then(advertListener).shouldHaveZeroInteractions();
+        then(callback).shouldHaveZeroInteractions();
+    }
+
+    @Test
+    public void doesNotSkipAdvert_whenPlayingContent() {
+        advertState.update(false, UNSET_ADVERT_BREAK_INDEX, UNSET_ADVERT_INDEX);
+        Mockito.reset(advertListener, callback);
+        advertState.skipAdvert();
+
+        then(advertListener).shouldHaveZeroInteractions();
+        then(callback).shouldHaveZeroInteractions();
+    }
+
+    @Test
+    public void skipsAdvert_whenPlayingAdverts() {
+        advertState.update(true, 1, 0);
+        Mockito.reset(advertListener, callback);
+        advertState.skipAdvert();
+
+        InOrder inOrder = Mockito.inOrder(advertListener, callback);
+        then(callback).should(inOrder).onAdvertSkipped(1, 0);
+        then(advertListener).should(inOrder).onAdvertSkipped(FIRST_ADVERT);
+        then(callback).shouldHaveNoMoreInteractions();
+        then(advertListener).shouldHaveNoMoreInteractions();
+    }
+
+    @Test
+    public void notifiesBreakEnd_whenSkippingLastAdvertInBreak() {
+        advertState.update(true, 1, 1);
+        Mockito.reset(advertListener, callback);
+        advertState.skipAdvert();
+
+        InOrder inOrder = Mockito.inOrder(advertListener, callback);
+        then(callback).should(inOrder).onAdvertSkipped(1, 1);
+        then(advertListener).should(inOrder).onAdvertSkipped(SECOND_ADVERT);
+        then(advertListener).should(inOrder).onAdvertBreakEnd(SECOND_ADVERT_BREAK);
+        then(callback).shouldHaveNoMoreInteractions();
+        then(advertListener).shouldHaveNoMoreInteractions();
+    }
 }

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/AdvertStateTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/AdvertStateTest.java
@@ -164,7 +164,7 @@ public class AdvertStateTest {
 
     @Test
     public void doesNotSkipAdvertBreak_whenPlayingContent() {
-        advertState.update(false, UNSET_ADVERT_BREAK_INDEX, UNSET_ADVERT_INDEX);
+        advertState.update(IS_NOT_PLAYING_ADVERT, UNSET_ADVERT_BREAK_INDEX, UNSET_ADVERT_INDEX);
         Mockito.reset(callback);
         advertState.skipAdvertBreak();
 
@@ -173,7 +173,7 @@ public class AdvertStateTest {
 
     @Test
     public void skipsAdvertBreak_whenPlayingAdverts() {
-        advertState.update(true, 0, 0);
+        advertState.update(IS_PLAYING_ADVERT, 0, 0);
         Mockito.reset(callback);
         advertState.skipAdvertBreak();
 
@@ -199,7 +199,7 @@ public class AdvertStateTest {
 
     @Test
     public void doesNotSkipAdvert_whenPlayingContent() {
-        advertState.update(false, UNSET_ADVERT_BREAK_INDEX, UNSET_ADVERT_INDEX);
+        advertState.update(IS_NOT_PLAYING_ADVERT, UNSET_ADVERT_BREAK_INDEX, UNSET_ADVERT_INDEX);
         Mockito.reset(callback);
         advertState.skipAdvert();
 
@@ -208,7 +208,7 @@ public class AdvertStateTest {
 
     @Test
     public void skipsAdvert_whenPlayingAdverts() {
-        advertState.update(true, 1, 0);
+        advertState.update(IS_PLAYING_ADVERT, 1, 0);
         Mockito.reset(callback);
         advertState.skipAdvert();
 
@@ -218,7 +218,7 @@ public class AdvertStateTest {
 
     @Test
     public void notifiesBreakEnd_whenSkippingLastAdvertInBreak() {
-        advertState.update(true, 1, 1);
+        advertState.update(IS_PLAYING_ADVERT, 1, 1);
         Mockito.reset(callback);
         advertState.skipAdvert();
 
@@ -229,7 +229,7 @@ public class AdvertStateTest {
 
     @Test
     public void doesNotClickAdvert_whenPlayingContent() {
-        advertState.update(false, UNSET_ADVERT_BREAK_INDEX, UNSET_ADVERT_INDEX);
+        advertState.update(IS_NOT_PLAYING_ADVERT, UNSET_ADVERT_BREAK_INDEX, UNSET_ADVERT_INDEX);
         Mockito.reset(callback);
         advertState.clickAdvert();
 
@@ -245,7 +245,7 @@ public class AdvertStateTest {
 
     @Test
     public void clicksAdvert_whenPlayingAdverts() {
-        advertState.update(true, 0, 0);
+        advertState.update(IS_PLAYING_ADVERT, 0, 0);
         Mockito.reset(callback);
         advertState.clickAdvert();
 
@@ -272,5 +272,26 @@ public class AdvertStateTest {
         long advertDuration = advertState.advertDurationBy(0, 0);
 
         assertThat(advertDuration).isEqualTo(C.msToUs(ONE_SECOND_IN_MILLIS));
+    }
+
+    @Test
+    public void marksAdvertResumePosition_whenStoppingWhilstPlayingAnAdvert() {
+        advertState.update(IS_PLAYING_ADVERT, 0, 0);
+        Mockito.reset(callback);
+
+        advertState.stop(0);
+
+        then(callback).should().markAdvertResumePosition(0);
+        then(callback).shouldHaveNoMoreInteractions();
+    }
+
+    @Test
+    public void doesNotMarkAdvertResumePosition_whenStoppingWhilstPlayingContent() {
+        advertState.update(IS_NOT_PLAYING_ADVERT, 0, 0);
+        Mockito.reset(callback);
+
+        advertState.stop(0);
+
+        then(callback).shouldHaveZeroInteractions();
     }
 }

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/AdvertStateTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/AdvertStateTest.java
@@ -118,8 +118,8 @@ public class AdvertStateTest {
     public void disablesAdverts() {
         advertState.disableAdverts();
 
-        then(callback).should().onAdvertsDisabled();
-        then(callback).should().onAdvertsDisabled();
+        then(callback).should().onAdvertsDisabled(advertBreaks);
+        then(callback).should().onAdvertsDisabled(advertBreaks);
         then(callback).shouldHaveNoMoreInteractions();
     }
 

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/AdvertStateTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/AdvertStateTest.java
@@ -11,6 +11,7 @@ import java.util.List;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.mockito.InOrder;
 import org.mockito.Mockito;
 
 import utils.ExceptionMatcher;
@@ -85,8 +86,9 @@ public class AdvertStateTest {
     public void notifiesStartOfAdvertBreak_andAdvert_whenTransitioningToAdverts() {
         advertState.update(IS_PLAYING_ADVERT, 0, 0);
 
-        then(callback).should().onAdvertBreakStart(FIRST_ADVERT_BREAK);
-        then(callback).should().onAdvertStart(FIRST_ADVERT);
+        InOrder inOrder = Mockito.inOrder(callback);
+        then(callback).should(inOrder).onAdvertBreakStart(FIRST_ADVERT_BREAK);
+        then(callback).should(inOrder).onAdvertStart(FIRST_ADVERT);
         then(callback).shouldHaveNoMoreInteractions();
     }
 
@@ -105,9 +107,10 @@ public class AdvertStateTest {
         Mockito.reset(callback);
         advertState.update(IS_NOT_PLAYING_ADVERT, UNSET_ADVERT_BREAK_INDEX, UNSET_ADVERT_INDEX);
 
-        then(callback).should().onAdvertPlayed(0, 0);
-        then(callback).should().onAdvertEnd(FIRST_ADVERT);
-        then(callback).should().onAdvertBreakEnd(FIRST_ADVERT_BREAK);
+        InOrder inOrder = Mockito.inOrder(callback);
+        then(callback).should(inOrder).onAdvertPlayed(0, 0);
+        then(callback).should(inOrder).onAdvertEnd(FIRST_ADVERT);
+        then(callback).should(inOrder).onAdvertBreakEnd(FIRST_ADVERT_BREAK);
         then(callback).shouldHaveNoMoreInteractions();
     }
 
@@ -117,9 +120,10 @@ public class AdvertStateTest {
         Mockito.reset(callback);
         advertState.update(IS_PLAYING_ADVERT, 1, 1);
 
-        then(callback).should().onAdvertPlayed(1, 0);
-        then(callback).should().onAdvertEnd(FIRST_ADVERT);
-        then(callback).should().onAdvertStart(SECOND_ADVERT);
+        InOrder inOrder = Mockito.inOrder(callback);
+        then(callback).should(inOrder).onAdvertPlayed(1, 0);
+        then(callback).should(inOrder).onAdvertEnd(FIRST_ADVERT);
+        then(callback).should(inOrder).onAdvertStart(SECOND_ADVERT);
     }
 
     @Test
@@ -232,8 +236,9 @@ public class AdvertStateTest {
         Mockito.reset(callback);
         advertState.skipAdvert();
 
-        then(callback).should().onAdvertSkipped(1, 1, SECOND_ADVERT);
-        then(callback).should().onAdvertBreakEnd(SECOND_ADVERT_BREAK);
+        InOrder inOrder = Mockito.inOrder(callback);
+        then(callback).should(inOrder).onAdvertSkipped(1, 1, SECOND_ADVERT);
+        then(callback).should(inOrder).onAdvertBreakEnd(SECOND_ADVERT_BREAK);
         then(callback).shouldHaveNoMoreInteractions();
     }
 

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -26,8 +26,8 @@ dependencies {
     implementation project(':core')
     implementation 'com.google.android.exoplayer:exoplayer:2.10.1'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
-    implementation 'com.google.android.material:material:1.1.0-alpha08'
+    implementation 'com.google.android.material:material:1.1.0-alpha09'
     implementation 'androidx.appcompat:appcompat:1.0.2'
     testImplementation 'junit:junit:4.12'
-    testImplementation 'com.google.truth:truth:0.44'
+    testImplementation 'com.google.truth:truth:1.0'
 }


### PR DESCRIPTION
## Problem
When creating the `NoPlayerAdsLoader` we were a little concerned that we had very few tests for it 😬 and that it was generally difficult to test. 

## Solution
Extract logic related adverts to a more testable component `AdvertState` and add tests 😄 

### Paired with 
Nobody.
