### PR TITLE
Add max vide size constrain

### DIFF
--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,7 +1,0 @@
-<component name="InspectionProjectProfileManager">
-  <settings>
-    <option name="PROJECT_PROFILE" value="Project Default" />
-    <option name="USE_PROJECT_PROFILE" value="true" />
-    <version value="1.0" />
-  </settings>
-</component>

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0'
+        classpath 'com.android.tools.build:gradle:3.5.1'
         classpath 'com.novoda:bintray-release:0.9.1'
         classpath 'com.novoda:gradle-static-analysis-plugin:1.0'
         classpath 'com.novoda:gradle-build-properties-plugin:0.4.1'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -68,7 +68,7 @@ dependencies {
     implementation 'androidx.annotation:annotation:1.1.0'
 
     testImplementation 'junit:junit:4.12'
-    testImplementation 'org.mockito:mockito-core:3.0.0'
+    testImplementation 'org.mockito:mockito-core:3.1.0'
     testImplementation 'org.easytesting:fest-assert-core:2.0M10'
 }
 

--- a/core/src/main/java/com/novoda/noplayer/NoPlayer.java
+++ b/core/src/main/java/com/novoda/noplayer/NoPlayer.java
@@ -2,10 +2,13 @@ package com.novoda.noplayer;
 
 import android.net.Uri;
 
+import androidx.annotation.FloatRange;
+
 import com.novoda.noplayer.internal.exoplayer.NoPlayerAdsLoader;
 import com.novoda.noplayer.internal.utils.Optional;
 import com.novoda.noplayer.model.AudioTracks;
 import com.novoda.noplayer.model.Bitrate;
+import com.novoda.noplayer.model.Dimension;
 import com.novoda.noplayer.model.PlayerAudioTrack;
 import com.novoda.noplayer.model.PlayerSubtitleTrack;
 import com.novoda.noplayer.model.PlayerVideoTrack;
@@ -14,8 +17,6 @@ import com.novoda.noplayer.model.Timeout;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-
-import androidx.annotation.FloatRange;
 
 // There are a lot of features for playing and monitoring video.
 @SuppressWarnings("PMD.ExcessivePublicCount")
