### PR TITLE
Split GitHub actions

### DIFF
--- a/.github/workflows/production-builder.yml
+++ b/.github/workflows/production-builder.yml
@@ -1,0 +1,56 @@
+name: Pull Request Builder
+
+on:
+  push:
+    branches:
+      - master
+
+env:
+  GRADLE_USER_HOME: .gradle
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout source-code
+        uses: actions/checkout@v2
+
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+
+      - name: Synchronise cache 1/2
+        uses: actions/cache@v1
+        with:
+          path: .gradle/wrapper
+          key: gradle-cache-wrapper-${{ hashFiles('**/build.gradle') }}
+
+      - name: Synchronise cache 2/2
+        uses: actions/cache@v1
+        with:
+          path: .gradle/caches
+          key: gradle-cache-caches-${{ hashFiles('**/build.gradle') }}
+
+      - name: Build
+        run: ./gradlew --no-daemon build
+
+      - name: Upload release
+        run: ./gradlew bintrayUpload -PdryRun=false -PbintraySnapshot=false -PbintrayOrg=${{ secrets.BINTRAY_ORG }} -PbintrayRepo=${{ secrets.BINTRAY_REPO_RELEASE }} -PbintrayUser=${{ secrets.BINTRAY_USER }} -PbintrayKey=${{ secrets.BINTRAY_KEY_RELEASE }}
+
+      - name: Notify slack if success
+        if: success()
+        uses: novoda/github-slack-action@master
+        with:
+          color: good
+          text: New No-Player <https://bintray.com/novoda-oss/maven/no-player|release> available
+          webhook: ${{ secrets.SLACK_NOS }}
+
+      - name: Notify slack if failure
+        if: failure()
+        with:
+          color: danger
+          text: No-Player release (master) build failed
+          webhook: ${{ secrets.SLACK_NOS }}

--- a/.github/workflows/production-builder.yml
+++ b/.github/workflows/production-builder.yml
@@ -50,6 +50,7 @@ jobs:
 
       - name: Notify slack if failure
         if: failure()
+        uses: novoda/github-slack-action@master
         with:
           color: danger
           text: No-Player release (master) build failed

--- a/.github/workflows/production-builder.yml
+++ b/.github/workflows/production-builder.yml
@@ -1,4 +1,4 @@
-name: Pull Request Builder
+name: Production Builder
 
 on:
   push:

--- a/.github/workflows/pull-request-builder.yml
+++ b/.github/workflows/pull-request-builder.yml
@@ -5,7 +5,6 @@ on:
 
 env:
   GRADLE_USER_HOME: .gradle
-  SLACK_NOS: ${{ secrets.SLACK_NOS }}
 
 jobs:
 

--- a/.github/workflows/pull-request-builder.yml
+++ b/.github/workflows/pull-request-builder.yml
@@ -2,10 +2,6 @@ name: Pull Request Builder
 
 on:
   pull_request:
-  push:
-    branches:
-      - master
-      - develop
 
 env:
   GRADLE_USER_HOME: .gradle
@@ -19,8 +15,6 @@ jobs:
     steps:
       - name: Checkout source-code
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 1
 
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
@@ -69,33 +63,3 @@ jobs:
         with:
           name: unit-tests-demo
           path: demo/build/test-results
