### PR TITLE
Add GitHub Action as a pull request builder

### DIFF
--- a/.github/workflows/pull-request-builder.yml
+++ b/.github/workflows/pull-request-builder.yml
@@ -1,0 +1,53 @@
+name: Pull Request Builder
+
+on:
+  pull_request:
+
+env:
+  GRADLE_USER_HOME: .gradle
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout source-code
+        uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
+
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+
+      - name: Synchronise cache 1/2
+        uses: actions/cache@v1
+        with:
+          path: .gradle/wrapper
+          key: gradle-cache-wrapper-${{ hashFiles('core/build.gradle') }}
+
+      - name: Synchronise cache 2/2
+        uses: actions/cache@v1
+        with:
+          path: .gradle/caches
+          key: gradle-cache-caches-${{ hashFiles('core/build.gradle') }}
+
+      - name: Build
+        run: ./gradlew --no-daemon evaluateViolations lint test
+
+      - name: Gather results
+        if: success() || failure()
+        run: |
+          mkdir -p artifacts/core |
+          mkdir -p artifacts/demo |
+          cp -r core/build/reports/* artifacts/core |
+          cp -r demo/build/reports/* artifacts/demo
+
+      - name: Upload results
+        uses: actions/upload-artifact@v1.0.0
+        if: success() || failure()
+        with:
+          name: results
+          path: artifacts


### PR DESCRIPTION
## Problem

We want to move away from local Jenkins to the cloud CI on GitHub

## Solution

- Created a Pull Request builder as GitHub Actions
- At the end of the build, it will upload an artifacts.zip file that will contain all static analysis and tests results even if the build fails

### Test(s) added 

Tested in this PR

### Screenshots

No UI changes

### Paired with 

Nobody