@@ -265,6 +266,19 @@ public interface NoPlayer extends PlayerState {
      * @param maxVideoBitrate The maximum video bitrate in bit per second.
      */
     void setMaxVideoBitrate(int maxVideoBitrate);
+
+    /**
+     * Sets the maximum video size allowed. If the content contains tracks above the specified video size,
+     * those tracks will not be selected.
+     *
+     * @param maxVideoSize The maxium video size in pixels
+     */
+    void setMaxVideoSize(Dimension maxVideoSize);
+
+    /**
+     * Clears the maximum video size, if set.
+     */
+    void clearMaxVideoSize();
 
     interface PlayerError {
 

--- a/core/src/main/java/com/novoda/noplayer/Options.java
+++ b/core/src/main/java/com/novoda/noplayer/Options.java
@@ -1,6 +1,7 @@
 package com.novoda.noplayer;
 
 import com.novoda.noplayer.internal.utils.Optional;
+import com.novoda.noplayer.model.Dimension;
 
 import java.util.List;
 
@@ -14,6 +15,7 @@ public class Options {
     private final int minDurationBeforeQualityIncreaseInMillis;
     private final int maxInitialBitrate;
     private final int maxVideoBitrate;
+    private final Dimension maxVideoSize;
     private final Optional<Long> initialPositionInMillis;
     private final Optional<Long> initialAdvertBreakPositionInMillis;
     private final List<String> unsupportedVideoDecoders;
@@ -46,6 +48,7 @@ public class Options {
             int minDurationBeforeQualityIncreaseInMillis,
             int maxInitialBitrate,
             int maxVideoBitrate,
+            Dimension maxVideoSize,
             Optional<Long> initialPositionInMillis,
             Optional<Long> initialAdvertBreakPositionInMillis,
             List<String> unsupportedVideoDecoders,
@@ -54,6 +57,7 @@ public class Options {
         this.minDurationBeforeQualityIncreaseInMillis = minDurationBeforeQualityIncreaseInMillis;
         this.maxInitialBitrate = maxInitialBitrate;
         this.maxVideoBitrate = maxVideoBitrate;
+        this.maxVideoSize = maxVideoSize;
         this.initialPositionInMillis = initialPositionInMillis;
         this.initialAdvertBreakPositionInMillis = initialAdvertBreakPositionInMillis;
         this.unsupportedVideoDecoders = unsupportedVideoDecoders;
@@ -76,6 +80,10 @@ public class Options {
         return maxVideoBitrate;
     }
 
+    public Dimension maxVideoSize() {
+        return maxVideoSize;
+    }
+
     public Optional<Long> getInitialPositionInMillis() {
         return initialPositionInMillis;
     }
@@ -94,67 +102,50 @@ public class Options {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
+        if (this == o) return true;
+        if (!(o instanceof Options)) return false;
 
         Options options = (Options) o;
 
-        if (minDurationBeforeQualityIncreaseInMillis != options.minDurationBeforeQualityIncreaseInMillis) {
+        if (minDurationBeforeQualityIncreaseInMillis != options.minDurationBeforeQualityIncreaseInMillis)
             return false;
-        }
-        if (maxInitialBitrate != options.maxInitialBitrate) {
+        if (maxInitialBitrate != options.maxInitialBitrate) return false;
+        if (maxVideoBitrate != options.maxVideoBitrate) return false;
+        if (contentType != options.contentType) return false;
+        if (!maxVideoSize.equals(options.maxVideoSize)) return false;
+        if (!initialPositionInMillis.equals(options.initialPositionInMillis)) return false;
+        if (!initialAdvertBreakPositionInMillis.equals(options.initialAdvertBreakPositionInMillis))
             return false;
-        }
-        if (maxVideoBitrate != options.maxVideoBitrate) {
-            return false;
-        }
-        if (contentType != options.contentType) {
-            return false;
-        }
-        if (initialPositionInMillis != null ? !initialPositionInMillis.equals(options.initialPositionInMillis)
-                : options.initialPositionInMillis != null) {
-            return false;
-        }
-        if (initialAdvertBreakPositionInMillis != null ? !initialAdvertBreakPositionInMillis.equals(options.initialAdvertBreakPositionInMillis)
-                : options.initialAdvertBreakPositionInMillis != null) {
-            return false;
-        }
-        if (unsupportedVideoDecoders != null ? !unsupportedVideoDecoders.equals(options.unsupportedVideoDecoders)
-                : options.unsupportedVideoDecoders != null) {
-            return false;
-        }
-        return hdQualityBitrateThreshold != null ? hdQualityBitrateThreshold.equals(options.hdQualityBitrateThreshold)
-                : options.hdQualityBitrateThreshold == null;
+        if (!unsupportedVideoDecoders.equals(options.unsupportedVideoDecoders)) return false;
+        return hdQualityBitrateThreshold.equals(options.hdQualityBitrateThreshold);
     }
 
     @Override
     public int hashCode() {
-        int result = contentType != null ? contentType.hashCode() : 0;
+        int result = contentType.hashCode();
         result = 31 * result + minDurationBeforeQualityIncreaseInMillis;
         result = 31 * result + maxInitialBitrate;
         result = 31 * result + maxVideoBitrate;
-        result = 31 * result + (initialPositionInMillis != null ? initialPositionInMillis.hashCode() : 0);
-        result = 31 * result + (initialAdvertBreakPositionInMillis != null ? initialAdvertBreakPositionInMillis.hashCode() : 0);
-        result = 31 * result + (unsupportedVideoDecoders != null ? unsupportedVideoDecoders.hashCode() : 0);
-        result = 31 * result + (hdQualityBitrateThreshold != null ? hdQualityBitrateThreshold.hashCode() : 0);
+        result = 31 * result + maxVideoSize.hashCode();
+        result = 31 * result + initialPositionInMillis.hashCode();
+        result = 31 * result + initialAdvertBreakPositionInMillis.hashCode();
+        result = 31 * result + unsupportedVideoDecoders.hashCode();
+        result = 31 * result + hdQualityBitrateThreshold.hashCode();
         return result;
     }
 
     @Override
     public String toString() {
-        return "Options{"
-                + "contentType=" + contentType
-                + ", minDurationBeforeQualityIncreaseInMillis=" + minDurationBeforeQualityIncreaseInMillis
-                + ", maxInitialBitrate=" + maxInitialBitrate
-                + ", maxVideoBitrate=" + maxVideoBitrate
-                + ", initialPositionInMillis=" + initialPositionInMillis
-                + ", initialAdvertBreakPositionInMillis=" + initialAdvertBreakPositionInMillis
-                + ", unsupportedVideoDecoders=" + unsupportedVideoDecoders
-                + ", hdQualityBitrateThreshold=" + hdQualityBitrateThreshold
-                + '}';
+        return "Options{" +
+                "contentType=" + contentType +
+                ", minDurationBeforeQualityIncreaseInMillis=" + minDurationBeforeQualityIncreaseInMillis +
+                ", maxInitialBitrate=" + maxInitialBitrate +
+                ", maxVideoBitrate=" + maxVideoBitrate +
+                ", maxVideoSize=" + maxVideoSize +
+                ", initialPositionInMillis=" + initialPositionInMillis +
+                ", initialAdvertBreakPositionInMillis=" + initialAdvertBreakPositionInMillis +
+                ", unsupportedVideoDecoders=" + unsupportedVideoDecoders +
+                ", hdQualityBitrateThreshold=" + hdQualityBitrateThreshold +
+                '}';
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/Options.java
+++ b/core/src/main/java/com/novoda/noplayer/Options.java
@@ -102,21 +102,40 @@ public class Options {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof Options)) return false;
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof Options)) {
+            return false;
+        }
 
         Options options = (Options) o;
 
-        if (minDurationBeforeQualityIncreaseInMillis != options.minDurationBeforeQualityIncreaseInMillis)
+        if (minDurationBeforeQualityIncreaseInMillis != options.minDurationBeforeQualityIncreaseInMillis) {
             return false;
-        if (maxInitialBitrate != options.maxInitialBitrate) return false;
-        if (maxVideoBitrate != options.maxVideoBitrate) return false;
-        if (contentType != options.contentType) return false;
-        if (!maxVideoSize.equals(options.maxVideoSize)) return false;
-        if (!initialPositionInMillis.equals(options.initialPositionInMillis)) return false;
-        if (!initialAdvertBreakPositionInMillis.equals(options.initialAdvertBreakPositionInMillis))
+        }
+
+        if (maxInitialBitrate != options.maxInitialBitrate) {
             return false;
-        if (!unsupportedVideoDecoders.equals(options.unsupportedVideoDecoders)) return false;
+        }
+        if (maxVideoBitrate != options.maxVideoBitrate) {
+            return false;
+        }
+        if (contentType != options.contentType) {
+            return false;
+        }
+        if (!maxVideoSize.equals(options.maxVideoSize)) {
+            return false;
+        }
+        if (!initialPositionInMillis.equals(options.initialPositionInMillis)) {
+            return false;
+        }
+        if (!initialAdvertBreakPositionInMillis.equals(options.initialAdvertBreakPositionInMillis)) {
+            return false;
+        }
+        if (!unsupportedVideoDecoders.equals(options.unsupportedVideoDecoders)) {
+            return false;
+        }
         return hdQualityBitrateThreshold.equals(options.hdQualityBitrateThreshold);
     }
 
@@ -136,16 +155,16 @@ public class Options {
 
     @Override
     public String toString() {
-        return "Options{" +
-                "contentType=" + contentType +
-                ", minDurationBeforeQualityIncreaseInMillis=" + minDurationBeforeQualityIncreaseInMillis +
-                ", maxInitialBitrate=" + maxInitialBitrate +
-                ", maxVideoBitrate=" + maxVideoBitrate +
-                ", maxVideoSize=" + maxVideoSize +
-                ", initialPositionInMillis=" + initialPositionInMillis +
-                ", initialAdvertBreakPositionInMillis=" + initialAdvertBreakPositionInMillis +
-                ", unsupportedVideoDecoders=" + unsupportedVideoDecoders +
-                ", hdQualityBitrateThreshold=" + hdQualityBitrateThreshold +
-                '}';
+        return "Options{"
+                + "contentType=" + contentType
+                + ", minDurationBeforeQualityIncreaseInMillis=" + minDurationBeforeQualityIncreaseInMillis
+                + ", maxInitialBitrate=" + maxInitialBitrate
+                + ", maxVideoBitrate=" + maxVideoBitrate
+                + ", maxVideoSize=" + maxVideoSize
+                + ", initialPositionInMillis=" + initialPositionInMillis
+                + ", initialAdvertBreakPositionInMillis=" + initialAdvertBreakPositionInMillis
+                + ", unsupportedVideoDecoders=" + unsupportedVideoDecoders
+                + ", hdQualityBitrateThreshold=" + hdQualityBitrateThreshold
+                + '}';
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/OptionsBuilder.java
+++ b/core/src/main/java/com/novoda/noplayer/OptionsBuilder.java
@@ -3,6 +3,7 @@ package com.novoda.noplayer;
 import android.net.Uri;
 
 import com.novoda.noplayer.internal.utils.Optional;
+import com.novoda.noplayer.model.Dimension;
 
 import java.util.Collections;
 import java.util.List;
@@ -15,11 +16,14 @@ public class OptionsBuilder {
     private static final int DEFAULT_MIN_DURATION_FOR_QUALITY_INCREASE_MS = 10000;
     private static final int DEFAULT_MAX_INITIAL_BITRATE = 800000;
     private static final int DEFAULT_MAX_VIDEO_BITRATE = Integer.MAX_VALUE;
+    private static final int DEFAULT_MAX_INITIAL_VIDEO_WIDTH = Integer.MAX_VALUE;
+    private static final int DEFAULT_MAX_INITIAL_VIDEO_HEIGH = Integer.MAX_VALUE;
 
     private ContentType contentType = ContentType.H264;
     private int minDurationBeforeQualityIncreaseInMillis = DEFAULT_MIN_DURATION_FOR_QUALITY_INCREASE_MS;
     private int maxInitialBitrate = DEFAULT_MAX_INITIAL_BITRATE;
     private int maxVideoBitrate = DEFAULT_MAX_VIDEO_BITRATE;
+    private Dimension maxVideoSize = Dimension.from(DEFAULT_MAX_INITIAL_VIDEO_WIDTH, DEFAULT_MAX_INITIAL_VIDEO_HEIGH);
     private Optional<Long> initialPositionInMillis = Optional.absent();
     private Optional<Long> initialAdvertBreakPositionInMillis = Optional.absent();
     private List<String> unsupportedVideoDecoders = Collections.emptyList();
@@ -72,6 +76,18 @@ public class OptionsBuilder {
      */
     public OptionsBuilder withMaxVideoBitrate(int maxVideoBitrate) {
         this.maxVideoBitrate = maxVideoBitrate;
+        return this;
+    }
+
+    /**
+     * Sets {@link OptionsBuilder} to build {@link Options} with given maximum video size.
+     *
+     * @param maxVideoSize maximum allowed video size.
+     * @return {@link OptionsBuilder}
+     */
+
+    public OptionsBuilder withMaxVideoSize(Dimension maxVideoSize) {
+        this.maxVideoSize = maxVideoSize;
         return this;
     }
 
@@ -139,6 +155,7 @@ public class OptionsBuilder {
                 minDurationBeforeQualityIncreaseInMillis,
                 maxInitialBitrate,
                 maxVideoBitrate,
+                maxVideoSize,
                 initialPositionInMillis,
                 initialAdvertBreakPositionInMillis,
                 unsupportedVideoDecoders,

--- a/core/src/main/java/com/novoda/noplayer/OptionsBuilder.java
+++ b/core/src/main/java/com/novoda/noplayer/OptionsBuilder.java
@@ -16,18 +16,17 @@ public class OptionsBuilder {
     private static final int DEFAULT_MIN_DURATION_FOR_QUALITY_INCREASE_MS = 10000;
     private static final int DEFAULT_MAX_INITIAL_BITRATE = 800000;
     private static final int DEFAULT_MAX_VIDEO_BITRATE = Integer.MAX_VALUE;
-    private static final int DEFAULT_MAX_INITIAL_VIDEO_WIDTH = Integer.MAX_VALUE;
-    private static final int DEFAULT_MAX_INITIAL_VIDEO_HEIGH = Integer.MAX_VALUE;
+    private static final Dimension DEFAULT_MAX_INITIAL_VIDEO_SIZE = Dimension.from(Integer.MAX_VALUE, Integer.MAX_VALUE);
 
     private ContentType contentType = ContentType.H264;
     private int minDurationBeforeQualityIncreaseInMillis = DEFAULT_MIN_DURATION_FOR_QUALITY_INCREASE_MS;
     private int maxInitialBitrate = DEFAULT_MAX_INITIAL_BITRATE;
     private int maxVideoBitrate = DEFAULT_MAX_VIDEO_BITRATE;
-    private Dimension maxVideoSize = Dimension.from(DEFAULT_MAX_INITIAL_VIDEO_WIDTH, DEFAULT_MAX_INITIAL_VIDEO_HEIGH);
     private Optional<Long> initialPositionInMillis = Optional.absent();
     private Optional<Long> initialAdvertBreakPositionInMillis = Optional.absent();
     private List<String> unsupportedVideoDecoders = Collections.emptyList();
     private Optional<Integer> hdQualityThreshold = Optional.absent();
+    private Dimension maxVideoSize = DEFAULT_MAX_INITIAL_VIDEO_SIZE;
 
     /**
      * Sets {@link OptionsBuilder} to build {@link Options} with a given {@link ContentType}.

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/CompositeTrackSelector.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/CompositeTrackSelector.java
@@ -9,6 +9,7 @@ import com.novoda.noplayer.internal.exoplayer.mediasource.ExoPlayerSubtitleTrack
 import com.novoda.noplayer.internal.exoplayer.mediasource.ExoPlayerVideoTrackSelector;
 import com.novoda.noplayer.internal.utils.Optional;
 import com.novoda.noplayer.model.AudioTracks;
+import com.novoda.noplayer.model.Dimension;
 import com.novoda.noplayer.model.PlayerAudioTrack;
 import com.novoda.noplayer.model.PlayerSubtitleTrack;
 import com.novoda.noplayer.model.PlayerVideoTrack;
@@ -84,5 +85,13 @@ class CompositeTrackSelector {
 
     void setMaxVideoBitrate(int maxVideoBitrate) {
         videoTrackSelector.setMaxVideoBitrate(maxVideoBitrate);
+    }
+
+    public void setMaxVideoSize(Dimension maxVideoSize) {
+        videoTrackSelector.setMaxVideoSize(maxVideoSize);
+    }
+
+    void clearMaxVideoSize() {
+        videoTrackSelector.clearMaxVideoSize();
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/CompositeTrackSelectorCreator.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/CompositeTrackSelectorCreator.java
@@ -10,6 +10,7 @@ import com.novoda.noplayer.internal.exoplayer.mediasource.ExoPlayerAudioTrackSel
 import com.novoda.noplayer.internal.exoplayer.mediasource.ExoPlayerSubtitleTrackSelector;
 import com.novoda.noplayer.internal.exoplayer.mediasource.ExoPlayerTrackSelector;
 import com.novoda.noplayer.internal.exoplayer.mediasource.ExoPlayerVideoTrackSelector;
+import com.novoda.noplayer.model.Dimension;
 
 class CompositeTrackSelectorCreator {
 
@@ -25,8 +26,10 @@ class CompositeTrackSelectorCreator {
                 Clock.DEFAULT
         );
         DefaultTrackSelector trackSelector = new DefaultTrackSelector(adaptiveTrackSelectionFactory);
+        Dimension maxVideoSize = options.maxVideoSize();
         DefaultTrackSelector.Parameters trackSelectorParameters = trackSelector.buildUponParameters()
                 .setMaxVideoBitrate(options.maxVideoBitrate())
+                .setMaxVideoSize(maxVideoSize.width(), maxVideoSize.height())
                 .build();
         trackSelector.setParameters(trackSelectorParameters);
 

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
@@ -1,7 +1,9 @@
 package com.novoda.noplayer.internal.exoplayer;
 
 import android.net.Uri;
+
 import androidx.annotation.Nullable;
+
 import com.google.android.exoplayer2.C;
 import com.google.android.exoplayer2.Player;
 import com.google.android.exoplayer2.SimpleExoPlayer;
@@ -20,6 +22,7 @@ import com.novoda.noplayer.internal.exoplayer.mediasource.MediaSourceFactory;
 import com.novoda.noplayer.internal.utils.AndroidDeviceVersion;
 import com.novoda.noplayer.internal.utils.Optional;
 import com.novoda.noplayer.model.AudioTracks;
+import com.novoda.noplayer.model.Dimension;
 import com.novoda.noplayer.model.PlayerAudioTrack;
 import com.novoda.noplayer.model.PlayerSubtitleTrack;
 import com.novoda.noplayer.model.PlayerVideoTrack;
@@ -347,6 +350,16 @@ class ExoPlayerFacade {
     void setMaxVideoBitrate(int maxVideoBitrate) {
         assertVideoLoaded();
         compositeTrackSelector.setMaxVideoBitrate(maxVideoBitrate);
+    }
+
+    public void setMaxVideoSize(Dimension maxVideoSize) {
+        assertVideoLoaded();
+        compositeTrackSelector.setMaxVideoSize(maxVideoSize);
+    }
+
+    void clearMaxVideoSize() {
+        assertVideoLoaded();
+        compositeTrackSelector.clearMaxVideoSize();
     }
 
     private void assertVideoLoaded() {

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImpl.java
@@ -18,6 +18,7 @@ import com.novoda.noplayer.internal.exoplayer.forwarder.ExoPlayerForwarder;
 import com.novoda.noplayer.internal.listeners.PlayerListenersHolder;
 import com.novoda.noplayer.internal.utils.Optional;
 import com.novoda.noplayer.model.AudioTracks;
+import com.novoda.noplayer.model.Dimension;
 import com.novoda.noplayer.model.LoadTimeout;
 import com.novoda.noplayer.model.PlayerAudioTrack;
 import com.novoda.noplayer.model.PlayerSubtitleTrack;
@@ -179,6 +180,16 @@ class ExoPlayerTwoImpl implements NoPlayer {
     @Override
     public void setMaxVideoBitrate(int maxVideoBitrate) {
         exoPlayer.setMaxVideoBitrate(maxVideoBitrate);
+    }
+
+    @Override
+    public void setMaxVideoSize(Dimension maxVideoSize) {
+        exoPlayer.setMaxVideoSize(maxVideoSize);
+    }
+
+    @Override
+    public void clearMaxVideoSize() {
+        exoPlayer.clearMaxVideoSize();
     }
 
     @Override

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/mediasource/ExoPlayerTrackSelector.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/mediasource/ExoPlayerTrackSelector.java
@@ -4,9 +4,10 @@ import com.google.android.exoplayer2.RendererCapabilities;
 import com.google.android.exoplayer2.source.TrackGroupArray;
 import com.google.android.exoplayer2.trackselection.DefaultTrackSelector;
 import com.google.android.exoplayer2.trackselection.MappingTrackSelector;
-import com.novoda.noplayer.internal.exoplayer.SupportMapper;
 import com.novoda.noplayer.internal.exoplayer.RendererTypeRequester;
+import com.novoda.noplayer.internal.exoplayer.SupportMapper;
 import com.novoda.noplayer.internal.utils.Optional;
+import com.novoda.noplayer.model.Dimension;
 import com.novoda.noplayer.model.Support;
 
 // We cannot make it final as we need to mock it in tests
@@ -120,5 +121,17 @@ public class ExoPlayerTrackSelector {
                         .setMaxVideoBitrate(maxValue)
                         .build()
         );
+    }
+
+    public void setMaxVideoSize(Dimension maxVideoSize) {
+        trackSelector.setParameters(
+                trackSelector.buildUponParameters()
+                        .setMaxVideoSize(maxVideoSize.width(), maxVideoSize.height())
+                        .build()
+        );
+    }
+
+    void clearMaxVideoSize() {
+        setMaxVideoSize(Dimension.from(Integer.MAX_VALUE, Integer.MAX_VALUE));
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/mediasource/ExoPlayerVideoTrackSelector.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/mediasource/ExoPlayerVideoTrackSelector.java
@@ -8,6 +8,7 @@ import com.google.android.exoplayer2.trackselection.DefaultTrackSelector;
 import com.novoda.noplayer.ContentType;
 import com.novoda.noplayer.internal.exoplayer.RendererTypeRequester;
 import com.novoda.noplayer.internal.utils.Optional;
+import com.novoda.noplayer.model.Dimension;
 import com.novoda.noplayer.model.PlayerVideoTrack;
 import com.novoda.noplayer.model.PlayerVideoTrackCodecMapping;
 
@@ -100,5 +101,13 @@ public class ExoPlayerVideoTrackSelector {
 
     public void setMaxVideoBitrate(int maxVideoBitrate) {
         trackSelector.setMaxVideoBitrate(maxVideoBitrate);
+    }
+
+    public void setMaxVideoSize(Dimension maxVideoSize) {
+        trackSelector.setMaxVideoSize(maxVideoSize);
+    }
+
+    public void clearMaxVideoSize() {
+        trackSelector.clearMaxVideoSize();
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerFacade.java
@@ -7,12 +7,15 @@ import android.net.Uri;
 import android.view.Surface;
 import android.view.SurfaceHolder;
 
+import androidx.annotation.Nullable;
+
 import com.novoda.noplayer.AdvertView;
 import com.novoda.noplayer.internal.mediaplayer.PlaybackStateChecker.PlaybackState;
 import com.novoda.noplayer.internal.mediaplayer.forwarder.MediaPlayerForwarder;
 import com.novoda.noplayer.internal.utils.NoPlayerLog;
 import com.novoda.noplayer.internal.utils.Optional;
 import com.novoda.noplayer.model.AudioTracks;
+import com.novoda.noplayer.model.Dimension;
 import com.novoda.noplayer.model.Either;
 import com.novoda.noplayer.model.PlayerAudioTrack;
 import com.novoda.noplayer.model.PlayerSubtitleTrack;
@@ -22,8 +25,6 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-
-import androidx.annotation.Nullable;
 
 // Not much we can do, wrapping MediaPlayer is a lot of work
 @SuppressWarnings("PMD.GodClass")
@@ -367,5 +368,15 @@ class AndroidMediaPlayerFacade {
     void skipAdvert() {
         assertIsInPlaybackState();
         NoPlayerLog.w("Tried to skip advert break but has not been implemented for MediaPlayer.");
+    }
+
+    void setMaxVideoSize(Dimension maxVideoSize) {
+        assertIsInPlaybackState();
+        NoPlayerLog.w("Tried to set maxVideoSize but has not been implemented for MediaPlayer.");
+    }
+
+    void clearMaxVideoSize() {
+        assertIsInPlaybackState();
+        NoPlayerLog.w("Tried to clear max video size but has not been implemented for MediaPlayer.");
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/mediaplayer/AndroidMediaPlayerImpl.java
@@ -20,6 +20,7 @@ import com.novoda.noplayer.internal.listeners.PlayerListenersHolder;
 import com.novoda.noplayer.internal.mediaplayer.forwarder.MediaPlayerForwarder;
 import com.novoda.noplayer.internal.utils.Optional;
 import com.novoda.noplayer.model.AudioTracks;
+import com.novoda.noplayer.model.Dimension;
 import com.novoda.noplayer.model.Either;
 import com.novoda.noplayer.model.LoadTimeout;
 import com.novoda.noplayer.model.PlayerAudioTrack;
@@ -434,6 +435,16 @@ class AndroidMediaPlayerImpl implements NoPlayer {
     @Override
     public void setMaxVideoBitrate(int maxVideoBitrate) {
         mediaPlayer.setMaxVideoBitrate(maxVideoBitrate);
+    }
+
+    @Override
+    public void setMaxVideoSize(Dimension maxVideoSize) {
+        mediaPlayer.setMaxVideoSize(maxVideoSize);
+    }
+
+    @Override
+    public void clearMaxVideoSize() {
+        mediaPlayer.clearMaxVideoSize();
     }
 
     @Override

--- a/core/src/main/java/com/novoda/noplayer/model/Dimension.java
+++ b/core/src/main/java/com/novoda/noplayer/model/Dimension.java
@@ -1,6 +1,6 @@
 package com.novoda.noplayer.model;
 
-public class Dimension {
+public final class Dimension {
 
     private final int width;
     private final int heigh;
@@ -14,7 +14,6 @@ public class Dimension {
         this.heigh = heigh;
     }
 
-
     public int width() {
         return width;
     }
@@ -25,12 +24,18 @@ public class Dimension {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof Dimension)) return false;
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof Dimension)) {
+            return false;
+        }
 
         Dimension dimension = (Dimension) o;
 
-        if (width != dimension.width) return false;
+        if (width != dimension.width) {
+            return false;
+        }
         return heigh == dimension.heigh;
     }
 
@@ -43,9 +48,9 @@ public class Dimension {
 
     @Override
     public String toString() {
-        return "Dimension{" +
-                "width=" + width +
-                ", heigh=" + heigh +
-                '}';
+        return "Dimension{"
+                + "width=" + width
+                + ", heigh=" + heigh
+                + '}';
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/model/Dimension.java
+++ b/core/src/main/java/com/novoda/noplayer/model/Dimension.java
@@ -1,0 +1,43 @@
+package com.novoda.noplayer.model;
+
+public class Dimension {
+
+    private final int width;
+    private final int heigh;
+
+    public static Dimension from(int width, int heigth) {
+        return new Dimension(width, heigth);
+    }
+
+    private Dimension(int width, int heigh) {
+        this.width = width;
+        this.heigh = heigh;
+    }
+
+
+    public int width() {
+        return width;
+    }
+
+    public int height() {
+        return heigh;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Dimension)) return false;
+
+        Dimension dimension = (Dimension) o;
+
+        if (width != dimension.width) return false;
+        return heigh == dimension.heigh;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = width;
+        result = 31 * result + heigh;
+        return result;
+    }
+}

--- a/core/src/main/java/com/novoda/noplayer/model/Dimension.java
+++ b/core/src/main/java/com/novoda/noplayer/model/Dimension.java
@@ -40,4 +40,12 @@ public class Dimension {
         result = 31 * result + heigh;
         return result;
     }
+
+    @Override
+    public String toString() {
+        return "Dimension{" +
+                "width=" + width +
+                ", heigh=" + heigh +
+                '}';
+    }
 }

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -27,7 +27,7 @@ dependencies {
     implementation 'com.google.android.exoplayer:exoplayer-core:2.10.5'
     implementation 'com.google.android.exoplayer:exoplayer-dash:2.10.5'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
-    implementation 'com.google.android.material:material:1.1.0-alpha10'
+    implementation 'com.google.android.material:material:1.1.0-beta01'
     implementation 'androidx.appcompat:appcompat:1.1.0'
     testImplementation 'junit:junit:4.12'
     testImplementation 'com.google.truth:truth:1.0'

--- a/demo/src/main/java/com/novoda/demo/MainActivity.java
+++ b/demo/src/main/java/com/novoda/demo/MainActivity.java
@@ -22,6 +22,7 @@ import com.novoda.noplayer.PlayerBuilder;
 import com.novoda.noplayer.PlayerView;
 import com.novoda.noplayer.internal.utils.NoPlayerLog;
 import com.novoda.noplayer.model.AudioTracks;
+import com.novoda.noplayer.model.Dimension;
 import com.novoda.noplayer.model.KeySetId;
 import com.novoda.noplayer.model.PlayerSubtitleTrack;
 import com.novoda.noplayer.model.PlayerVideoTrack;
@@ -33,6 +34,7 @@ public class MainActivity extends Activity {
     private static final int HALF_A_SECOND_IN_MILLIS = 500;
     private static final int TWO_MEGABITS = 2000000;
     private static final int MAX_VIDEO_BITRATE = 800000;
+    private static final Dimension MAX_VIDEO_SIZE = Dimension.from(1024, 576);
 
     private NoPlayer player;
     private ControllerView controllerView;
@@ -42,7 +44,8 @@ public class MainActivity extends Activity {
     private View videoSelectionButton;
     private View audioSelectionButton;
     private View subtitleSelectionButton;
-    private CheckBox hdSelectionCheckBox;
+    private CheckBox bitrateSelectionCheckBox;
+    private CheckBox maxVideoSizeSelectionCheckBox;
 
     private OfflineLicense offlineLicense;
 
@@ -78,13 +81,15 @@ public class MainActivity extends Activity {
         videoSelectionButton = findViewById(R.id.button_video_selection);
         audioSelectionButton = findViewById(R.id.button_audio_selection);
         subtitleSelectionButton = findViewById(R.id.button_subtitle_selection);
-        hdSelectionCheckBox = findViewById(R.id.button_hd_selection);
+        bitrateSelectionCheckBox = findViewById(R.id.button_bitrate_selection);
+        maxVideoSizeSelectionCheckBox = findViewById(R.id.button_maxsize_selection);
         controllerView = findViewById(R.id.controller_view);
 
         videoSelectionButton.setOnClickListener(showVideoSelectionDialog);
         audioSelectionButton.setOnClickListener(showAudioSelectionDialog);
         subtitleSelectionButton.setOnClickListener(showSubtitleSelectionDialog);
-        hdSelectionCheckBox.setOnCheckedChangeListener(toggleHdSelection);
+        bitrateSelectionCheckBox.setOnCheckedChangeListener(toggleBitrateSelection);
+        maxVideoSizeSelectionCheckBox.setOnCheckedChangeListener(toggleVideoSizeSelection);
     }
 
     private final NoPlayer.TracksChangedListener tracksChangedListener = new NoPlayer.TracksChangedListener() {
@@ -167,10 +172,7 @@ public class MainActivity extends Activity {
     }
 
     private int getMaxVideoBitrate() {
-        if (hdSelectionCheckBox.isChecked()) {
-            return Integer.MAX_VALUE;
-        }
-        return MAX_VIDEO_BITRATE;
+        return bitrateSelectionCheckBox.isChecked() ? MAX_VIDEO_BITRATE : Integer.MAX_VALUE;
     }
 
     private final View.OnClickListener showVideoSelectionDialog = new View.OnClickListener() {
@@ -195,13 +197,24 @@ public class MainActivity extends Activity {
         }
     };
 
-    private final CompoundButton.OnCheckedChangeListener toggleHdSelection = new CompoundButton.OnCheckedChangeListener() {
+    private final CompoundButton.OnCheckedChangeListener toggleBitrateSelection = new CompoundButton.OnCheckedChangeListener() {
         @Override
         public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
             if (isChecked) {
-                player.clearMaxVideoBitrate();
-            } else {
                 player.setMaxVideoBitrate(MAX_VIDEO_BITRATE);
+            } else {
+                player.clearMaxVideoBitrate();
+            }
+        }
+    };
+
+    private final CompoundButton.OnCheckedChangeListener toggleVideoSizeSelection = new CompoundButton.OnCheckedChangeListener() {
+        @Override
+        public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+            if (isChecked) {
+                player.setMaxVideoSize(MAX_VIDEO_SIZE);
+            } else {
+                player.clearMaxVideoSize();
             }
         }
     };

--- a/demo/src/main/java/com/novoda/demo/MainActivity.java
+++ b/demo/src/main/java/com/novoda/demo/MainActivity.java
@@ -136,9 +136,9 @@ public class MainActivity extends Activity {
     private void load(@Nullable byte[] license) {
 
         PlayerBuilder playerBuilder = new PlayerBuilder()
-            .allowFallbackDecoders()
-            .withUserAgent("Android/Linux")
-            .allowCrossProtocolRedirects();
+                .allowFallbackDecoders()
+                .withUserAgent("Android/Linux")
+                .allowCrossProtocolRedirects();
 
         if (license != null) {
             if (playbackParameters.shouldDownloadLicense()) {
@@ -163,16 +163,21 @@ public class MainActivity extends Activity {
         player.getListeners().addTracksChangedListener(tracksChangedListener);
 
         Options options = new OptionsBuilder()
-            .withContentType(ContentType.DASH)
-            .withMinDurationBeforeQualityIncreaseInMillis(HALF_A_SECOND_IN_MILLIS)
-            .withMaxInitialBitrate(TWO_MEGABITS)
-            .withMaxVideoBitrate(getMaxVideoBitrate())
-            .build();
+                .withContentType(ContentType.DASH)
+                .withMinDurationBeforeQualityIncreaseInMillis(HALF_A_SECOND_IN_MILLIS)
+                .withMaxInitialBitrate(TWO_MEGABITS)
+                .withMaxVideoBitrate(getMaxVideoBitrate())
+                .withMaxVideoSize(getMaxVideoSize())
+                .build();
         demoPresenter.startPresenting(Uri.parse(playbackParameters.mpdAddress()), options);
     }
 
     private int getMaxVideoBitrate() {
         return bitrateSelectionCheckBox.isChecked() ? MAX_VIDEO_BITRATE : Integer.MAX_VALUE;
+    }
+
+    private Dimension getMaxVideoSize() {
+        return maxVideoSizeSelectionCheckBox.isChecked() ? MAX_VIDEO_SIZE : Dimension.from(Integer.MAX_VALUE, Integer.MAX_VALUE);
     }
 
     private final View.OnClickListener showVideoSelectionDialog = new View.OnClickListener() {

--- a/demo/src/main/res/layout/activity_main.xml
+++ b/demo/src/main/res/layout/activity_main.xml
@@ -33,13 +33,25 @@
         android:layout_height="wrap_content"
         android:text="@string/subtitle" />
 
-      <CheckBox
-          android:id="@+id/button_hd_selection"
-          style="?android:attr/buttonBarButtonStyle"
-          android:layout_width="wrap_content"
-          android:layout_height="wrap_content"
-          android:text="@string/hd"/>
+    </LinearLayout>
 
+    <LinearLayout
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content">
+
+      <CheckBox
+        android:id="@+id/button_bitrate_selection"
+        style="?android:attr/buttonBarButtonStyle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/bitrate" />
+
+      <CheckBox
+        android:id="@+id/button_maxsize_selection"
+        style="?android:attr/buttonBarButtonStyle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/maxVideoSize" />
     </LinearLayout>
 
     <com.novoda.noplayer.NoPlayerView

--- a/demo/src/main/res/values/strings.xml
+++ b/demo/src/main/res/values/strings.xml
@@ -6,7 +6,8 @@
   <string name="video">Video</string>
   <string name="audio">Audio</string>
   <string name="subtitle">Subtitle</string>
-  <string name="hd">HD</string>
+  <string name="bitrate">Max Bitrate: 800kbps</string>
+  <string name="maxVideoSize">Max Video Size: 1024x576p</string>
 
   <string name="content_description_play_pause">Play/pause</string>
   <string name="enter_mpd_address">Enter MPD address</string>


### PR DESCRIPTION
## Problem

We need to add the capability of limiting the maximum video size that the ExoPlayer will allow for playback

## Solution

Expose a public method for setting the max video size that will connect to the native track selection max video size in the ExoPlayer. Also for this purpose, I have created a `Dimension` class in order to encapsulate width and hight.

I have also updated the project dependencies.

`toString`, `hashCode` and `equals` have been generated using the `IDE` code generation feature

### Test(s) added 

Tested in the demo application. While doing this I have noticed that the checkboxes were not working as expected, actually, they were implemented in reverse (checked was no limit, unchecked with a limit). I have fixed the HD checkbox and added an additional one.

### Screenshots

![Screenshot_1570442907](https://user-images.githubusercontent.com/2845931/66304201-93274780-e8f4-11e9-9139-d1346f0d326b.png)

### Paired with 

Nobody
