### PR TITLE
Gated adverts fix - prevent ads enabling from triggering gate instantly

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -60,7 +60,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.google.android.exoplayer:exoplayer-core:2.10.5'
+    implementation 'com.google.android.exoplayer:exoplayer-core:local'
     implementation 'com.google.android.exoplayer:exoplayer-hls:2.10.5'
     implementation 'com.google.android.exoplayer:exoplayer-dash:2.10.5'
     implementation 'com.google.android.exoplayer:exoplayer-ui:2.10.5'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -60,7 +60,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.google.android.exoplayer:exoplayer-core:local'
+    implementation 'com.google.android.exoplayer:exoplayer-core:2.10.5'
     implementation 'com.google.android.exoplayer:exoplayer-hls:2.10.5'
     implementation 'com.google.android.exoplayer:exoplayer-dash:2.10.5'
     implementation 'com.google.android.exoplayer:exoplayer-ui:2.10.5'

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/AdvertState.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/AdvertState.java
@@ -31,6 +31,8 @@ class AdvertState {
 
         void skipDisabledAdvertBreak(int advertBreakIndex, AdvertBreak advertBreak);
 
+        void reenableSkippedAdverts(List<AdvertBreak> advertBreaks);
+
         void onAdvertSkipped(int advertBreakIndex, int advertIndex, Advert advert);
 
         void onAdvertClicked(Advert advert);
@@ -136,7 +138,7 @@ class AdvertState {
         if (!advertsDisabled) {
             return;
         }
-        
+
         advertsDisabled = false;
         callback.onAdvertsEnabled(advertBreaks);
         resetState();
@@ -163,6 +165,13 @@ class AdvertState {
             callback.onAdvertBreakEnd(advertBreak);
         }
         resetState();
+    }
+
+    void handleSeek() {
+        if (advertsDisabled) {
+            return;
+        }
+        callback.reenableSkippedAdverts(advertBreaks);
     }
 
     void clickAdvert() {

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/AdvertState.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/AdvertState.java
@@ -29,6 +29,8 @@ class AdvertState {
 
         void onAdvertBreakSkipped(int advertBreakIndex, AdvertBreak advertBreak);
 
+        void skipDisabledAdvertBreak(int advertBreakIndex, AdvertBreak advertBreak);
+
         void onAdvertSkipped(int advertBreakIndex, int advertIndex, Advert advert);
 
         void onAdvertClicked(Advert advert);
@@ -61,6 +63,14 @@ class AdvertState {
     void update(boolean isPlayingAdvert, int currentAdvertBreakIndex, int currentAdvertIndex) {
         boolean wasPlayingAd = playingAdvert;
         playingAdvert = isPlayingAdvert;
+
+        if (advertsDisabled) {
+            if (isPlayingAdvert) {
+                callback.skipDisabledAdvertBreak(currentAdvertBreakIndex, advertBreaks.get(advertBreakIndex));
+            }
+            resetState();
+            return;
+        }
 
         int previousAdvertBreakIndex = advertBreakIndex;
         int previousAdvertIndex = advertIndex;
@@ -109,23 +119,16 @@ class AdvertState {
     }
 
     void disableAdverts() {
-        if (advertsDisabled) {
-            return;
+        if (playingAdvert) {
+            callback.onAdvertBreakSkipped(advertBreakIndex, advertBreaks.get(advertBreakIndex));
         }
-
         advertsDisabled = true;
         callback.onAdvertsDisabled(advertBreaks);
-        resetState();
     }
 
     void enableAdverts() {
-        if (!advertsDisabled) {
-            return;
-        }
-
         advertsDisabled = false;
         callback.onAdvertsEnabled(advertBreaks);
-        resetState();
     }
 
     void skipAdvertBreak() {

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/AdvertState.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/AdvertState.java
@@ -66,7 +66,7 @@ class AdvertState {
 
         if (advertsDisabled) {
             if (isPlayingAdvert) {
-                callback.skipDisabledAdvertBreak(currentAdvertBreakIndex, advertBreaks.get(advertBreakIndex));
+                callback.skipDisabledAdvertBreak(currentAdvertBreakIndex, advertBreaks.get(currentAdvertBreakIndex));
             }
             resetState();
             return;
@@ -77,16 +77,17 @@ class AdvertState {
 
         advertBreakIndex = playingAdvert ? currentAdvertBreakIndex : INVALID_INDEX;
         advertIndex = playingAdvert ? currentAdvertIndex : INVALID_INDEX;
-        boolean advertFinished = wasPlayingAd && advertIndex != previousAdvertIndex;
 
+        boolean advertStarted = isPlayingAdvert && advertIndex != previousAdvertIndex;
+
+        if (advertStarted) {
+            notifyAdvertStart(advertBreakIndex, advertIndex);
+        }
+
+        boolean advertFinished = wasPlayingAd && advertIndex != previousAdvertIndex;
         if (advertFinished) {
             callback.onAdvertPlayed(previousAdvertBreakIndex, previousAdvertIndex);
             notifyAdvertEnd(previousAdvertBreakIndex, previousAdvertIndex);
-        }
-
-        boolean advertStarted = isPlayingAdvert && advertIndex != previousAdvertIndex;
-        if (advertStarted) {
-            notifyAdvertStart(advertBreakIndex, advertIndex);
         }
     }
 
@@ -119,16 +120,25 @@ class AdvertState {
     }
 
     void disableAdverts() {
+        if (advertsDisabled) {
+            return;
+        }
+
         if (playingAdvert) {
-            callback.onAdvertBreakSkipped(advertBreakIndex, advertBreaks.get(advertBreakIndex));
+            callback.skipDisabledAdvertBreak(advertBreakIndex, advertBreaks.get(advertBreakIndex));
         }
         advertsDisabled = true;
         callback.onAdvertsDisabled(advertBreaks);
+        resetState();
     }
 
     void enableAdverts() {
+        if (!advertsDisabled) {
+            return;
+        }
         advertsDisabled = false;
         callback.onAdvertsEnabled(advertBreaks);
+        resetState();
     }
 
     void skipAdvertBreak() {

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/AdvertState.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/AdvertState.java
@@ -7,6 +7,7 @@ import com.novoda.noplayer.AdvertBreak;
 import java.io.IOException;
 import java.util.List;
 
+@SuppressWarnings("PMD.GodClass")
 class AdvertState {
 
     interface Callback {
@@ -63,16 +64,23 @@ class AdvertState {
     }
 
     void update(boolean isPlayingAdvert, int currentAdvertBreakIndex, int currentAdvertIndex) {
+        if (advertsDisabled) {
+            skipDisabledAdvertBreak(isPlayingAdvert, currentAdvertBreakIndex);
+        } else {
+            updateNotDisabled(isPlayingAdvert, currentAdvertBreakIndex, currentAdvertIndex);
+        }
+    }
+
+    private void skipDisabledAdvertBreak(boolean isPlayingAdvert, int currentAdvertBreakIndex) {
+        if (isPlayingAdvert) {
+            callback.skipDisabledAdvertBreak(currentAdvertBreakIndex, advertBreaks.get(currentAdvertBreakIndex));
+        }
+        resetState();
+    }
+
+    private void updateNotDisabled(boolean isPlayingAdvert, int currentAdvertBreakIndex, int currentAdvertIndex) {
         boolean wasPlayingAd = playingAdvert;
         playingAdvert = isPlayingAdvert;
-
-        if (advertsDisabled) {
-            if (isPlayingAdvert) {
-                callback.skipDisabledAdvertBreak(currentAdvertBreakIndex, advertBreaks.get(currentAdvertBreakIndex));
-            }
-            resetState();
-            return;
-        }
 
         int previousAdvertBreakIndex = advertBreakIndex;
         int previousAdvertIndex = advertIndex;
@@ -90,7 +98,6 @@ class AdvertState {
         if (advertStarted) {
             notifyAdvertStart(advertBreakIndex, advertIndex);
         }
-
     }
 
     private void notifyAdvertEnd(int playedAdvertBreakIndex, int playedAdvertIndex) {

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/AdvertState.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/AdvertState.java
@@ -136,6 +136,7 @@ class AdvertState {
         if (!advertsDisabled) {
             return;
         }
+        
         advertsDisabled = false;
         callback.onAdvertsEnabled(advertBreaks);
         resetState();

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/AdvertState.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/AdvertState.java
@@ -80,17 +80,17 @@ class AdvertState {
         advertBreakIndex = playingAdvert ? currentAdvertBreakIndex : INVALID_INDEX;
         advertIndex = playingAdvert ? currentAdvertIndex : INVALID_INDEX;
 
-        boolean advertStarted = isPlayingAdvert && advertIndex != previousAdvertIndex;
-
-        if (advertStarted) {
-            notifyAdvertStart(advertBreakIndex, advertIndex);
-        }
-
         boolean advertFinished = wasPlayingAd && advertIndex != previousAdvertIndex;
         if (advertFinished) {
             callback.onAdvertPlayed(previousAdvertBreakIndex, previousAdvertIndex);
             notifyAdvertEnd(previousAdvertBreakIndex, previousAdvertIndex);
         }
+
+        boolean advertStarted = isPlayingAdvert && advertIndex != previousAdvertIndex;
+        if (advertStarted) {
+            notifyAdvertStart(advertBreakIndex, advertIndex);
+        }
+
     }
 
     private void notifyAdvertEnd(int playedAdvertBreakIndex, int playedAdvertIndex) {

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
@@ -267,14 +267,13 @@ public class NoPlayerAdsLoader implements AdsLoader, Player.EventListener, Adver
 
         @Override
         public void onAdvertsDisabled(List<AdvertBreak> advertBreaks) {
-            adPlaybackState = SkippedAdverts.markAdvertBreakAsSkipped(advertBreaks, adPlaybackState);
-            updateAdPlaybackState();
             advertListener.onAdvertsDisabled();
         }
 
         @Override
         public void onAdvertsEnabled(List<AdvertBreak> advertBreaks) {
             AvailableAdverts.markSkippedAdvertsAsAvailable(advertBreaks, adPlaybackState);
+            adPlaybackState = SkippedAdverts.markCurrentGateAsSkipped(player.getContentPosition(), advertBreaks, adPlaybackState);
             updateAdPlaybackState();
             advertListener.onAdvertsEnabled(advertBreaks);
         }
@@ -284,6 +283,12 @@ public class NoPlayerAdsLoader implements AdsLoader, Player.EventListener, Adver
             adPlaybackState = SkippedAdverts.markAdvertBreakAsSkipped(advertBreakIndex, adPlaybackState);
             updateAdPlaybackState();
             advertListener.onAdvertBreakSkipped(advertBreak);
+        }
+
+        @Override
+        public void skipDisabledAdvertBreak(int advertBreakIndex, AdvertBreak advertBreak) {
+            adPlaybackState = SkippedAdverts.markAdvertBreakAsSkipped(advertBreakIndex, adPlaybackState);
+            updateAdPlaybackState();
         }
 
         @Override

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/NoPlayerAdsLoader.java
@@ -22,6 +22,8 @@ import java.util.concurrent.TimeUnit;
 
 import androidx.annotation.Nullable;
 
+import static com.google.android.exoplayer2.Player.DISCONTINUITY_REASON_SEEK;
+
 // Not much we can do, orchestrating adverts is a lot of work.
 @SuppressWarnings("PMD.GodClass")
 public class NoPlayerAdsLoader implements AdsLoader, Player.EventListener, AdvertView.AdvertInteractionListener {
@@ -189,6 +191,10 @@ public class NoPlayerAdsLoader implements AdsLoader, Player.EventListener, Adver
             // We need all of the above to be able to respond to advert events.
             return;
         }
+        if (reason == DISCONTINUITY_REASON_SEEK) {
+            advertState.handleSeek();
+        }
+
         advertState.update(player.isPlayingAd(), player.getCurrentAdGroupIndex(), player.getCurrentAdIndexInAdGroup());
     }
 
@@ -288,6 +294,12 @@ public class NoPlayerAdsLoader implements AdsLoader, Player.EventListener, Adver
         @Override
         public void skipDisabledAdvertBreak(int advertBreakIndex, AdvertBreak advertBreak) {
             adPlaybackState = SkippedAdverts.markAdvertBreakAsSkipped(advertBreakIndex, adPlaybackState);
+            updateAdPlaybackState();
+        }
+
+        @Override
+        public void reenableSkippedAdverts(List<AdvertBreak> advertBreaks) {
+            AvailableAdverts.markSkippedAdvertsAsAvailable(advertBreaks, adPlaybackState);
             updateAdPlaybackState();
         }
 

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/SkippedAdverts.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/SkippedAdverts.java
@@ -1,5 +1,6 @@
 package com.novoda.noplayer.internal.exoplayer;
 
+import com.google.android.exoplayer2.C;
 import com.google.android.exoplayer2.source.ads.AdPlaybackState;
 import com.novoda.noplayer.AdvertBreak;
 
@@ -80,19 +81,21 @@ final class SkippedAdverts {
     static AdPlaybackState markCurrentGateAsSkipped(long currentPositionInMillis,
                                                     List<AdvertBreak> advertBreaks,
                                                     AdPlaybackState adPlaybackState) {
-        AdPlaybackState updatedPlaybackState = adPlaybackState;
 
-        long min = Long.MAX_VALUE;
-        int advertBreakIndex = 0;
-
+        int advertBreakIndex = C.INDEX_UNSET;
         for (int i = 0; i < advertBreaks.size(); i++) {
-            long distance = currentPositionInMillis - advertBreaks.get(i).startTimeInMillis();
-            if (min > distance && distance > 0) {
+            if (advertBreaks.get(i).startTimeInMillis() <= currentPositionInMillis) {
                 advertBreakIndex = i;
+            } else {
+                break;
             }
         }
 
-        return updatedPlaybackState.withSkippedAdGroup(advertBreakIndex);
+        if (advertBreakIndex == C.INDEX_UNSET) {
+            return adPlaybackState;
+        } else {
+            return adPlaybackState.withSkippedAdGroup(advertBreakIndex);
+        }
     }
 
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/SkippedAdverts.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/SkippedAdverts.java
@@ -77,4 +77,21 @@ final class SkippedAdverts {
         return updatedPlaybackState;
     }
 
+    static AdPlaybackState markCurrentGateAsSkipped(long currentPositionInMillis,
+                                                    List<AdvertBreak> advertBreaks,
+                                                    AdPlaybackState adPlaybackState) {
+        long min = Long.MAX_VALUE;
+        int advertBreakIndex = 0;
+
+        for (int i = 0; i < advertBreaks.size(); i++) {
+            long distance = currentPositionInMillis - advertBreaks.get(i).startTimeInMillis();
+            if (min > distance && distance > 0) {
+                advertBreakIndex = i;
+            }
+        }
+
+        AdPlaybackState updatedPlaybackState = adPlaybackState;
+        return updatedPlaybackState.withSkippedAdGroup(advertBreakIndex);
+    }
+
 }

--- a/core/src/main/java/com/novoda/noplayer/internal/exoplayer/SkippedAdverts.java
+++ b/core/src/main/java/com/novoda/noplayer/internal/exoplayer/SkippedAdverts.java
@@ -80,6 +80,8 @@ final class SkippedAdverts {
     static AdPlaybackState markCurrentGateAsSkipped(long currentPositionInMillis,
                                                     List<AdvertBreak> advertBreaks,
                                                     AdPlaybackState adPlaybackState) {
+        AdPlaybackState updatedPlaybackState = adPlaybackState;
+
         long min = Long.MAX_VALUE;
         int advertBreakIndex = 0;
 
@@ -90,7 +92,6 @@ final class SkippedAdverts {
             }
         }
 
-        AdPlaybackState updatedPlaybackState = adPlaybackState;
         return updatedPlaybackState.withSkippedAdGroup(advertBreakIndex);
     }
 

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/AdvertStateTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/AdvertStateTest.java
@@ -309,4 +309,23 @@ public class AdvertStateTest {
 
         then(callback).shouldHaveZeroInteractions();
     }
+
+    @Test
+    public void doesNotHandleSeekWhenAdvertsDisabled() {
+        advertState.disableAdverts();
+        Mockito.reset(callback);
+
+        advertState.handleSeek();
+
+        then(callback).shouldHaveNoInteractions();
+    }
+
+    @Test
+    public void doesHandleSeekWhenAdvertsEnabled() {
+        advertState.handleSeek();
+
+        then(callback).should().reenableSkippedAdverts(ADVERT_BREAKS);
+    }
+
+
 }

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/AdvertStateTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/AdvertStateTest.java
@@ -19,8 +19,11 @@ import utils.ExceptionMatcher;
 import static com.novoda.noplayer.AdvertBreakFixtures.anAdvertBreak;
 import static com.novoda.noplayer.AdvertFixtures.anAdvert;
 import static org.fest.assertions.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 
 public class AdvertStateTest {
 
@@ -327,5 +330,26 @@ public class AdvertStateTest {
         then(callback).should().reenableSkippedAdverts(ADVERT_BREAKS);
     }
 
+    @Test
+    public void skipsPlayingAdvertsOnDisable() {
+        advertState.update(IS_PLAYING_ADVERT, 0, 0);
+
+        advertState.disableAdverts();
+
+        then(callback).should().skipDisabledAdvertBreak(0, FIRST_ADVERT_BREAK);
+    }
+
+    @Test
+    public void skipsPlayingAdvertsOnUpdateWhenDisabled() {
+        advertState.disableAdverts();
+
+        then(callback).should().onAdvertsDisabled(ADVERT_BREAKS);
+        then(callback).should(never()).skipDisabledAdvertBreak(anyInt(), any(AdvertBreak.class));
+
+        advertState.update(IS_PLAYING_ADVERT, 0, 0);
+
+        then(callback).should().skipDisabledAdvertBreak(0, FIRST_ADVERT_BREAK);
+        then(callback).shouldHaveNoMoreInteractions();
+    }
 
 }

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/SkippedAdvertsTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/SkippedAdvertsTest.java
@@ -3,12 +3,15 @@ package com.novoda.noplayer.internal.exoplayer;
 import com.google.android.exoplayer2.source.ads.AdPlaybackState;
 import com.novoda.noplayer.AdvertBreak;
 
+import org.junit.Test;
+
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.Test;
-
-import static com.google.android.exoplayer2.source.ads.AdPlaybackState.*;
+import static com.google.android.exoplayer2.source.ads.AdPlaybackState.AD_STATE_AVAILABLE;
+import static com.google.android.exoplayer2.source.ads.AdPlaybackState.AD_STATE_PLAYED;
+import static com.google.android.exoplayer2.source.ads.AdPlaybackState.AD_STATE_SKIPPED;
 import static com.novoda.noplayer.AdvertBreakFixtures.anAdvertBreak;
 import static com.novoda.noplayer.AdvertFixtures.anAdvert;
 import static org.fest.assertions.api.Assertions.assertThat;
@@ -105,6 +108,82 @@ public class SkippedAdvertsTest {
         assertThatGroupContains(adPlaybackState.adGroups[2], new int[]{AD_STATE_PLAYED});
         assertThatGroupContains(adPlaybackState.adGroups[3], new int[]{AD_STATE_PLAYED});
     }
+
+    @Test
+    public void markCurrentGateAsSkipped() {
+        AdPlaybackState initialAvailableAdPlaybackState = AdvertPlaybackState.from(ADVERT_BREAKS).adPlaybackState();
+        AdPlaybackState adPlaybackState = SkippedAdverts.markCurrentGateAsSkipped(TWENTY_SECONDS_IN_MILLIS + 1, ADVERT_BREAKS, initialAvailableAdPlaybackState);
+
+        assertThatGroupContains(adPlaybackState.adGroups[0], new int[]{AD_STATE_AVAILABLE, AD_STATE_AVAILABLE});
+        assertThatGroupContains(adPlaybackState.adGroups[1], new int[]{AD_STATE_SKIPPED});
+        assertThatGroupContains(adPlaybackState.adGroups[2], new int[]{AD_STATE_AVAILABLE});
+        assertThatGroupContains(adPlaybackState.adGroups[3], new int[]{AD_STATE_AVAILABLE});
+    }
+
+    @Test
+    public void doesNotMarkCurrentPlayedGateAsSkipped() {
+        AdPlaybackState initialAvailableAdPlaybackState = AdvertPlaybackState.from(ADVERT_BREAKS).adPlaybackState();
+        initialAvailableAdPlaybackState = initialAvailableAdPlaybackState.withPlayedAd(0, 0);
+        initialAvailableAdPlaybackState = initialAvailableAdPlaybackState.withPlayedAd(0, 1);
+        AdPlaybackState adPlaybackState = SkippedAdverts.markCurrentGateAsSkipped(TWENTY_SECONDS_IN_MILLIS, ADVERT_BREAKS, initialAvailableAdPlaybackState);
+
+        assertThatGroupContains(adPlaybackState.adGroups[0], new int[]{AD_STATE_PLAYED, AD_STATE_PLAYED});
+        assertThatGroupContains(adPlaybackState.adGroups[1], new int[]{AD_STATE_AVAILABLE});
+        assertThatGroupContains(adPlaybackState.adGroups[2], new int[]{AD_STATE_AVAILABLE});
+        assertThatGroupContains(adPlaybackState.adGroups[3], new int[]{AD_STATE_AVAILABLE});
+    }
+
+    @Test
+    public void doesNotMarkCurrentNonInitialPlayedGateAsSkipped() {
+        AdPlaybackState initialAvailableAdPlaybackState = AdvertPlaybackState.from(ADVERT_BREAKS).adPlaybackState();
+        initialAvailableAdPlaybackState = initialAvailableAdPlaybackState.withPlayedAd(0, 0);
+        initialAvailableAdPlaybackState = initialAvailableAdPlaybackState.withPlayedAd(0, 1);
+        initialAvailableAdPlaybackState = initialAvailableAdPlaybackState.withPlayedAd(1, 0);
+        AdPlaybackState adPlaybackState = SkippedAdverts.markCurrentGateAsSkipped(TWENTY_SECONDS_IN_MILLIS + 1, ADVERT_BREAKS, initialAvailableAdPlaybackState);
+
+        assertThatGroupContains(adPlaybackState.adGroups[0], new int[]{AD_STATE_PLAYED, AD_STATE_PLAYED});
+        assertThatGroupContains(adPlaybackState.adGroups[1], new int[]{AD_STATE_PLAYED});
+        assertThatGroupContains(adPlaybackState.adGroups[2], new int[]{AD_STATE_AVAILABLE});
+        assertThatGroupContains(adPlaybackState.adGroups[3], new int[]{AD_STATE_AVAILABLE});
+    }
+
+    @Test
+    public void markVeryFirstCurrentGateAsSkipped() {
+        AdPlaybackState initialAvailableAdPlaybackState = AdvertPlaybackState.from(ADVERT_BREAKS).adPlaybackState();
+        AdPlaybackState adPlaybackState = SkippedAdverts.markCurrentGateAsSkipped(0, ADVERT_BREAKS, initialAvailableAdPlaybackState);
+
+        assertThatGroupContains(adPlaybackState.adGroups[0], new int[]{AD_STATE_SKIPPED, AD_STATE_SKIPPED});
+        assertThatGroupContains(adPlaybackState.adGroups[1], new int[]{AD_STATE_AVAILABLE});
+        assertThatGroupContains(adPlaybackState.adGroups[2], new int[]{AD_STATE_AVAILABLE});
+        assertThatGroupContains(adPlaybackState.adGroups[3], new int[]{AD_STATE_AVAILABLE});
+    }
+
+    @Test
+    public void markVeryLastCurrentGateAsSkipped() {
+        AdPlaybackState initialAvailableAdPlaybackState = AdvertPlaybackState.from(ADVERT_BREAKS).adPlaybackState();
+        AdPlaybackState adPlaybackState = SkippedAdverts.markCurrentGateAsSkipped(Long.MAX_VALUE, ADVERT_BREAKS, initialAvailableAdPlaybackState);
+
+        assertThatGroupContains(adPlaybackState.adGroups[0], new int[]{AD_STATE_AVAILABLE, AD_STATE_AVAILABLE});
+        assertThatGroupContains(adPlaybackState.adGroups[1], new int[]{AD_STATE_AVAILABLE});
+        assertThatGroupContains(adPlaybackState.adGroups[2], new int[]{AD_STATE_AVAILABLE});
+        assertThatGroupContains(adPlaybackState.adGroups[3], new int[]{AD_STATE_SKIPPED});
+    }
+
+// TODO refactor method
+//    @Test
+//    public void doesNotMarkAnyGateAsSkippedForNoAds() {
+//        AdPlaybackState initialAvailableAdPlaybackState = AdvertPlaybackState.from(new ArrayList<AdvertBreak>(0)).adPlaybackState();
+//        AdPlaybackState adPlaybackState = SkippedAdverts.markCurrentGateAsSkipped(0, ADVERT_BREAKS, initialAvailableAdPlaybackState);
+//        assertThat(initialAvailableAdPlaybackState).isEqualTo(adPlaybackState);
+//    }
+//
+//
+//    @Test
+//    public void doesNotMarkAnyGateAsSkippedForNegativePosition() {
+//        AdPlaybackState initialAvailableAdPlaybackState = AdvertPlaybackState.from(ADVERT_BREAKS).adPlaybackState();
+//        AdPlaybackState adPlaybackState = SkippedAdverts.markCurrentGateAsSkipped(-1, ADVERT_BREAKS, initialAvailableAdPlaybackState);
+//        assertThat(initialAvailableAdPlaybackState).isEqualTo(adPlaybackState);
+//    }
 
     private void assertThatGroupContains(AdPlaybackState.AdGroup adGroup, int[] states) {
         assertThat(adGroup.states).containsOnly(states);

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/SkippedAdvertsTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/SkippedAdvertsTest.java
@@ -145,19 +145,6 @@ public class SkippedAdvertsTest {
     }
 
     @Test
-    public void doesNotMarkCurrentGateAsSkippedIfPlayedFirstAlready() {
-        AdPlaybackState initialAvailableAdPlaybackState = AdvertPlaybackState.from(ADVERT_BREAKS).adPlaybackState();
-        initialAvailableAdPlaybackState = initialAvailableAdPlaybackState.withPlayedAd(0, 0);
-        initialAvailableAdPlaybackState = initialAvailableAdPlaybackState.withPlayedAd(0, 1);
-        AdPlaybackState adPlaybackState = SkippedAdverts.markCurrentGateAsSkipped(1, ADVERT_BREAKS, initialAvailableAdPlaybackState);
-
-        assertThatGroupContains(adPlaybackState.adGroups[0], new int[]{AD_STATE_PLAYED, AD_STATE_PLAYED});
-        assertThatGroupContains(adPlaybackState.adGroups[1], new int[]{AD_STATE_AVAILABLE});
-        assertThatGroupContains(adPlaybackState.adGroups[2], new int[]{AD_STATE_AVAILABLE});
-        assertThatGroupContains(adPlaybackState.adGroups[3], new int[]{AD_STATE_AVAILABLE});
-    }
-
-    @Test
     public void markCurrentGateAsSkippedForTheFirstGate() {
         AdPlaybackState initialAvailableAdPlaybackState = AdvertPlaybackState.from(ADVERT_BREAKS).adPlaybackState();
         AdPlaybackState adPlaybackState = SkippedAdverts.markCurrentGateAsSkipped(TEN_SECONDS_IN_MILLIS, ADVERT_BREAKS, initialAvailableAdPlaybackState);
@@ -169,7 +156,20 @@ public class SkippedAdvertsTest {
     }
 
     @Test
-    public void markCurrentGateAsSkippedForTheVeryLastPeriod() {
+    public void doesNotMarkCurrentGateAsSkippedForTheFirstGateIfPlayedAlready() {
+        AdPlaybackState initialAvailableAdPlaybackState = AdvertPlaybackState.from(ADVERT_BREAKS).adPlaybackState();
+        initialAvailableAdPlaybackState = initialAvailableAdPlaybackState.withPlayedAd(0, 0);
+        initialAvailableAdPlaybackState = initialAvailableAdPlaybackState.withPlayedAd(0, 1);
+        AdPlaybackState adPlaybackState = SkippedAdverts.markCurrentGateAsSkipped(TEN_SECONDS_IN_MILLIS, ADVERT_BREAKS, initialAvailableAdPlaybackState);
+
+        assertThatGroupContains(adPlaybackState.adGroups[0], new int[]{AD_STATE_PLAYED, AD_STATE_PLAYED});
+        assertThatGroupContains(adPlaybackState.adGroups[1], new int[]{AD_STATE_AVAILABLE});
+        assertThatGroupContains(adPlaybackState.adGroups[2], new int[]{AD_STATE_AVAILABLE});
+        assertThatGroupContains(adPlaybackState.adGroups[3], new int[]{AD_STATE_AVAILABLE});
+    }
+
+    @Test
+    public void markCurrentGateAsSkippedForLastGate() {
         AdPlaybackState initialAvailableAdPlaybackState = AdvertPlaybackState.from(ADVERT_BREAKS).adPlaybackState();
         AdPlaybackState adPlaybackState = SkippedAdverts.markCurrentGateAsSkipped(FORTY_SECONDS_IN_MILLIS, ADVERT_BREAKS, initialAvailableAdPlaybackState);
 
@@ -180,7 +180,7 @@ public class SkippedAdvertsTest {
     }
 
     @Test
-    public void markCurrentGateAsSkippedForTheVeryLastPeriodForLargeCurrentPosition() {
+    public void markCurrentGateAsSkippedForTheVeryLastGateForLargeCurrentPosition() {
         AdPlaybackState initialAvailableAdPlaybackState = AdvertPlaybackState.from(ADVERT_BREAKS).adPlaybackState();
         AdPlaybackState adPlaybackState = SkippedAdverts.markCurrentGateAsSkipped(Long.MAX_VALUE, ADVERT_BREAKS, initialAvailableAdPlaybackState);
 
@@ -191,7 +191,7 @@ public class SkippedAdvertsTest {
     }
 
     @Test
-    public void doesNotMarkAnyGateAsSkippedForNoAds() {
+    public void doesNotMarkAnyGatesAsSkippedForNoAds() {
         AdPlaybackState initialAvailableAdPlaybackState = AdvertPlaybackState.from(new ArrayList<AdvertBreak>(0)).adPlaybackState();
         AdPlaybackState adPlaybackState = SkippedAdverts.markCurrentGateAsSkipped(0, ADVERT_BREAKS, initialAvailableAdPlaybackState);
 
@@ -199,7 +199,7 @@ public class SkippedAdvertsTest {
     }
 
     @Test
-    public void doesNotMarkAnyGateAsSkippedForNegativePosition() {
+    public void doesNotMarkAnyGatesAsSkippedForNegativePosition() {
         AdPlaybackState initialAvailableAdPlaybackState = AdvertPlaybackState.from(ADVERT_BREAKS).adPlaybackState();
         AdPlaybackState adPlaybackState = SkippedAdverts.markCurrentGateAsSkipped(-1, ADVERT_BREAKS, initialAvailableAdPlaybackState);
 
@@ -209,7 +209,7 @@ public class SkippedAdvertsTest {
     @Test
     public void doesNotMarkCurrentGateAsSkippedWhenNoPreviousGatesAvailable() {
         AdPlaybackState initialAvailableAdPlaybackState = AdvertPlaybackState.from(ADVERT_BREAKS).adPlaybackState();
-        AdPlaybackState adPlaybackState = SkippedAdverts.markCurrentGateAsSkipped(TEN_SECONDS_IN_MILLIS -1, ADVERT_BREAKS, initialAvailableAdPlaybackState);
+        AdPlaybackState adPlaybackState = SkippedAdverts.markCurrentGateAsSkipped(TEN_SECONDS_IN_MILLIS - 1, ADVERT_BREAKS, initialAvailableAdPlaybackState);
 
         assertThat(initialAvailableAdPlaybackState).isEqualTo(adPlaybackState);
     }

--- a/core/src/test/java/com/novoda/noplayer/internal/exoplayer/SkippedAdvertsTest.java
+++ b/core/src/test/java/com/novoda/noplayer/internal/exoplayer/SkippedAdvertsTest.java
@@ -121,11 +121,35 @@ public class SkippedAdvertsTest {
     }
 
     @Test
-    public void doesNotMarkCurrentPlayedGateAsSkipped() {
+    public void markCurrentGateAsSkippedFromTheVeryBegginingOfPeriod() {
+        AdPlaybackState initialAvailableAdPlaybackState = AdvertPlaybackState.from(ADVERT_BREAKS).adPlaybackState();
+        AdPlaybackState adPlaybackState = SkippedAdverts.markCurrentGateAsSkipped(TWENTY_SECONDS_IN_MILLIS, ADVERT_BREAKS, initialAvailableAdPlaybackState);
+
+        assertThatGroupContains(adPlaybackState.adGroups[0], new int[]{AD_STATE_AVAILABLE, AD_STATE_AVAILABLE});
+        assertThatGroupContains(adPlaybackState.adGroups[1], new int[]{AD_STATE_SKIPPED});
+        assertThatGroupContains(adPlaybackState.adGroups[2], new int[]{AD_STATE_AVAILABLE});
+        assertThatGroupContains(adPlaybackState.adGroups[3], new int[]{AD_STATE_AVAILABLE});
+    }
+
+
+    @Test
+    public void doesNotMarkCurrentGateAsSkippedIfPlayedAlready() {
+        AdPlaybackState initialAvailableAdPlaybackState = AdvertPlaybackState.from(ADVERT_BREAKS).adPlaybackState();
+        initialAvailableAdPlaybackState = initialAvailableAdPlaybackState.withPlayedAd(1, 0);
+        AdPlaybackState adPlaybackState = SkippedAdverts.markCurrentGateAsSkipped(TWENTY_SECONDS_IN_MILLIS, ADVERT_BREAKS, initialAvailableAdPlaybackState);
+
+        assertThatGroupContains(adPlaybackState.adGroups[0], new int[]{AD_STATE_AVAILABLE, AD_STATE_AVAILABLE});
+        assertThatGroupContains(adPlaybackState.adGroups[1], new int[]{AD_STATE_PLAYED});
+        assertThatGroupContains(adPlaybackState.adGroups[2], new int[]{AD_STATE_AVAILABLE});
+        assertThatGroupContains(adPlaybackState.adGroups[3], new int[]{AD_STATE_AVAILABLE});
+    }
+
+    @Test
+    public void doesNotMarkCurrentGateAsSkippedIfPlayedFirstAlready() {
         AdPlaybackState initialAvailableAdPlaybackState = AdvertPlaybackState.from(ADVERT_BREAKS).adPlaybackState();
         initialAvailableAdPlaybackState = initialAvailableAdPlaybackState.withPlayedAd(0, 0);
         initialAvailableAdPlaybackState = initialAvailableAdPlaybackState.withPlayedAd(0, 1);
-        AdPlaybackState adPlaybackState = SkippedAdverts.markCurrentGateAsSkipped(TWENTY_SECONDS_IN_MILLIS, ADVERT_BREAKS, initialAvailableAdPlaybackState);
+        AdPlaybackState adPlaybackState = SkippedAdverts.markCurrentGateAsSkipped(1, ADVERT_BREAKS, initialAvailableAdPlaybackState);
 
         assertThatGroupContains(adPlaybackState.adGroups[0], new int[]{AD_STATE_PLAYED, AD_STATE_PLAYED});
         assertThatGroupContains(adPlaybackState.adGroups[1], new int[]{AD_STATE_AVAILABLE});
@@ -134,23 +158,9 @@ public class SkippedAdvertsTest {
     }
 
     @Test
-    public void doesNotMarkCurrentNonInitialPlayedGateAsSkipped() {
+    public void markCurrentGateAsSkippedForTheFirstGate() {
         AdPlaybackState initialAvailableAdPlaybackState = AdvertPlaybackState.from(ADVERT_BREAKS).adPlaybackState();
-        initialAvailableAdPlaybackState = initialAvailableAdPlaybackState.withPlayedAd(0, 0);
-        initialAvailableAdPlaybackState = initialAvailableAdPlaybackState.withPlayedAd(0, 1);
-        initialAvailableAdPlaybackState = initialAvailableAdPlaybackState.withPlayedAd(1, 0);
-        AdPlaybackState adPlaybackState = SkippedAdverts.markCurrentGateAsSkipped(TWENTY_SECONDS_IN_MILLIS + 1, ADVERT_BREAKS, initialAvailableAdPlaybackState);
-
-        assertThatGroupContains(adPlaybackState.adGroups[0], new int[]{AD_STATE_PLAYED, AD_STATE_PLAYED});
-        assertThatGroupContains(adPlaybackState.adGroups[1], new int[]{AD_STATE_PLAYED});
-        assertThatGroupContains(adPlaybackState.adGroups[2], new int[]{AD_STATE_AVAILABLE});
-        assertThatGroupContains(adPlaybackState.adGroups[3], new int[]{AD_STATE_AVAILABLE});
-    }
-
-    @Test
-    public void markVeryFirstCurrentGateAsSkipped() {
-        AdPlaybackState initialAvailableAdPlaybackState = AdvertPlaybackState.from(ADVERT_BREAKS).adPlaybackState();
-        AdPlaybackState adPlaybackState = SkippedAdverts.markCurrentGateAsSkipped(0, ADVERT_BREAKS, initialAvailableAdPlaybackState);
+        AdPlaybackState adPlaybackState = SkippedAdverts.markCurrentGateAsSkipped(TEN_SECONDS_IN_MILLIS, ADVERT_BREAKS, initialAvailableAdPlaybackState);
 
         assertThatGroupContains(adPlaybackState.adGroups[0], new int[]{AD_STATE_SKIPPED, AD_STATE_SKIPPED});
         assertThatGroupContains(adPlaybackState.adGroups[1], new int[]{AD_STATE_AVAILABLE});
@@ -159,7 +169,18 @@ public class SkippedAdvertsTest {
     }
 
     @Test
-    public void markVeryLastCurrentGateAsSkipped() {
+    public void markCurrentGateAsSkippedForTheVeryLastPeriod() {
+        AdPlaybackState initialAvailableAdPlaybackState = AdvertPlaybackState.from(ADVERT_BREAKS).adPlaybackState();
+        AdPlaybackState adPlaybackState = SkippedAdverts.markCurrentGateAsSkipped(FORTY_SECONDS_IN_MILLIS, ADVERT_BREAKS, initialAvailableAdPlaybackState);
+
+        assertThatGroupContains(adPlaybackState.adGroups[0], new int[]{AD_STATE_AVAILABLE, AD_STATE_AVAILABLE});
+        assertThatGroupContains(adPlaybackState.adGroups[1], new int[]{AD_STATE_AVAILABLE});
+        assertThatGroupContains(adPlaybackState.adGroups[2], new int[]{AD_STATE_AVAILABLE});
+        assertThatGroupContains(adPlaybackState.adGroups[3], new int[]{AD_STATE_SKIPPED});
+    }
+
+    @Test
+    public void markCurrentGateAsSkippedForTheVeryLastPeriodForLargeCurrentPosition() {
         AdPlaybackState initialAvailableAdPlaybackState = AdvertPlaybackState.from(ADVERT_BREAKS).adPlaybackState();
         AdPlaybackState adPlaybackState = SkippedAdverts.markCurrentGateAsSkipped(Long.MAX_VALUE, ADVERT_BREAKS, initialAvailableAdPlaybackState);
 
@@ -169,21 +190,29 @@ public class SkippedAdvertsTest {
         assertThatGroupContains(adPlaybackState.adGroups[3], new int[]{AD_STATE_SKIPPED});
     }
 
-// TODO refactor method
-//    @Test
-//    public void doesNotMarkAnyGateAsSkippedForNoAds() {
-//        AdPlaybackState initialAvailableAdPlaybackState = AdvertPlaybackState.from(new ArrayList<AdvertBreak>(0)).adPlaybackState();
-//        AdPlaybackState adPlaybackState = SkippedAdverts.markCurrentGateAsSkipped(0, ADVERT_BREAKS, initialAvailableAdPlaybackState);
-//        assertThat(initialAvailableAdPlaybackState).isEqualTo(adPlaybackState);
-//    }
-//
-//
-//    @Test
-//    public void doesNotMarkAnyGateAsSkippedForNegativePosition() {
-//        AdPlaybackState initialAvailableAdPlaybackState = AdvertPlaybackState.from(ADVERT_BREAKS).adPlaybackState();
-//        AdPlaybackState adPlaybackState = SkippedAdverts.markCurrentGateAsSkipped(-1, ADVERT_BREAKS, initialAvailableAdPlaybackState);
-//        assertThat(initialAvailableAdPlaybackState).isEqualTo(adPlaybackState);
-//    }
+    @Test
+    public void doesNotMarkAnyGateAsSkippedForNoAds() {
+        AdPlaybackState initialAvailableAdPlaybackState = AdvertPlaybackState.from(new ArrayList<AdvertBreak>(0)).adPlaybackState();
+        AdPlaybackState adPlaybackState = SkippedAdverts.markCurrentGateAsSkipped(0, ADVERT_BREAKS, initialAvailableAdPlaybackState);
+
+        assertThat(initialAvailableAdPlaybackState).isEqualTo(adPlaybackState);
+    }
+
+    @Test
+    public void doesNotMarkAnyGateAsSkippedForNegativePosition() {
+        AdPlaybackState initialAvailableAdPlaybackState = AdvertPlaybackState.from(ADVERT_BREAKS).adPlaybackState();
+        AdPlaybackState adPlaybackState = SkippedAdverts.markCurrentGateAsSkipped(-1, ADVERT_BREAKS, initialAvailableAdPlaybackState);
+
+        assertThat(initialAvailableAdPlaybackState).isEqualTo(adPlaybackState);
+    }
+
+    @Test
+    public void doesNotMarkCurrentGateAsSkippedWhenNoPreviousGatesAvailable() {
+        AdPlaybackState initialAvailableAdPlaybackState = AdvertPlaybackState.from(ADVERT_BREAKS).adPlaybackState();
+        AdPlaybackState adPlaybackState = SkippedAdverts.markCurrentGateAsSkipped(TEN_SECONDS_IN_MILLIS -1, ADVERT_BREAKS, initialAvailableAdPlaybackState);
+
+        assertThat(initialAvailableAdPlaybackState).isEqualTo(adPlaybackState);
+    }
 
     private void assertThatGroupContains(AdPlaybackState.AdGroup adGroup, int[] states) {
         assertThat(adGroup.states).containsOnly(states);

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -27,7 +27,7 @@ dependencies {
     implementation 'com.google.android.exoplayer:exoplayer-core:2.10.5'
     implementation 'com.google.android.exoplayer:exoplayer-dash:2.10.5'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
-    implementation 'com.google.android.material:material:1.2.0-alpha01'
+    implementation 'com.google.android.material:material:1.2.0-alpha02'
     implementation 'androidx.appcompat:appcompat:1.1.0'
     testImplementation 'junit:junit:4.12'
     testImplementation 'com.google.truth:truth:1.0'


### PR DESCRIPTION
## Problem

After update of exoplayer 2.10.4 -> 2.10.5 enabling adverts would trigger gate instantly.

@Mecharyry identified code in exoplayer that broke previous behaviour. 
```
      newPeriodId = queue.resolveMediaPeriodIdForAds(playbackInfo.periodId.periodUid, newContentPositionUs);
      if (!playbackInfo.periodId.isAd() && !newPeriodId.isAd()) {
        // Drop update if we keep playing the same content (MediaPeriod.periodUid are identical) and
        // only MediaPeriodId.nextAdGroupIndex may have changed. This postpones a potential
        // discontinuity until we reach the former next ad group position.
        newPeriodId = playbackInfo.periodId;
      }
```

## Solution

Change `NoPlayerAdsLoader` and `AdvertState` to account for that change. Given 

|-----|-----|-----|-----$ - player timeline with gates
x - current position
p - played gate
s - skipped gate
a - available gate
P - playing gate

- when ads disabled, always mark current gate as skipped (if not played) to prevent triggering adds. 
  - p-----a-----s--x--a-----$ => p-----s--x--a-----a-----$ 
- when ads enabled and seek performed reenable all skipped ads to let the current gate trigger
  - p-----a-----s--x--a-----$ => p-----P---x-a-----a-----$

### Test(s) added 

Yes, for new methods and some more for method performing skipping current gate.

### Screenshots

| Before | After |
| ------ | ----- |
| ![1](https://user-images.githubusercontent.com/1994645/69380670-dd009d00-0caa-11ea-99df-d4084343fa14.gif) | ![2](https://user-images.githubusercontent.com/1994645/69380688-e558d800-0caa-11ea-966f-59ae09ee3529.gif) |

### Paired with 

@Mecharyry (kudos for solution)
@JozefCeluch @danybony 
