### PR TITLE
Metadata callback

### DIFF
--- a/core/src/main/java/com/novoda/noplayer/Listeners.java
+++ b/core/src/main/java/com/novoda/noplayer/Listeners.java
@@ -172,4 +172,18 @@ public interface Listeners {
      * @param tracksChangedListener to remove.
      */
     void removeTracksChangedListener(NoPlayer.TracksChangedListener tracksChangedListener);
+
+    /**
+     * Add a given {@link NoPlayer.MetadataChangedListener} to be notified when Metadata changes occur.
+     *
+     * @param metadataChangedListener to notify.
+     */
+    void addMetadataChangedListener(NoPlayer.MetadataChangedListener metadataChangedListener);
+
+    /**
+     * Remove a given {@link NoPlayer.MetadataChangedListener}.
+     *
+     * @param metadataChangedListener to remove.
+     */
+    void removeMetadataChangedListener(NoPlayer.MetadataChangedListener metadataChangedListener);
 }

--- a/core/src/main/java/com/novoda/noplayer/NoPlayer.java
+++ b/core/src/main/java/com/novoda/noplayer/NoPlayer.java
@@ -9,6 +9,7 @@ import com.novoda.noplayer.internal.utils.Optional;
 import com.novoda.noplayer.model.AudioTracks;
 import com.novoda.noplayer.model.Bitrate;
 import com.novoda.noplayer.model.Dimension;
+import com.novoda.noplayer.metadata.Metadata;
 import com.novoda.noplayer.model.PlayerAudioTrack;
 import com.novoda.noplayer.model.PlayerSubtitleTrack;
 import com.novoda.noplayer.model.PlayerVideoTrack;
