### PR TITLE
System captions - remove spans

### DIFF
--- a/core/src/main/java/com/novoda/noplayer/SubtitlePainter.java
+++ b/core/src/main/java/com/novoda/noplayer/SubtitlePainter.java
@@ -170,7 +170,7 @@ final class SubtitlePainter {
 
         SubtitlesStyle subtitlesStyle = captionPreferences.getStyle();
 
-        this.cueText = cue.text();
+        this.cueText = subtitlesStyle.formatText(cue.text());
         this.cueTextAlignment = cue.textAlignment();
         this.cueBitmap = cue.bitmap();
         this.cueLine = cue.line();
@@ -258,9 +258,7 @@ final class SubtitlePainter {
 
         // Remove embedded styling or font size if requested.
         CharSequence cueText;
-        if (captionPreferences.isAccessibilityCaptionsStyleEnabled()) {
-            cueText = this.cueText.toString(); // Equivalent to erasing all spans.
-        } else if (applyEmbeddedFontSizes && applyEmbeddedStyles) {
+        if (applyEmbeddedFontSizes && applyEmbeddedStyles) {
             cueText = this.cueText;
         } else if (!applyEmbeddedStyles) {
             cueText = this.cueText.toString(); // Equivalent to erasing all spans.

--- a/core/src/main/java/com/novoda/noplayer/SubtitlePainter.java
+++ b/core/src/main/java/com/novoda/noplayer/SubtitlePainter.java
@@ -460,7 +460,7 @@ final class SubtitlePainter {
     }
 
 
-    public void setAccessibilityCaptionsStyleEnabled(boolean enabled) {
+    void setAccessibilityCaptionsStyleEnabled(boolean enabled) {
         captionPreferences.setAccessibilityCaptionsStyleEnabled(enabled);
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/SubtitlePainter.java
+++ b/core/src/main/java/com/novoda/noplayer/SubtitlePainter.java
@@ -258,7 +258,9 @@ final class SubtitlePainter {
 
         // Remove embedded styling or font size if requested.
         CharSequence cueText;
-        if (applyEmbeddedFontSizes && applyEmbeddedStyles) {
+        if (captionPreferences.isAccessibilityCaptionsStyleEnabled()) {
+            cueText = this.cueText.toString(); // Equivalent to erasing all spans.
+        } else if (applyEmbeddedFontSizes && applyEmbeddedStyles) {
             cueText = this.cueText;
         } else if (!applyEmbeddedStyles) {
             cueText = this.cueText.toString(); // Equivalent to erasing all spans.

--- a/core/src/main/java/com/novoda/noplayer/subtitles/KitKatSubtitlesStyle.java
+++ b/core/src/main/java/com/novoda/noplayer/subtitles/KitKatSubtitlesStyle.java
@@ -56,4 +56,9 @@ class KitKatSubtitlesStyle implements SubtitlesStyle {
         return captionStyle.edgeColor;
     }
 
+    @Override
+    public CharSequence formatText(CharSequence text) {
+        return text.toString(); // removes any Spans in SpannableString
+    }
+
 }

--- a/core/src/main/java/com/novoda/noplayer/subtitles/NoOpSubtitlesStyle.java
+++ b/core/src/main/java/com/novoda/noplayer/subtitles/NoOpSubtitlesStyle.java
@@ -42,4 +42,9 @@ class NoOpSubtitlesStyle implements SubtitlesStyle {
         return fallbackColor;
     }
 
+    @Override
+    public CharSequence formatText(CharSequence text) {
+        return text;
+    }
+
 }

--- a/core/src/main/java/com/novoda/noplayer/subtitles/SubtitlesStyle.java
+++ b/core/src/main/java/com/novoda/noplayer/subtitles/SubtitlesStyle.java
@@ -20,4 +20,6 @@ public interface SubtitlesStyle {
     int edgeTypeOr(int fallbackEdgeType);
 
     int edgeColorOr(int fallbackColor);
+
+    CharSequence formatText(CharSequence text);
 }

--- a/core/src/main/java/com/novoda/noplayer/subtitles/SystemCaptionPreferences.java
+++ b/core/src/main/java/com/novoda/noplayer/subtitles/SystemCaptionPreferences.java
@@ -45,8 +45,4 @@ public class SystemCaptionPreferences {
     public void setAccessibilityCaptionsStyleEnabled(boolean enabled) {
         this.enabled = enabled;
     }
-
-    public boolean isAccessibilityCaptionsStyleEnabled() {
-        return enabled;
-    }
 }

--- a/core/src/main/java/com/novoda/noplayer/subtitles/SystemCaptionPreferences.java
+++ b/core/src/main/java/com/novoda/noplayer/subtitles/SystemCaptionPreferences.java
@@ -45,4 +45,8 @@ public class SystemCaptionPreferences {
     public void setAccessibilityCaptionsStyleEnabled(boolean enabled) {
         this.enabled = enabled;
     }
+
+    public boolean isAccessibilityCaptionsStyleEnabled() {
+        return enabled;
+    }
 }

--- a/core/src/test/java/com/novoda/noplayer/subtitles/SystemCaptionPreferencesTest.java
+++ b/core/src/test/java/com/novoda/noplayer/subtitles/SystemCaptionPreferencesTest.java
@@ -42,6 +42,12 @@ public class SystemCaptionPreferencesTest {
     private static final float SYSTEM_TEXT_SCALE_RATIO = 2f;
     private static final Typeface SYSTEM_TYPEFACE = mock(Typeface.class);
     private static final Typeface NO_TYPEFACE = null;
+    private static final CharSequence SPANNED_TEXT = mock(CharSequence.class);
+    private static final String CLEAN_TEXT = "clean text";
+
+    static {
+        when(SPANNED_TEXT.toString()).thenReturn(CLEAN_TEXT);
+    }
 
     private final TestCase testCase;
 
@@ -130,6 +136,18 @@ public class SystemCaptionPreferencesTest {
         assertThat(color).isEqualTo(testCase.expectedEdgeColor);
     }
 
+    @Test
+    public void shouldFormatText() {
+
+        SystemCaptionPreferences preferences = givenSystemCaptionPreferences(testCase);
+
+        CharSequence text = preferences.getStyle().formatText(SPANNED_TEXT);
+
+        assertThat(text).isEqualTo(testCase.expectedformattedText);
+
+
+    }
+
     private static final TestCase PRE_KITKAT_TEST_CASE = new TestCase(JELLY_BEAN_MR2, "PRE_KITKAT")
         .expectedBackgroundColor(FALLBACK_COLOR)
         .expectedForegroundColor(FALLBACK_COLOR)
@@ -137,7 +155,8 @@ public class SystemCaptionPreferencesTest {
         .expectedTextSize(TEXT_SIZE)
         .expectedTypeface(NO_TYPEFACE)
         .expectedEdgeType(EDGE_TYPE_NONE)
-        .expectedEdgeColor(FALLBACK_COLOR);
+        .expectedEdgeColor(FALLBACK_COLOR)
+        .expectedformattedText(SPANNED_TEXT);
 
     private static final TestCase KITKAT_TEST_CASE = new TestCase(KITKAT, "KITKAT")
         .expectedBackgroundColor(SYSTEM_BACKGROUND_COLOR)
@@ -146,7 +165,8 @@ public class SystemCaptionPreferencesTest {
         .expectedTextSize(TEXT_SIZE * SYSTEM_TEXT_SCALE_RATIO)
         .expectedTypeface(SYSTEM_TYPEFACE)
         .expectedEdgeType(SYSTEM_EDGE_TYPE)
-        .expectedEdgeColor(SYSTEM_EDGE_COLOR);
+        .expectedEdgeColor(SYSTEM_EDGE_COLOR)
+        .expectedformattedText(CLEAN_TEXT);
 
     private static final TestCase POST_LOLLIPOP_TEST_CASE = new TestCase(LOLLIPOP, "POST_LOLLIPOP")
         .expectedBackgroundColor(SYSTEM_BACKGROUND_COLOR)
@@ -155,7 +175,8 @@ public class SystemCaptionPreferencesTest {
         .expectedTextSize(TEXT_SIZE * SYSTEM_TEXT_SCALE_RATIO)
         .expectedTypeface(SYSTEM_TYPEFACE)
         .expectedEdgeType(SYSTEM_EDGE_TYPE)
-        .expectedEdgeColor(SYSTEM_EDGE_COLOR);
+        .expectedEdgeColor(SYSTEM_EDGE_COLOR)
+        .expectedformattedText(CLEAN_TEXT);
 
     private static final TestCase DISABLED_TEST_CASE = new TestCase(LOLLIPOP, "DISABLED")
         .captionsManagerDisabled()
@@ -165,7 +186,8 @@ public class SystemCaptionPreferencesTest {
         .expectedTextSize(TEXT_SIZE)
         .expectedTypeface(NO_TYPEFACE)
         .expectedEdgeType(EDGE_TYPE_NONE)
-        .expectedEdgeColor(FALLBACK_COLOR);
+        .expectedEdgeColor(FALLBACK_COLOR)
+        .expectedformattedText(SPANNED_TEXT);
 
     private static final TestCase LOCALLY_DISABLED_TEST_CASE = new TestCase(LOLLIPOP, "LOCALLY DISABLED")
         .captionsLocallyDisabled()
@@ -175,12 +197,14 @@ public class SystemCaptionPreferencesTest {
         .expectedTextSize(TEXT_SIZE)
         .expectedTypeface(NO_TYPEFACE)
         .expectedEdgeType(EDGE_TYPE_NONE)
-        .expectedEdgeColor(FALLBACK_COLOR);
+        .expectedEdgeColor(FALLBACK_COLOR)
+        .expectedformattedText(SPANNED_TEXT);
 
     private static class TestCase {
 
         final int sdkLevel;
         final String name;
+        CharSequence expectedformattedText;
         boolean captionsManagerIsEnabled = true;
         boolean captionsLocallyEnabled = true;
         int expectedBackgroundColor;
@@ -228,6 +252,11 @@ public class SystemCaptionPreferencesTest {
 
         TestCase expectedEdgeColor(int expectedEdgeColor) {
             this.expectedEdgeColor = expectedEdgeColor;
+            return this;
+        }
+
+        TestCase expectedformattedText(CharSequence expectedformattedText) {
+            this.expectedformattedText = expectedformattedText;
             return this;
         }
 

--- a/core/src/test/java/com/novoda/noplayer/subtitles/SystemCaptionPreferencesTest.java
+++ b/core/src/test/java/com/novoda/noplayer/subtitles/SystemCaptionPreferencesTest.java
@@ -138,14 +138,11 @@ public class SystemCaptionPreferencesTest {
 
     @Test
     public void shouldFormatText() {
-
         SystemCaptionPreferences preferences = givenSystemCaptionPreferences(testCase);
 
         CharSequence text = preferences.getStyle().formatText(SPANNED_TEXT);
 
         assertThat(text).isEqualTo(testCase.expectedformattedText);
-
-
     }
 
     private static final TestCase PRE_KITKAT_TEST_CASE = new TestCase(JELLY_BEAN_MR2, "PRE_KITKAT")


### PR DESCRIPTION
## Problem

When enabling accessibility caption preferences in #277 we forgot about taking into account spans. The video we used to test didn't have custom formatting in the provided caption cues.

## Solution

Make sure that we remove all `Span` elements when required.

### Test(s) added 

No tests added

### Screenshots

We don't have a video with styled captions to test this, it'll be tested in-situ.

### Paired with 

No one
