### PR TITLE
Move SubtitleView outside aspect ratio frame layout changes

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -40,8 +40,8 @@ buildProperties {
 }
 
 android {
-    compileSdkVersion 28
-    buildToolsVersion '28.0.3'
+    compileSdkVersion 29
+    buildToolsVersion '29.0.2'
 
     defaultConfig {
         minSdkVersion 16

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -41,7 +41,7 @@ buildProperties {
 
 android {
     compileSdkVersion 29
-    buildToolsVersion '29.0.2'
+    buildToolsVersion '28.0.3'
 
     defaultConfig {
         minSdkVersion 16

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -41,7 +41,7 @@ buildProperties {
 
 android {
     compileSdkVersion 29
-    buildToolsVersion '28.0.3'
+    buildToolsVersion '29.0.2'
 
     defaultConfig {
         minSdkVersion 16

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/error/RendererErrorMapper.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/error/RendererErrorMapper.java
@@ -125,6 +125,9 @@ final class RendererErrorMapper {
                         DetailErrorType.LICENSE_POLICY_REQUIRED_NOT_SUPPORTED_BY_DEVICE_ERROR,
                         message
                 );
+            case MediaCodec.CryptoException.ERROR_INSUFFICIENT_SECURITY:
+            case MediaCodec.CryptoException.ERROR_FRAME_TOO_LARGE:
+            case MediaCodec.CryptoException.ERROR_LOST_STATE:
             default:
                 return new NoPlayerError(PlayerErrorType.CONTENT_DECRYPTION, DetailErrorType.UNKNOWN, message);
         }

--- a/core/src/main/res/layout/noplayer_view.xml
+++ b/core/src/main/res/layout/noplayer_view.xml
@@ -1,25 +1,30 @@
 <?xml version="1.0" encoding="utf-8"?>
-<com.google.android.exoplayer2.ui.AspectRatioFrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-  android:id="@+id/video_frame"
-  android:layout_width="match_parent"
-  android:layout_height="wrap_content">
+<merge xmlns:android="http://schemas.android.com/apk/res/android">
 
-  <SurfaceView
-    android:id="@+id/surface_view"
+  <com.google.android.exoplayer2.ui.AspectRatioFrameLayout
+    android:id="@+id/video_frame"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:layout_gravity="center" />
+    android:layout_height="wrap_content"
+    android:layout_gravity="center">
+
+    <SurfaceView
+      android:id="@+id/surface_view"
+      android:layout_width="match_parent"
+      android:layout_height="match_parent"
+      android:layout_gravity="center" />
+
+    <View
+      android:id="@+id/shutter"
+      android:layout_width="match_parent"
+      android:layout_height="match_parent"
+      android:background="@android:color/black" />
+
+  </com.google.android.exoplayer2.ui.AspectRatioFrameLayout>
 
   <com.novoda.noplayer.SubtitleView
     android:id="@+id/subtitles_layout"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
     android:visibility="gone" />
 
-  <View
-    android:id="@+id/shutter"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="@android:color/black" />
-
-</com.google.android.exoplayer2.ui.AspectRatioFrameLayout>
+</merge>

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 29
-    buildToolsVersion '29.0.2'
+    buildToolsVersion '28.0.3'
 
     defaultConfig {
         applicationId 'com.novoda.demo'

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 28
-    buildToolsVersion '28.0.3'
+    compileSdkVersion 29
+    buildToolsVersion '29.0.2'
 
     defaultConfig {
         applicationId 'com.novoda.demo'
         minSdkVersion 16
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionCode 1
         versionName '1.0'
     }

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 29
-    buildToolsVersion '28.0.3'
+    buildToolsVersion '29.0.2'
 
     defaultConfig {
         applicationId 'com.novoda.demo'


### PR DESCRIPTION
## Problem

With resize mode changes the subtitles were being cut off in some scenarios

## Solution

Move the subtitle view out of the view whose size is controlled by the `AspectRatioFrameLayout`. This changes the behavior of the player if it's not in full-screen which can be seen in the portrait gif..

The reason why this didn't work was that the `SubtitleView` matched the size of the `AspectRatioFrameLayout` whose canvas would be bigger than the screen in certain resize modes. Moving it outside makes it match the size of the parent which is `NoPlayerView` that is fixed. That's why there is the different behavior in portrait

### Test(s) added 

none, the views just moved in the layout file

### Screenshots

| Before | After |
| ------ | ----- |
| ![2019-11-05 14 36 29](https://user-images.githubusercontent.com/1104656/68212449-d51dd900-ffd9-11e9-85cd-2c7ca02bd928.gif) | ![2019-11-05 14 32 10](https://user-images.githubusercontent.com/1104656/68212189-51fc8300-ffd9-11e9-9569-d098cded4c2c.gif) |
| ![2019-11-05 14 37 23](https://user-images.githubusercontent.com/1104656/68212469-dbac5080-ffd9-11e9-826b-70d4bd9b08d7.gif) | ![2019-11-05 14 32 46](https://user-images.githubusercontent.com/1104656/68212205-588afa80-ffd9-11e9-8b88-c63c158c1a01.gif) |

### Paired with 

nobody