-
-      - uses: rlespinasse/github-slug-action@master
-
-      - name: Upload snapshot
-        if: env.GITHUB_REF_SLUG == 'develop'
-        run: ./gradlew bintrayUpload -PdryRun=false -PbintraySnapshot=true -PbintrayOrg=${{ secrets.BINTRAY_ORG }} -PbintrayRepo=${{ secrets.BINTRAY_REPO_SNAPSHOT }} -PbintrayUser=${{ secrets.BINTRAY_USER }} -PbintrayKey=${{ secrets.BINTRAY_KEY_SNAPSHOT }}
-
-      - name: Notify slack if success
-        if: env.GITHUB_REF_SLUG == 'develop' && success()
-        run: |
-          curl -X POST -H 'Content-type: application/json' --data '{"attachments": [{"color": "good","text": "New No-Player <https://bintray.com/novoda-oss/snapshots/no-player|snapshot> available"}]}' $SLACK_NOS
-
-      - name: Notify slack if failure
-        if: env.GITHUB_REF_SLUG == 'develop' && failure()
-        run: |
-          curl -X POST -H 'Content-type: application/json' --data '{"attachments": [{"color": "danger","text": "No-Player snapshot build failed"}]}' $SLACK_NOS
-
-      - name: Upload release
-        if: env.GITHUB_REF_SLUG == 'master'
-        run: ./gradlew bintrayUpload -PdryRun=false -PbintraySnapshot=false -PbintrayOrg=${{ secrets.BINTRAY_ORG }} -PbintrayRepo=${{ secrets.BINTRAY_REPO_RELEASE }} -PbintrayUser=${{ secrets.BINTRAY_USER }} -PbintrayKey=${{ secrets.BINTRAY_KEY_RELEASE }}
-
-      - name: Notify slack if success
-        if: env.GITHUB_REF_SLUG == 'master' && success()
-        run: |
-          curl -X POST -H 'Content-type: application/json' --data '{"attachments": [{"color": "good","text": "New No-Player <https://bintray.com/novoda-oss/maven/no-player|release> available"}]}' $SLACK_NOS
-
-      - name: Notify slack if failure
-        if: env.GITHUB_REF_SLUG == 'master' && failure()
-        run: |
-          curl -X POST -H 'Content-type: application/json' --data '{"attachments": [{"color": "danger","text": "No-Player release (master) build failed"}]}' $SLACK_NOS

--- a/.github/workflows/snapshot-builder.yml
+++ b/.github/workflows/snapshot-builder.yml
@@ -1,4 +1,4 @@
-name: Pull Request Builder
+name: Snapshot Builder
 
 on:
   push:

--- a/.github/workflows/snapshot-builder.yml
+++ b/.github/workflows/snapshot-builder.yml
@@ -1,0 +1,57 @@
+name: Pull Request Builder
+
+on:
+  push:
+    branches:
+      - develop
+
+env:
+  GRADLE_USER_HOME: .gradle
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout source-code
+        uses: actions/checkout@v2
+
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+
+      - name: Synchronise cache 1/2
+        uses: actions/cache@v1
+        with:
+          path: .gradle/wrapper
+          key: gradle-cache-wrapper-${{ hashFiles('**/build.gradle') }}
+
+      - name: Synchronise cache 2/2
+        uses: actions/cache@v1
+        with:
+          path: .gradle/caches
+          key: gradle-cache-caches-${{ hashFiles('**/build.gradle') }}
+
+      - name: Build
+        run: ./gradlew --no-daemon build
+
+      - name: Upload snapshot
+        run: ./gradlew bintrayUpload -PdryRun=false -PbintraySnapshot=true -PbintrayOrg=${{ secrets.BINTRAY_ORG }} -PbintrayRepo=${{ secrets.BINTRAY_REPO_SNAPSHOT }} -PbintrayUser=${{ secrets.BINTRAY_USER }} -PbintrayKey=${{ secrets.BINTRAY_KEY_SNAPSHOT }}
+
+      - name: Notify slack if success
+        if: success()
+        uses: novoda/github-slack-action@master
+        with:
+          color: good
+          text: New No-Player <https://bintray.com/novoda-oss/snapshots/no-player|snapshot> available
+          webhook: ${{ secrets.SLACK_NOS }}
+
+      - name: Notify slack if failure
+        if: failure()
+        uses: novoda/github-slack-action@master
+        with:
+          color: danger
+          text: No-Player snapshot build failed
+          webhook: ${{ secrets.$SLACK_NOS }}

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.1'
+        classpath 'com.android.tools.build:gradle:3.5.3'
         classpath 'com.novoda:bintray-release:0.9.1'
         classpath 'com.novoda:gradle-static-analysis-plugin:1.0'
         classpath 'com.novoda:gradle-build-properties-plugin:0.4.1'


### PR DESCRIPTION
## Problem

There is only one github action for pull request, snapshot and production builds. We would like to be able to have different build badges in the main page repository and split the tasks

## Solution

Split the current task into three:
- Pull requests
- Snapshots
- Production

### Test(s) added 

No

### Screenshots

No UI changes

### Paired with 

Nobody