@@ -332,6 +333,10 @@ public interface NoPlayer extends PlayerState {
 
     interface TracksChangedListener {
         void onTracksChanged();
+    }
+
+    interface MetadataChangedListener {
+        void onMetadataChanged(Metadata metadata);
     }
 
     /**

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerFacade.java
@@ -216,6 +216,7 @@ class ExoPlayerFacade {
         exoPlayer.addListener(forwarder.exoPlayerEventListener());
         exoPlayer.addAnalyticsListener(forwarder.analyticsListener());
         exoPlayer.addVideoListener(forwarder.videoListener());
+        exoPlayer.addMetadataOutput(forwarder.metadataListener());
 
         setMovieAudioAttributes(exoPlayer);
 

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImpl.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/ExoPlayerTwoImpl.java
@@ -77,6 +77,7 @@ class ExoPlayerTwoImpl implements NoPlayer {
         forwarder.bind(listenersHolder.getDroppedVideoFramesListeners());
         forwarder.bind(listenersHolder.getAdvertListeners());
         forwarder.bind(listenersHolder.getTracksChangedListeners());
+        forwarder.bind(listenersHolder.getMetadataChangedListeners());
         forwarder.bind(resetOnErrorListener());
         listenersHolder.addPreparedListener(new PreparedListener() {
             @Override

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/ExoPlayerForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/ExoPlayerForwarder.java
@@ -4,6 +4,7 @@ import com.google.android.exoplayer2.analytics.AnalyticsListener;
 import com.google.android.exoplayer2.drm.DefaultDrmSessionEventListener;
 import com.google.android.exoplayer2.source.MediaSourceEventListener;
 import com.google.android.exoplayer2.video.VideoListener;
+import com.novoda.noplayer.metadata.MetadataParser;
 import com.novoda.noplayer.NoPlayer;
 import com.novoda.noplayer.PlayerState;
 import com.novoda.noplayer.internal.utils.Optional;
@@ -15,6 +16,8 @@ public class ExoPlayerForwarder {
     private final NoPlayerAnalyticsListener analyticsListener;
     private final ExoPlayerVideoListener videoListener;
     private final ExoPlayerDrmSessionEventListener drmSessionEventListener;
+    private final ExoPlayerMetadataListener exoplayerMetadataListener;
+    private final MetadataParser metadataParser;
     private Optional<NoPlayer.AdvertListener> advertListeners = Optional.absent();
 
     public ExoPlayerForwarder() {
@@ -23,6 +26,8 @@ public class ExoPlayerForwarder {
         videoListener = new ExoPlayerVideoListener();
         analyticsListener = new NoPlayerAnalyticsListener();
         drmSessionEventListener = new ExoPlayerDrmSessionEventListener();
+        exoplayerMetadataListener = new ExoPlayerMetadataListener();
+        metadataParser = new MetadataParser();
     }
 
     public EventListener exoPlayerEventListener() {
@@ -47,6 +52,10 @@ public class ExoPlayerForwarder {
 
     public Optional<NoPlayer.AdvertListener> advertListener() {
         return advertListeners;
+    }
+
+    public ExoPlayerMetadataListener metadataListener() {
+        return exoplayerMetadataListener;
     }
 
     public void bind(NoPlayer.PreparedListener preparedListener, PlayerState playerState) {
@@ -91,5 +100,9 @@ public class ExoPlayerForwarder {
 
     public void bind(NoPlayer.TracksChangedListener tracksChangedListeners) {
         exoPlayerEventListener.add(new TracksChangedForwarder(tracksChangedListeners));
+    }
+
+    public void bind(NoPlayer.MetadataChangedListener metadataChangedListener) {
+        exoplayerMetadataListener.add(new MetadataChangedForwarder(metadataChangedListener, metadataParser));
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/ExoPlayerMetadataListener.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/ExoPlayerMetadataListener.java
@@ -1,0 +1,27 @@
+package com.novoda.noplayer.internal.exoplayer.forwarder;
+
+import com.google.android.exoplayer2.metadata.Metadata;
+import com.google.android.exoplayer2.metadata.MetadataOutput;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+public class ExoPlayerMetadataListener implements MetadataOutput {
+
+    private final List<MetadataOutput> listeners = new CopyOnWriteArrayList<>();
+
+    public void add(MetadataOutput listener) {
+        listeners.add(listener);
+    }
+
+    public void remove(MetadataOutput listener) {
+        listeners.remove(listener);
+    }
+
+    @Override
+    public void onMetadata(Metadata metadata) {
+        for(MetadataOutput listener : listeners) {
+            listener.onMetadata(metadata);
+        }
+    }
+}

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/ExoPlayerMetadataListener.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/ExoPlayerMetadataListener.java
@@ -20,7 +20,7 @@ public class ExoPlayerMetadataListener implements MetadataOutput {
 
     @Override
     public void onMetadata(Metadata metadata) {
-        for(MetadataOutput listener : listeners) {
+        for (MetadataOutput listener : listeners) {
             listener.onMetadata(metadata);
         }
     }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/MetadataChangedForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/MetadataChangedForwarder.java
@@ -1,0 +1,22 @@
+package com.novoda.noplayer.internal.exoplayer.forwarder;
+
+import com.google.android.exoplayer2.metadata.Metadata;
+import com.google.android.exoplayer2.metadata.MetadataOutput;
+import com.novoda.noplayer.metadata.MetadataParser;
+import com.novoda.noplayer.NoPlayer;
+
+class MetadataChangedForwarder implements MetadataOutput {
+
+    private final NoPlayer.MetadataChangedListener metadataChangedListener;
+    private final MetadataParser metadataParser;
+
+    MetadataChangedForwarder(NoPlayer.MetadataChangedListener metadataChangedListener, MetadataParser metadataParser) {
+        this.metadataChangedListener = metadataChangedListener;
+        this.metadataParser = metadataParser;
+    }
+
+    @Override
+    public void onMetadata(Metadata metadata) {
+        metadataChangedListener.onMetadataChanged(metadataParser.parseMetadata(metadata));
+    }
+}

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/MetadataChangedForwarder.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/forwarder/MetadataChangedForwarder.java
@@ -17,6 +17,8 @@ class MetadataChangedForwarder implements MetadataOutput {
 
     @Override
     public void onMetadata(Metadata metadata) {
-        metadataChangedListener.onMetadataChanged(metadataParser.parseMetadata(metadata));
+        if (metadata != null) {
+            metadataChangedListener.onMetadataChanged(metadataParser.parseMetadata(metadata));
+        }
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/listeners/MetadataChangedListeners.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/listeners/MetadataChangedListeners.java
@@ -1,0 +1,31 @@
+package com.novoda.noplayer.internal.listeners;
+
+import com.novoda.noplayer.NoPlayer;
+import com.novoda.noplayer.metadata.Metadata;
+
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
+
+class MetadataChangedListeners implements NoPlayer.MetadataChangedListener {
+
+    private final Set<NoPlayer.MetadataChangedListener> listeners = new CopyOnWriteArraySet<>();
+
+    public void add(NoPlayer.MetadataChangedListener listener) {
+        listeners.add(listener);
+    }
+
+    public void remove(NoPlayer.MetadataChangedListener listener) {
+        listeners.remove(listener);
+    }
+
+    public void clear() {
+        listeners.clear();
+    }
+
+    @Override
+    public void onMetadataChanged(Metadata metadata) {
+        for (NoPlayer.MetadataChangedListener listener : listeners) {
+            listener.onMetadataChanged(metadata);
+        }
+    }
+}

--- a/core/src/main/java/com/novoda/noplayer/internal/listeners/PlayerListenersHolder.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/listeners/PlayerListenersHolder.java
@@ -17,6 +17,7 @@ public class PlayerListenersHolder implements Listeners {
     private final DroppedFramesListeners droppedFramesListeners;
     private final AdvertListeners advertListeners;
     private final TracksChangedListeners tracksChangedListeners;
+    private final MetadataChangedListeners metadataChangedListeners;
 
     private final HeartbeatCallbacks heartbeatCallbacks;
 
@@ -33,6 +34,7 @@ public class PlayerListenersHolder implements Listeners {
         droppedFramesListeners = new DroppedFramesListeners();
         advertListeners = new AdvertListeners();
         tracksChangedListeners = new TracksChangedListeners();
+        metadataChangedListeners = new MetadataChangedListeners();
     }
 
     @Override
@@ -155,6 +157,16 @@ public class PlayerListenersHolder implements Listeners {
         tracksChangedListeners.remove(tracksChangedListener);
     }
 
+    @Override
+    public void addMetadataChangedListener(NoPlayer.MetadataChangedListener metadataChangedListener) {
+        metadataChangedListeners.add(metadataChangedListener);
+    }
+
+    @Override
+    public void removeMetadataChangedListener(NoPlayer.MetadataChangedListener metadataChangedListener) {
+        metadataChangedListeners.remove(metadataChangedListener);
+    }
+
     public NoPlayer.ErrorListener getErrorListeners() {
         return errorListeners;
     }
@@ -203,6 +215,10 @@ public class PlayerListenersHolder implements Listeners {
         return tracksChangedListeners;
     }
 
+    public NoPlayer.MetadataChangedListener getMetadataChangedListeners() {
+        return metadataChangedListeners;
+    }
+
     public void resetState() {
         preparedListeners.resetPreparedState();
         completionListeners.resetCompletedState();
@@ -221,5 +237,6 @@ public class PlayerListenersHolder implements Listeners {
         droppedFramesListeners.clear();
         advertListeners.clear();
         tracksChangedListeners.clear();
+        metadataChangedListeners.clear();
     }
 }

--- a/core/src/main/java/com/novoda/noplayer/metadata/Metadata.java
+++ b/core/src/main/java/com/novoda/noplayer/metadata/Metadata.java
@@ -10,6 +10,9 @@ public class Metadata {
         this.entries = entries;
     }
 
+    /**
+     * Return a list of entries that are instance of {@link BinaryFrame} or {@link EventMessage}
+     */
     public List<Entry> getEntries() {
         return entries;
     }

--- a/core/src/main/java/com/novoda/noplayer/metadata/Metadata.java
+++ b/core/src/main/java/com/novoda/noplayer/metadata/Metadata.java
@@ -1,0 +1,56 @@
+package com.novoda.noplayer.metadata;
+
+import java.util.List;
+
+public class Metadata {
+
+    private final List<Entry> entries;
+
+    public Metadata(List<Entry> entries) {
+        this.entries = entries;
+    }
+
+    public List<Entry> getEntries() {
+        return entries;
+    }
+
+    public interface Entry { }
+
+    public static class BinaryFrame implements Entry {
+
+        private final String id;
+        private final String data;
+
+        public BinaryFrame(String id, String data) {
+            this.id = id;
+            this.data = data;
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public String getData() {
+            return data;
+        }
+    }
+
+    public static class EventMessage implements Entry {
+
+        private final String schemeIdUri;
+        private final String messageData;
+
+        public EventMessage(String schemeIdUri, String messageData) {
+            this.schemeIdUri = schemeIdUri;
+            this.messageData = messageData;
+        }
+
+        public String getSchemeIdUri() {
+            return schemeIdUri;
+        }
+
+        public String getMessageData() {
+            return messageData;
+        }
+    }
+}

--- a/core/src/main/java/com/novoda/noplayer/metadata/MetadataParser.java
+++ b/core/src/main/java/com/novoda/noplayer/metadata/MetadataParser.java
@@ -3,22 +3,29 @@ package com.novoda.noplayer.metadata;
 import com.google.android.exoplayer2.metadata.emsg.EventMessage;
 import com.google.android.exoplayer2.metadata.id3.BinaryFrame;
 
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 
 public class MetadataParser {
 
+    private static final Charset UTF8 = Charset.forName("UTF-8");
+
     public Metadata parseMetadata(com.google.android.exoplayer2.metadata.Metadata metadata) {
+        if (metadata == null) {
+            return null;
+        }
+
         List<Metadata.Entry> entries = new ArrayList<>();
         for (int i = 0; i < metadata.length(); i++) {
             com.google.android.exoplayer2.metadata.Metadata.Entry entry = metadata.get(i);
             if (entry instanceof BinaryFrame) {
-                String data = new String(((BinaryFrame) entry).data);
+                String data = new String(((BinaryFrame) entry).data, UTF8);
                 String id = ((BinaryFrame) entry).id;
                 entries.add(new Metadata.BinaryFrame(id, data));
             } else if (entry instanceof EventMessage) {
                 String schemeIdUri = ((EventMessage) entry).schemeIdUri;
-                String messageData = new String(((EventMessage) entry).messageData);
+                String messageData = new String(((EventMessage) entry).messageData, UTF8);
                 entries.add(new Metadata.EventMessage(schemeIdUri, messageData));
             }
         }

--- a/core/src/main/java/com/novoda/noplayer/metadata/MetadataParser.java
+++ b/core/src/main/java/com/novoda/noplayer/metadata/MetadataParser.java
@@ -1,0 +1,28 @@
+package com.novoda.noplayer.metadata;
+
+import com.google.android.exoplayer2.metadata.emsg.EventMessage;
+import com.google.android.exoplayer2.metadata.id3.BinaryFrame;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class MetadataParser {
+
+    public Metadata parseMetadata(com.google.android.exoplayer2.metadata.Metadata metadata) {
+        List<Metadata.Entry> entries = new ArrayList<>();
+        for (int i = 0; i < metadata.length(); i++) {
+            com.google.android.exoplayer2.metadata.Metadata.Entry entry = metadata.get(i);
+            if (entry instanceof BinaryFrame) {
+                String data = new String(((BinaryFrame) entry).data);
+                String id = ((BinaryFrame) entry).id;
+                entries.add(new Metadata.BinaryFrame(id, data));
+            } else if (entry instanceof EventMessage) {
+                String schemeIdUri = ((EventMessage) entry).schemeIdUri;
+                String messageData = new String(((EventMessage) entry).messageData);
+                entries.add(new Metadata.EventMessage(schemeIdUri, messageData));
+            }
+        }
+
+        return new Metadata(entries);
+    }
+}

--- a/core/src/test/java/com/novoda/noplayer/metadata/MetadataParserTest.java
+++ b/core/src/test/java/com/novoda/noplayer/metadata/MetadataParserTest.java
@@ -1,0 +1,85 @@
+package com.novoda.noplayer.metadata;
+
+
+import com.google.android.exoplayer2.metadata.Metadata;
+import com.google.android.exoplayer2.metadata.emsg.EventMessage;
+import com.google.android.exoplayer2.metadata.flac.VorbisComment;
+import com.google.android.exoplayer2.metadata.id3.BinaryFrame;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class MetadataParserTest {
+
+    private MetadataParser parser;
+
+    @Before
+    public void setUp() {
+        parser = new MetadataParser();
+    }
+
+    @Test
+    public void parseValidMetaDataEntries() {
+        Metadata metadata = getExoValidMetadata();
+        com.novoda.noplayer.metadata.Metadata parseMetadata = parser.parseMetadata(metadata);
+
+        List<com.novoda.noplayer.metadata.Metadata.Entry> entries = parseMetadata.getEntries();
+        assertEquals(4, entries.size());
+        assertTrue(entries.get(0) instanceof com.novoda.noplayer.metadata.Metadata.BinaryFrame);
+        assertTrue(entries.get(1) instanceof com.novoda.noplayer.metadata.Metadata.EventMessage);
+    }
+
+    @Test
+    public void parseMetaDataAndIgnoreExtraEntry() {
+        Metadata metadata = getExoExtrarMetadata();
+        com.novoda.noplayer.metadata.Metadata parseMetadata = parser.parseMetadata(metadata);
+
+        List<com.novoda.noplayer.metadata.Metadata.Entry> entries = parseMetadata.getEntries();
+        assertEquals(4, entries.size());
+        assertTrue(entries.get(0) instanceof com.novoda.noplayer.metadata.Metadata.BinaryFrame);
+        assertTrue(entries.get(1) instanceof com.novoda.noplayer.metadata.Metadata.EventMessage);
+    }
+
+    @Test
+    public void parseMetaDataEmptyEntry() {
+        Metadata metadata = new Metadata();
+        com.novoda.noplayer.metadata.Metadata parseMetadata = parser.parseMetadata(metadata);
+
+        List<com.novoda.noplayer.metadata.Metadata.Entry> entries = parseMetadata.getEntries();
+        assertEquals(0, entries.size());
+    }
+
+    @Test
+    public void parseNullMetadata() {
+        com.novoda.noplayer.metadata.Metadata parseMetadata = parser.parseMetadata(null);
+        assertNull(parseMetadata);
+    }
+
+    private Metadata getExoValidMetadata() {
+        return new Metadata(getBasicEntries());
+    }
+
+    private Metadata getExoExtrarMetadata() {
+        List<Metadata.Entry> entries = getBasicEntries();
+        // add an unconsumed event
+        entries.add(0,new VorbisComment("0", "0"));
+        return new Metadata(entries);
+    }
+
+    private List<Metadata.Entry> getBasicEntries() {
+        List<Metadata.Entry> entries = new ArrayList<>();
+        entries.add(new BinaryFrame("0", "0".getBytes()));
+        entries.add(new EventMessage("uri:scheme", "0", 0, 0, "0".getBytes()));
+        entries.add(new BinaryFrame("1", "1".getBytes()));
+        entries.add(new EventMessage("uri:scheme", "1", 1, 1, "1".getBytes()));
+        return entries;
+    }
+
+}

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
     buildToolsVersion '28.0.3'
 
     defaultConfig {
         applicationId 'com.novoda.demo'
         minSdkVersion 16
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionCode 1
         versionName '1.0'
     }

--- a/demo/src/main/java/com/novoda/demo/MainActivity.java
+++ b/demo/src/main/java/com/novoda/demo/MainActivity.java
@@ -24,6 +24,7 @@ import com.novoda.noplayer.internal.utils.NoPlayerLog;
 import com.novoda.noplayer.model.AudioTracks;
 import com.novoda.noplayer.model.Dimension;
 import com.novoda.noplayer.model.KeySetId;
+import com.novoda.noplayer.metadata.Metadata;
 import com.novoda.noplayer.model.PlayerSubtitleTrack;
 import com.novoda.noplayer.model.PlayerVideoTrack;
 
@@ -91,6 +92,13 @@ public class MainActivity extends Activity {
         bitrateSelectionCheckBox.setOnCheckedChangeListener(toggleBitrateSelection);
         maxVideoSizeSelectionCheckBox.setOnCheckedChangeListener(toggleVideoSizeSelection);
     }
+
+    private final NoPlayer.MetadataChangedListener onMetadataChanged = new NoPlayer.MetadataChangedListener(){
+        @Override
+        public void onMetadataChanged(Metadata metadata) {
+            Log.v(getClass().getSimpleName(), "onMetadata: " + metadata.getEntries().size());
+        }
+    };
 
     private final NoPlayer.TracksChangedListener tracksChangedListener = new NoPlayer.TracksChangedListener() {
         @Override
@@ -161,6 +169,7 @@ public class MainActivity extends Activity {
             }
         });
         player.getListeners().addTracksChangedListener(tracksChangedListener);
+        player.getListeners().addMetadataChangedListener(onMetadataChanged);
 
         Options options = new OptionsBuilder()
                 .withContentType(ContentType.DASH)

--- a/demo/src/main/java/com/novoda/demo/MainActivity.java
+++ b/demo/src/main/java/com/novoda/demo/MainActivity.java
@@ -93,7 +93,7 @@ public class MainActivity extends Activity {
         maxVideoSizeSelectionCheckBox.setOnCheckedChangeListener(toggleVideoSizeSelection);
     }
 
-    private final NoPlayer.MetadataChangedListener onMetadataChanged = new NoPlayer.MetadataChangedListener(){
+    private final NoPlayer.MetadataChangedListener onMetadataChanged = new NoPlayer.MetadataChangedListener() {
         @Override
         public void onMetadataChanged(Metadata metadata) {
             Log.v(getClass().getSimpleName(), "onMetadata: " + metadata.getEntries().size());


### PR DESCRIPTION
## Problem

Metadata object (Exoplayer) was being passed as a string to the info listener, you can't access data properly within it (to use for analytics reporting etc...).

## Solution

Create NoPlayer Metadata object and parse Exoplayer metadata object to the NoPlayer one.
At some point we probably need to do the same thing for the android media player

### Test(s) added 

Unit tests for the Metadata parser

### Paired with 

Nobody
